### PR TITLE
log: drop Logger.Warning()

### DIFF
--- a/pkg/agent/config-updater.go
+++ b/pkg/agent/config-updater.go
@@ -81,7 +81,7 @@ func (u *updater) Start() error {
 			u.Debug("sending SetConfig request to cri-resmgr")
 			_, err := u.resmgrCli.SetConfig(ctx, req, []grpc.CallOption{grpc.FailFast(false)}...)
 			if err != nil {
-				u.Warning("failed to update cri-resmgr config: %v", err)
+				u.Warn("failed to update cri-resmgr config: %v", err)
 				time.Sleep(1 * time.Second)
 			} else {
 				c = nil

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -186,7 +186,7 @@ func (g *grpcServer) GetConfig(ctx context.Context, req *v1.GetConfigRequest) (*
 	if g.getConfig != nil {
 		rpl.Config = g.getConfig()
 	} else {
-		g.Warning("no getter method configured, returning empty config!")
+		g.Warn("no getter method configured, returning empty config!")
 	}
 	return rpl, nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -405,7 +405,7 @@ func (stp *stp) allocateStpResources(c cache.Container, cs stpContainerStatus) e
 		if ok {
 			iNumCores, err := strconv.ParseInt(envNumCores, 10, 64)
 			if err != nil || iNumCores != cs.NExclusiveCPUs {
-				stp.Warning("Ignoring deprecated env variable setting, %s=%q does "+
+				stp.Warn("Ignoring deprecated env variable setting, %s=%q does "+
 					"not match the number of cores (%d) from resource request",
 					CmkEnvNumCores, envNumCores, cs.NExclusiveCPUs)
 			}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -39,7 +39,6 @@ const (
 type Logger interface {
 	Info(format string, args ...interface{})
 	Warn(format string, args ...interface{})
-	Warning(format string, args ...interface{})
 	Error(format string, args ...interface{})
 	Fatal(format string, args ...interface{})
 	Panic(format string, args ...interface{})
@@ -165,14 +164,6 @@ func (l *logger) Warn(format string, args ...interface{}) {
 	opt.active.Warn(l.formatMessage(format, args...))
 }
 
-// Emit a warning message.
-func (l *logger) Warning(format string, args ...interface{}) {
-	if !l.passthrough(LevelWarn) {
-		return
-	}
-	opt.active.Warn(l.formatMessage(format, args...))
-}
-
 // Emit an error message.
 func (l *logger) Error(format string, args ...interface{}) {
 	if !l.passthrough(LevelError) {
@@ -209,11 +200,6 @@ func Info(format string, args ...interface{}) {
 
 // Emit a warning message with the default source.
 func Warn(format string, args ...interface{}) {
-	defLogger.Warn(format, args...)
-}
-
-// Emit a warning message with the default source.
-func Warning(format string, args ...interface{}) {
 	defLogger.Warn(format, args...)
 }
 


### PR DESCRIPTION
Remove Warning() from Logger interface as it was just replicating
(copy-paste) the Warn() function. Decreases LOC and increases
consistency as Warning() was only used in few places. Also, the logger
Backend interface does not have Warning().