### PR TITLE
Make TopologyHints to be more generic

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -225,22 +225,22 @@ type Container interface {
 
 // A cached container.
 type container struct {
-	cache         *cache               // our cache of objects
-	Id            string               // container runtime id
-	PodId         string               // associate pods runtime id
-	CacheId       string               // our cache id
-	Name          string               // container name
-	Namespace     string               // container namespace
-	State         ContainerState       // created/running/exited/unknown
-	Image         string               // containers image
-	Command       []string             // command to run in container
-	Args          []string             // arguments for command
-	Labels        map[string]string    // container labels
-	Annotations   map[string]string    // container annotations
-	Env           map[string]string    // environment variables
-	Mounts        map[string]*Mount    // mounts
-	Devices       map[string]*Device   // devices
-	TopologyHints []sysfs.TopologyHint // Set of topology hints for all containers within Pod
+	cache         *cache              // our cache of objects
+	Id            string              // container runtime id
+	PodId         string              // associate pods runtime id
+	CacheId       string              // our cache id
+	Name          string              // container name
+	Namespace     string              // container namespace
+	State         ContainerState      // created/running/exited/unknown
+	Image         string              // containers image
+	Command       []string            // command to run in container
+	Args          []string            // arguments for command
+	Labels        map[string]string   // container labels
+	Annotations   map[string]string   // container annotations
+	Env           map[string]string   // environment variables
+	Mounts        map[string]*Mount   // mounts
+	Devices       map[string]*Device  // devices
+	TopologyHints sysfs.TopologyHints // Set of topology hints for all containers within Pod
 
 	Resources v1.ResourceRequirements // container resources (from webhook annotation)
 	LinuxReq  *cri.LinuxContainerResources

--- a/pkg/cri/resource-manager/policy.go
+++ b/pkg/cri/resource-manager/policy.go
@@ -142,6 +142,7 @@ func (m *resmgr) filterWithSyntheticResponse(ctx context.Context, method string,
 
 	switch req.(type) {
 	case *api.UpdateContainerResourcesRequest:
+		// TODO: we need to update container resources and TopologyHints in our cache (VPA)
 		return &api.UpdateContainerResourcesResponse{}, nil
 	}
 


### PR DESCRIPTION
Now cache.TopologyHints is a map, where key is a provider of the
hint. Providers can be kernel (sysfs), kubelet, etc...