### PR TITLE
External Decision Agent (EDA) builtin policy

### DIFF
--- a/pkg/cri/resource-manager/builtin-policies.go
+++ b/pkg/cri/resource-manager/builtin-policies.go
@@ -16,6 +16,7 @@ package resmgr
 
 import (
 	// List of builtin policies
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/eda"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/none"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-plus"

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -134,10 +134,22 @@ type Container interface {
 	GetLabelKeys() []string
 	// GetLabel returns the value of a container label.
 	GetLabel(string) (string, bool)
+	// GetResmgrLabelKeys returns container label keys (without the namespace
+	// part) in cri-resource-manager namespace.
+	GetResmgrLabelKeys() []string
+	// GetResmgrLabel returns the value of a container label from the
+	// cri-resource-manager namespace.
+	GetResmgrLabel(string) (string, bool)
 	// GetAnnotationKeys returns the keys of all annotations of the container.
 	GetAnnotationKeys() []string
 	// GetAnnotation returns the value of a container annotation.
 	GetAnnotation(key string, objPtr interface{}) (string, bool)
+	// GetResmgrAnnotationKeys returns container annotation keys (without the
+	// namespace part) in cri-resource-manager namespace.
+	GetResmgrAnnotationKeys() []string
+	// GetAnnotation returns the value of a container annotation from the
+	// cri-resource-manager namespace.
+	GetResmgrAnnotation(key string, objPtr interface{}) (string, bool)
 	// GetEnvKeys returns the keys of all container environment variables.
 	GetEnvKeys() []string
 	// GetEnv returns the value of a container environment variable.

--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestKeysInNamespace(t *testing.T) {
+	var m map[string]string
+	var keys []string
+	var expected []string
+
+	// nil or empty map should return nothing
+	keys = keysInNamespace(&m, "")
+	if len(keys) != 0 {
+		t.Errorf("Exptected empty list, received %v", keys)
+	}
+	keys = keysInNamespace(&m, "my.name.space")
+	if len(keys) != 0 {
+		t.Errorf("Exptected empty list, received %v", keys)
+	}
+	m = map[string]string{}
+	keys = keysInNamespace(&m, "")
+	if len(keys) != 0 {
+		t.Errorf("Exptected empty list, received %v", keys)
+	}
+
+	// Fill map with some values
+	m["no-namespace"] = ""
+	m["my.name.space"] = ""
+	m["my.name.space/key-1"] = ""
+	m["my.name.space/key-2"] = ""
+	m["other.name.space/other-key"] = ""
+
+	// Keys with no namespace
+	keys = keysInNamespace(&m, "")
+	sort.Strings(keys)
+	expected = []string{"my.name.space", "no-namespace"}
+	if !cmp.Equal(keys, expected) {
+		t.Errorf("Exptected %v, received %v", expected, keys)
+	}
+
+	// Keys in namespace
+	keys = keysInNamespace(&m, "my.name.space")
+	sort.Strings(keys)
+	expected = []string{"key-1", "key-2"}
+	if !cmp.Equal(keys, expected) {
+		t.Errorf("Exptected %v, received %v", expected, keys)
+	}
+}

--- a/pkg/cri/resource-manager/kubernetes/kubernetes.go
+++ b/pkg/cri/resource-manager/kubernetes/kubernetes.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+const (
+	ResmgrKeyNamespace = "cri-resource-manager.intel.com"
+)
+
+// ResmgrKey returns a full namespaced name of a resource manager specific key
+func ResmgrKey(name string) string {
+	return ResmgrKeyNamespace + "/" + name
+}

--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -1,0 +1,160 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eda
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+const (
+	// PolicyName is the symbol used to pull us in as a builtin policy.
+	PolicyName = "eda"
+	// PolicyDescription is a short description of this policy.
+	PolicyDescription = "Enforcement for CPU device plugin."
+	// cpusetAnnotationPrefix is the prefix of container annotations
+	// that the external agent uses for communicating the cpuset enforcement.
+	cpuSetContainerAnnotationPrefix = "cpu."
+)
+
+type eda struct {
+	logger.Logger
+
+	state cache.Cache // state cache
+}
+
+var _ policy.Backend = &eda{}
+
+//
+// Policy backend implementation
+//
+
+// CreateEdaPolicy creates a new policy instance.
+func CreateEdaPolicy(opts *policy.PolicyOpts) policy.Backend {
+	eda := &eda{Logger: logger.NewLogger(PolicyName)}
+	eda.Info("creating policy...")
+	// TODO: policy configuration (if any)
+	return eda
+}
+
+// Name returns the name of this policy.
+func (eda *eda) Name() string {
+	return PolicyName
+}
+
+// Description returns the description for this policy.
+func (eda *eda) Description() string {
+	return PolicyDescription
+}
+
+// Start prepares this policy for accepting allocation/release requests.
+func (eda *eda) Start(cch cache.Cache) error {
+	eda.Debug("preparing for making decisions...")
+	return nil
+}
+
+// AllocateResources is a resource allocation request for this policy.
+func (eda *eda) AllocateResources(c cache.Container) error {
+	containerID := c.GetCacheId()
+	eda.Debug("allocating resources for container %s...", containerID)
+
+	// Allocate (CPU) resources for the container
+	keys := c.GetResmgrAnnotationKeys()
+	cpus := cpuset.CPUSet{}
+	for _, key := range keys {
+		if strings.HasPrefix(key, cpuSetContainerAnnotationPrefix) {
+			strValue, _ := c.GetResmgrAnnotation(key, nil)
+			eda.Debug("detected cpuset annotation %s=%s", key, strValue)
+			cpusetValue, err := cpuset.Parse(strValue)
+			if err != nil {
+				return edaError("failed to parse cpuset %q: %v", strValue, err)
+			}
+			cpus = cpus.Union(cpusetValue)
+		}
+	}
+	if cpus.Size() > 0 {
+		eda.Debug("enforcing cpuset of container %q to %q", containerID, cpus.String())
+		c.SetCpusetCpus(cpus.String())
+	}
+	return nil
+}
+
+// ReleaseResources is a resource release request for this policy.
+func (eda *eda) ReleaseResources(c cache.Container) error {
+	eda.Debug("releasing resources of container %s...", c.GetCacheId())
+	return nil
+}
+
+// UpdateResources is a resource allocation update request for this policy.
+func (eda *eda) UpdateResources(c cache.Container) error {
+	eda.Debug("updating resource allocations of container %s...", c.GetCacheId())
+	return nil
+}
+
+// ExportResourceData provides resource data to export for the container.
+func (eda *eda) ExportResourceData(c cache.Container, syntax policy.DataSyntax) []byte {
+	return nil
+}
+
+func (eda *eda) PostStart(cch cache.Container) error {
+	return nil
+}
+
+// SetConfig sets the policy backend configuration
+func (eda *eda) SetConfig(conf string) error {
+	return nil
+}
+
+//
+// Helper functions for STP policy backend
+//
+
+func edaError(format string, args ...interface{}) error {
+	return fmt.Errorf(PolicyName+": "+format, args...)
+}
+
+//
+// Automatically register us as a policy implementation.
+//
+
+// Implementation is the implementation we register with the policy module.
+type Implementation func(*policy.PolicyOpts) policy.Backend
+
+// Name returns the name of this policy implementation.
+func (i Implementation) Name() string {
+	return PolicyName
+}
+
+// Description returns the desccription of this policy implementation.
+func (i Implementation) Description() string {
+	return PolicyDescription
+}
+
+// CreateFn returns the functions used to instantiate this policy.
+func (i Implementation) CreateFn() policy.CreateFn {
+	return policy.CreateFn(i)
+}
+
+var _ policy.Implementation = Implementation(nil)
+
+func init() {
+	policy.Register(Implementation(CreateEdaPolicy))
+}


### PR DESCRIPTION
Implements a very simple (builtin) policy that simply looks at cpu.*
container annotations (ofthe CRI container object) in the
cri-resource-manager namespace (i.e.
cri-resource-manager.intel.com/cpu.*). If any annotations are found, the
cpusets within are combined and and the cpuset of the container is set
accordingly.