### PR TITLE
topology-aware-policy: add initial/prototype version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ policy configuration adhere the following scheme:
 The data format of the policy configuration is policy-specific and may be
 different between policies (the `static` and `stp` policies use YAML).
 There is a
-[sammple ConfigMap spec](sample-configs/cri-resmgr-configmap.example.yaml)
+[sample ConfigMap spec](sample-configs/cri-resmgr-configmap.example.yaml)
 that contains referential policy configuration for the static and stp policies.
 See the policy-specific documentation for more information on the policy
 configurations ([STP policy documentation](docs/policy-static-pools.md))

--- a/docs/policy-topology-aware.md
+++ b/docs/policy-topology-aware.md
@@ -1,0 +1,2 @@
+See the topology-aware policy [README](/pkg/cri/resource-manager/policy/builtin/topology-aware/README.md).
+

--- a/pkg/cri/resource-manager/builtin-policies.go
+++ b/pkg/cri/resource-manager/builtin-policies.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-plus"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-pools"
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/topology-aware"
 )
 
 // TODO: add unit tests to verify that all builtin policies are found

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -63,15 +63,17 @@ type Pod interface {
 	GetName() string
 	GetNamespace() string
 	GetState() PodState
+	GetQOSClass() v1.PodQOSClass
+
 	GetLabelKeys() []string
 	GetLabel(string) (string, bool)
 	GetAnnotationKeys() []string
 	GetAnnotation(key string) (string, bool)
 	GetAnnotationObject(key string, objPtr interface{},
 		decode func([]byte, interface{}) error) (bool, error)
+
 	GetCgroupParentDir() string
 	GetPodResourceRequirements() PodResourceRequirements
-	GetPodQOS() v1.PodQOSClass
 }
 
 // A cached pod.
@@ -82,11 +84,11 @@ type pod struct {
 	Name         string            // pod sandbox name
 	Namespace    string            // pod namespace
 	State        PodState          // ready/not ready
+	QOSClass     v1.PodQOSClass    // pod QoS class
 	Labels       map[string]string // pod labels
 	Annotations  map[string]string // pod annotations
 	CgroupParent string            // cgroup parent directory
 
-	QOSClass  v1.PodQOSClass           // pod QoS class
 	Resources *PodResourceRequirements // annotated resource requirements
 }
 
@@ -124,6 +126,8 @@ type Container interface {
 	GetNamespace() string
 	// GetState returns the ContainerState of the container.
 	GetState() ContainerState
+	// GetQOSClass returns the QoS class the pod would have if this was its only container.
+	GetQOSClass() v1.PodQOSClass
 	// GetImage returns the image of the container.
 	GetImage() string
 	// GetCommand returns the container command.
@@ -247,6 +251,7 @@ type container struct {
 	Name          string              // container name
 	Namespace     string              // container namespace
 	State         ContainerState      // created/running/exited/unknown
+	QOSClass      v1.PodQOSClass      // QoS class, if the container had one
 	Image         string              // containers image
 	Command       []string            // command to run in container
 	Args          []string            // arguments for command
@@ -257,8 +262,8 @@ type container struct {
 	Devices       map[string]*Device  // devices
 	TopologyHints sysfs.TopologyHints // Set of topology hints for all containers within Pod
 
-	Resources v1.ResourceRequirements // container resources (from webhook annotation)
-	LinuxReq  *cri.LinuxContainerResources
+	Resources v1.ResourceRequirements      // container resources (from webhook annotation)
+	LinuxReq  *cri.LinuxContainerResources // used to estimate Resources if we lack annotations
 }
 
 // MountType is a propagation type.

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -55,24 +55,56 @@ type PodResourceRequirements struct {
 
 // Pod is the exposed interface from a cached pod.
 type Pod interface {
+	// GetInitContainers returns the init containers of the pod.
 	GetInitContainers() []Container
+	// GetContainers returns the (non-init) containers of the pod.
 	GetContainers() []Container
-
+	// GetId returns the pod id of the pod.
 	GetId() string
+	// GetUid returns the (kubernetes) unique id of the pod.
 	GetUid() string
+	// GetName returns the name of the pod.
 	GetName() string
+	// GetNamespace returns the namespace of the pod.
 	GetNamespace() string
+	// GetState returns the PodState of the pod.
 	GetState() PodState
+	// GetQOSClass returns the PodQOSClass of the pod.
 	GetQOSClass() v1.PodQOSClass
-
+	// GetLabelKeys returns the keys of all pod labels as a string slice.
 	GetLabelKeys() []string
+	// GetLabel returns the value of the given label and whether it was found.
 	GetLabel(string) (string, bool)
+	// GetResmgrLabelKeys returns pod label keys (without the namespace
+	// part) in cri-resource-manager namespace.
+	GetResmgrLabelKeys() []string
+	// GetResmgrLabel returns the value of a pod label from the
+	// cri-resource-manager namespace.
+	GetResmgrLabel(string) (string, bool)
+	// GetAnnotationKeys returns the keys of all annotations of the container.
+
+	// GetAnnotationKeys returns the keys of all pod annotations as a string slice.
 	GetAnnotationKeys() []string
+	// GetAnnotation returns the value of the given annotation and whether it was found.
 	GetAnnotation(key string) (string, bool)
+	// GetAnnotationObject decodes the value of the given annotation with the given function.
 	GetAnnotationObject(key string, objPtr interface{},
 		decode func([]byte, interface{}) error) (bool, error)
-
+	// GetResmgrAnnotationKeys returns pod annotation keys (without the
+	// namespace part) in cri-resource-manager namespace as a string slice.
+	GetResmgrAnnotationKeys() []string
+	// GetAnnotation returns the value of a pod annotation from the
+	// cri-resource-manager namespace and whether it was found.
+	GetResmgrAnnotation(key string) (string, bool)
+	// GetResmgrAnnotationObject decodes the value of the given annotation in the
+	// cri-resource-manager namespace.
+	GetResmgrAnnotationObject(key string, objPtr interface{},
+		decode func([]byte, interface{}) error) (bool, error)
+	// GetCgroupParentDir returns the pods cgroup parent directory.
 	GetCgroupParentDir() string
+	// GetPodResourceRequirements returns container resource requirements if the
+	// necessary associated annotation put in place by the CRI resource manager
+	// webhook was found.
 	GetPodResourceRequirements() PodResourceRequirements
 }
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -197,6 +197,9 @@ type Container interface {
 	// DeleteDevice removes a device from the container.
 	DeleteDevice(string)
 
+	// Get any attached topology hints.
+	GetTopologyHints() sysfs.TopologyHints
+
 	// GetCpuPeriod gets the CFS CPU period of the container.
 	GetCpuPeriod() int64
 	// GetCpuQuota gets the CFS CPU quota of the container.

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -23,7 +23,6 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -100,9 +99,11 @@ func (c *container) fromCreateRequest(req *cri.CreateContainerRequest) error {
 			c.Resources = r
 		} else if r, ok := p.Resources.Containers[c.Name]; ok {
 			c.Resources = r
-		} else {
-			c.Resources = c.estimateResources()
 		}
+	}
+
+	if len(c.Resources.Requests) == 0 && len(c.Resources.Limits) == 0 {
+		c.Resources = estimateComputeResources(c.LinuxReq)
 	}
 
 	c.TopologyHints = sysfs.MergeTopologyHints(c.TopologyHints, getKubeletHint(c.GetCpusetCpus(), c.GetCpusetMems()))
@@ -237,6 +238,16 @@ func (c *container) GetNamespace() string {
 
 func (c *container) GetState() ContainerState {
 	return c.State
+}
+
+func (c *container) GetQOSClass() v1.PodQOSClass {
+	var qos v1.PodQOSClass
+
+	if pod, found := c.GetPod(); found {
+		qos = pod.GetQOSClass()
+	}
+
+	return qos
 }
 
 func (c *container) GetImage() string {
@@ -621,65 +632,6 @@ func (c *container) SetCpusetMems(value string) {
 	}
 	c.LinuxReq.CpusetMems = value
 	c.cache.markChanged(c)
-}
-
-// constants for estimating request/limit for CPU and memory (kubernetes/pkg/cm/helpers_linux.go)
-const (
-	MinShares     = 2
-	SharesPerCPU  = 1024
-	MilliCPUToCPU = 1000
-)
-
-func (c *container) estimateResources() v1.ResourceRequirements {
-	r := v1.ResourceRequirements{
-		Requests: v1.ResourceList{},
-		Limits:   v1.ResourceList{},
-	}
-
-	if c.LinuxReq == nil {
-		return r
-	}
-
-	shares := c.LinuxReq.CpuShares
-	req := sharesToMilliCpu(shares)
-	if req > 0 {
-		qreq := resource.NewMilliQuantity(req, resource.DecimalSI)
-		r.Requests[v1.ResourceCPU] = *qreq
-	}
-
-	period := c.LinuxReq.CpuPeriod
-	quota := c.LinuxReq.CpuQuota
-	lim := quotaToMilliCpu(quota, period)
-	if lim > 0 {
-		qlim := resource.NewMilliQuantity(lim, resource.DecimalSI)
-		r.Limits[v1.ResourceCPU] = *qlim
-	}
-
-	memory := c.LinuxReq.MemoryLimitInBytes
-	if memory > 0 {
-		qmem := resource.NewQuantity(memory, resource.BinarySI)
-		r.Limits[v1.ResourceMemory] = *qmem
-	}
-
-	return r
-}
-
-func sharesToMilliCpu(shares int64) int64 {
-	if shares == MinShares {
-		return 0
-	}
-
-	return (shares * MilliCPUToCPU) / SharesPerCPU
-}
-
-func quotaToMilliCpu(quota, period int64) int64 {
-	if quota == 0 || period == 0 {
-		return 0
-	}
-
-	milliCpu := (quota * MilliCPUToCPU) / period
-
-	return milliCpu
 }
 
 func getTopologyHints(hostPath, containerPath string, readOnly bool) (ret sysfs.TopologyHints) {

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -509,6 +509,10 @@ func (c *container) DeleteDevice(path string) {
 	}
 }
 
+func (c *container) GetTopologyHints() sysfs.TopologyHints {
+	return c.TopologyHints
+}
+
 func (c *container) GetCpuPeriod() int64 {
 	if c.LinuxReq == nil {
 		return 0

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -20,9 +20,10 @@ import (
 
 	"k8s.io/api/core/v1"
 
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 )
 
 const (
@@ -151,6 +152,17 @@ func (p *pod) GetLabel(key string) (string, bool) {
 	return value, ok
 }
 
+// Get all label keys in the cri-resource-manager namespace.
+func (p *pod) GetResmgrLabelKeys() []string {
+	return keysInNamespace(&p.Labels, kubernetes.ResmgrKeyNamespace)
+}
+
+// Get the label for the given key in the cri-resource-manager namespace.
+func (p *pod) GetResmgrLabel(key string) (string, bool) {
+	value, ok := p.Labels[kubernetes.ResmgrKey(key)]
+	return value, ok
+}
+
 // Get the keys of all annotations of a pod.
 func (p *pod) GetAnnotationKeys() []string {
 	keys := make([]string, len(p.Annotations))
@@ -213,6 +225,22 @@ func (p *pod) GetAnnotationObject(key string, objPtr interface{},
 	}
 
 	return true, err
+}
+
+// Get the keys of all annotation in the cri-resource-manager namespace.
+func (p *pod) GetResmgrAnnotationKeys() []string {
+	return keysInNamespace(&p.Annotations, kubernetes.ResmgrKeyNamespace)
+}
+
+// Get the value of the given annotation in the cri-resource-manager namespace.
+func (p *pod) GetResmgrAnnotation(key string) (string, bool) {
+	return p.GetAnnotation(kubernetes.ResmgrKey(key))
+}
+
+// Get and decode the pod annotation for the key in the cri-resource-manager namespace..
+func (p *pod) GetResmgrAnnotationObject(key string, objPtr interface{},
+	decode func([]byte, interface{}) error) (bool, error) {
+	return p.GetAnnotationObject(kubernetes.ResmgrKey(key), objPtr, decode)
 }
 
 // Get the cgroup parent directory of a pod, if known.

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -19,8 +19,7 @@ import (
 	"strconv"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
+
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -245,78 +244,15 @@ func (p *pod) parseResourceAnnotations() {
 	p.GetAnnotationObject(KeyResourceAnnotation, p.Resources, nil)
 }
 
-// Determine the QoS class of a pod (code lifted over from Kubernetes).
-func (p *pod) GetPodQOS() v1.PodQOSClass {
-	if p.QOSClass != "" {
-		return p.QOSClass
+// Determine the QoS class of the pod.
+func (p *pod) GetQOSClass() v1.PodQOSClass {
+	if p.QOSClass == "" {
+		p.QOSClass = cgroupParentToQOS(p.CgroupParent)
 	}
 
-	requests := v1.ResourceList{}
-	limits := v1.ResourceList{}
-	zeroQuantity := resource.MustParse("0")
-	isGuaranteed := true
-	podResources := p.Resources
-	for _, resources := range podResources.Containers {
-		// process requests
-		for name, quantity := range resources.Requests {
-			if !isSupportedQoSComputeResource(name) {
-				continue
-			}
-			if quantity.Cmp(zeroQuantity) == 1 {
-				delta := quantity.Copy()
-				if _, exists := requests[name]; !exists {
-					requests[name] = *delta
-				} else {
-					delta.Add(requests[name])
-					requests[name] = *delta
-				}
-			}
-		}
-		// process limits
-		qosLimitsFound := sets.NewString()
-		for name, quantity := range resources.Limits {
-			if !isSupportedQoSComputeResource(name) {
-				continue
-			}
-			if quantity.Cmp(zeroQuantity) == 1 {
-				qosLimitsFound.Insert(string(name))
-				delta := quantity.Copy()
-				if _, exists := limits[name]; !exists {
-					limits[name] = *delta
-				} else {
-					delta.Add(limits[name])
-					limits[name] = *delta
-				}
-			}
-		}
+	if p.QOSClass == "" {
+		p.QOSClass = resourcesToQOS(p.Resources)
+	}
 
-		if !qosLimitsFound.HasAll(string(v1.ResourceMemory), string(v1.ResourceCPU)) {
-			isGuaranteed = false
-		}
-	}
-	if len(requests) == 0 && len(limits) == 0 {
-		p.QOSClass = v1.PodQOSBestEffort
-		return p.QOSClass
-	}
-	// Check is requests match limits for all resources.
-	if isGuaranteed {
-		for name, req := range requests {
-			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
-				isGuaranteed = false
-				break
-			}
-		}
-	}
-	if isGuaranteed &&
-		len(requests) == len(limits) {
-		p.QOSClass = v1.PodQOSGuaranteed
-		return p.QOSClass
-	}
-	p.QOSClass = v1.PodQOSBurstable
 	return p.QOSClass
-}
-
-// Check if a resource (class) contributes to the QoS class of a pod.
-func isSupportedQoSComputeResource(name v1.ResourceName) bool {
-	return name == v1.ResourceCPU || name == v1.ResourceMemory
 }

--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -1,0 +1,366 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	resapi "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// Constants/variables needed for converting between milliCPU, CFS shares, quota and period.
+const (
+	// CFS CPU shares, quota and period to/from milliCPU conversion
+	minShares      = 2
+	sharesPerCPU   = 1024
+	milliCPUToCPU  = 1000
+	QuotaPeriod    = 100000
+	minQuotaPeriod = 1000
+
+	// memory limit to OOM score adjustement
+	guaranteedOOMScoreAdj int = -998
+	besteffortOOMScoreAdj int = 1000
+
+	// cgroup parent to Pod QoS class mapping prefixes
+	cgroupBestEffortPrefix = "/kubepods.slice/kubepods-besteffort.slice/"
+	cgroupBurstablePrefix  = "/kubepods.slice/kubepods-burstable.slice/"
+)
+
+var memoryCapacity int64
+
+// estimateComputeResources calculates resource requests/limits from a CRI request.
+func estimateComputeResources(lnx *cri.LinuxContainerResources) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+
+	if lnx == nil {
+		return resources
+	}
+
+	// calculate CPU request
+	if value := SharesToMilliCPU(lnx.CpuShares); value > 0 {
+		qty := resapi.NewMilliQuantity(value, resapi.DecimalSI)
+		resources.Requests[corev1.ResourceCPU] = *qty
+	}
+
+	// calculate CPU limit
+	if value := QuotaToMilliCPU(lnx.CpuQuota, lnx.CpuPeriod); value > 0 {
+		qty := resapi.NewMilliQuantity(value, resapi.DecimalSI)
+		resources.Limits[corev1.ResourceCPU] = *qty
+	}
+
+	// calculate memory request
+	if value := OomScoreAdjToMemoryRequest(lnx.OomScoreAdj); value != 0 {
+		qty := resapi.NewQuantity(value, resapi.DecimalSI)
+		resources.Requests[corev1.ResourceMemory] = *qty
+	}
+
+	// calculate memory limit
+	if value := lnx.MemoryLimitInBytes; value > 0 {
+		qty := resapi.NewQuantity(value, resapi.DecimalSI)
+		resources.Limits[corev1.ResourceMemory] = *qty
+	}
+
+	return resources
+}
+
+// SharesToMilliCPU converts CFS CPU shares to milliCPU.
+func SharesToMilliCPU(shares int64) int64 {
+	if shares == minShares {
+		return 0
+	}
+
+	return int64((float64(shares*milliCPUToCPU) / float64(sharesPerCPU)) + 0.5)
+}
+
+// MilliCPUToShares converts milliCPU to CFS CPU shares.
+func MilliCPUToShares(milliCPU int) int64 {
+	if milliCPU == 0 {
+		return minShares
+	}
+
+	shares := (milliCPU * sharesPerCPU) / milliCPUToCPU
+	if shares < minShares {
+		return minShares
+	}
+
+	return int64(shares)
+}
+
+// QuotaToMilliCPU converts CFS quota and period to milliCPU.
+func QuotaToMilliCPU(quota, period int64) int64 {
+	if quota == 0 || period == 0 {
+		return 0
+	}
+
+	return int64(float64(quota*milliCPUToCPU)/float64(period) + 0.5)
+}
+
+// MilliCPUToQuota converts milliCPU to CFS quota and period values.
+func MilliCPUToQuota(milliCPU int64) (int64, int64) {
+	if milliCPU == 0 {
+		return 0, 0
+	}
+
+	period := int64(QuotaPeriod)
+	quota := (milliCPU * period) / milliCPUToCPU
+	if quota < minQuotaPeriod {
+		quota = minQuotaPeriod
+	}
+
+	return quota, period
+}
+
+// We don't do this direction (we leave the adjustment intact)...
+func MemoryRequestToOomScoreAdj(namespace string, configSource string, qos corev1.PodQOSClass,
+	memRequest int64) int64 {
+	panic("this shouldn't be called... better leave the OOM score adjustment intact.")
+	return 0
+}
+
+// OomScoreAdjToMemoryRequest tries to convert OOM score to original memory request.
+func OomScoreAdjToMemoryRequest(value int64) int64 {
+	if value == 0 {
+		return 0
+	}
+
+	switch value {
+	case int64(1000 + guaranteedOOMScoreAdj):
+		// lossy case, let's use boundary OOMScoreAdj value
+		value = int64(1000 + guaranteedOOMScoreAdj - 1)
+		return (memoryCapacity * (int64(1000) - value)) / int64(1000)
+
+	case int64(besteffortOOMScoreAdj - 1):
+		value = int64(besteffortOOMScoreAdj)
+		return (memoryCapacity * (int64(1000) - value)) / int64(1000)
+
+	default:
+		return (memoryCapacity * (int64(1000) - value)) / int64(1000)
+	}
+}
+
+// getMemoryCapacity parses memory capacity from /proc/meminfo (mimicking cAdvisor).
+func getMemoryCapacity() int64 {
+	var data []byte
+	var err error
+
+	if memoryCapacity > 0 {
+		return memoryCapacity
+	}
+
+	if data, err = ioutil.ReadFile("/proc/meminfo"); err != nil {
+		return -1
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		keyval := strings.Split(line, ":")
+		if len(keyval) != 2 || keyval[0] != "MemTotal" {
+			continue
+		}
+
+		valunit := strings.Split(strings.TrimSpace(keyval[1]), " ")
+		if len(valunit) != 2 || valunit[1] != "kB" {
+			return -1
+		}
+
+		memoryCapacity, err = strconv.ParseInt(valunit[0], 10, 64)
+		if err != nil {
+			return -1
+		}
+
+		memoryCapacity *= 1024
+		break
+	}
+
+	return memoryCapacity
+}
+
+// cgroupParentToQOS tries to map Pod cgroup parent to QOS class.
+func cgroupParentToQOS(dir string) corev1.PodQOSClass {
+	var qos corev1.PodQOSClass
+
+	switch {
+	case dir == "":
+		qos = corev1.PodQOSClass("")
+	case strings.HasPrefix(dir, cgroupBurstablePrefix):
+		qos = corev1.PodQOSBurstable
+	case strings.HasPrefix(dir, cgroupBestEffortPrefix):
+		qos = corev1.PodQOSBestEffort
+	default:
+		qos = corev1.PodQOSGuaranteed
+	}
+
+	return qos
+}
+
+// resourcesToQOS tries to map Pod container resources (from annotation) to QOS class.
+func resourcesToQOS(podResources *PodResourceRequirements) corev1.PodQOSClass {
+	var qos corev1.PodQOSClass
+
+	if podResources == nil {
+		return qos
+	}
+
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+	zeroQuantity := resapi.MustParse("0")
+	isGuaranteed := true
+	for _, resources := range podResources.Containers {
+		// process requests
+		for name, quantity := range resources.Requests {
+			if !isSupportedQoSComputeResource(name) {
+				continue
+			}
+			if quantity.Cmp(zeroQuantity) == 1 {
+				delta := quantity.Copy()
+				if _, exists := requests[name]; !exists {
+					requests[name] = *delta
+				} else {
+					delta.Add(requests[name])
+					requests[name] = *delta
+				}
+			}
+		}
+		// process limits
+		qosLimitsFound := sets.NewString()
+		for name, quantity := range resources.Limits {
+			if !isSupportedQoSComputeResource(name) {
+				continue
+			}
+			if quantity.Cmp(zeroQuantity) == 1 {
+				qosLimitsFound.Insert(string(name))
+				delta := quantity.Copy()
+				if _, exists := limits[name]; !exists {
+					limits[name] = *delta
+				} else {
+					delta.Add(limits[name])
+					limits[name] = *delta
+				}
+			}
+		}
+
+		if !qosLimitsFound.HasAll(string(corev1.ResourceMemory), string(corev1.ResourceCPU)) {
+			isGuaranteed = false
+		}
+	}
+	if len(requests) == 0 && len(limits) == 0 {
+		return corev1.PodQOSBestEffort
+	}
+	// Check is requests match limits for all resources.
+	if isGuaranteed {
+		for name, req := range requests {
+			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
+				isGuaranteed = false
+				break
+			}
+		}
+	}
+	if isGuaranteed &&
+		len(requests) == len(limits) {
+		return corev1.PodQOSGuaranteed
+	}
+	return corev1.PodQOSBurstable
+}
+
+/*
+// ContainerQOS tries to map Pod container resources (from annotation) to QOS class.
+func resourceRequirementsToQOS(resources *corev1.ResourceRequirements) corev1.PodQOSClass {
+	var qos corev1.PodQOSClass
+
+	if resources == nil {
+		return qos
+	}
+
+	if podResources == nil {
+		return qos
+	}
+
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+	zeroQuantity := resapi.MustParse("0")
+	isGuaranteed := true
+	for _, resources := range podResources.Containers {
+		// process requests
+		for name, quantity := range resources.Requests {
+			if !isSupportedQoSComputeResource(name) {
+				continue
+			}
+			if quantity.Cmp(zeroQuantity) == 1 {
+				delta := quantity.Copy()
+				if _, exists := requests[name]; !exists {
+					requests[name] = *delta
+				} else {
+					delta.Add(requests[name])
+					requests[name] = *delta
+				}
+			}
+		}
+		// process limits
+		qosLimitsFound := sets.NewString()
+		for name, quantity := range resources.Limits {
+			if !isSupportedQoSComputeResource(name) {
+				continue
+			}
+			if quantity.Cmp(zeroQuantity) == 1 {
+				qosLimitsFound.Insert(string(name))
+				delta := quantity.Copy()
+				if _, exists := limits[name]; !exists {
+					limits[name] = *delta
+				} else {
+					delta.Add(limits[name])
+					limits[name] = *delta
+				}
+			}
+		}
+
+		if !qosLimitsFound.HasAll(string(corev1.ResourceMemory), string(corev1.ResourceCPU)) {
+			isGuaranteed = false
+		}
+	}
+	if len(requests) == 0 && len(limits) == 0 {
+		return corev1.PodQOSBestEffort
+	}
+	// Check is requests match limits for all resources.
+	if isGuaranteed {
+		for name, req := range requests {
+			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
+				isGuaranteed = false
+				break
+			}
+		}
+	}
+	if isGuaranteed &&
+		len(requests) == len(limits) {
+		return corev1.PodQOSGuaranteed
+	}
+	return corev1.PodQOSBurstable
+}
+*/
+
+func isSupportedQoSComputeResource(name corev1.ResourceName) bool {
+	return name == corev1.ResourceCPU || name == corev1.ResourceMemory
+}
+
+func init() {
+	// TODO: get rid of this eventually, use pkg/sysfs instead...
+	getMemoryCapacity()
+}

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -385,7 +385,7 @@ func (s *static) allocateCPUs(numCPUs int, containerID string) (cpuset.CPUSet, e
 }
 
 func (s *static) guaranteedCPUs(pod cache.Pod, container cache.Container) int {
-	qos := pod.GetPodQOS()
+	qos := pod.GetQOSClass()
 
 	s.Debug("* QoS class for pod %s (%s) is %s", pod.GetId(), pod.GetName(), qos)
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/README.md
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/README.md
@@ -1,0 +1,146 @@
+# Topology-Aware Policy
+
+## Overview
+
+The `topology-aware` builtin policy splits up the node into a tree of pools from
+which then resources are allocated to Containers. Currently the tree of pools is
+constructed automatically using runtime-discovered hardware topology information
+about the node. The pools correspond to the topologically relevant HW components:
+sockets, NUMA nodes, and CPUs/cores. The root of the tree corresponds to the full
+HW available in the system, the next level corresponds to individual sockets in the
+system, the next one to individual NUMA nodes. While not actually present as such
+in the tree in the form of nodes, logically the lowest level corresponds to actual
+physical resoruces of interest: CPU cores, memory, etc.
+
+The main goal of the `topology-aware` policy is to try and distribute Containers
+among the pools in a way that both maximizes Container performance and minimizes
+interference between the Containers of different `Pod`s. This is accomplished by
+considering
+
+- topological characteristics of the Container's devices (`topology hints`)
+- potential hints provided by the user (in the form of policy-specific `annotations`)
+- current availability of hardware resources
+- other colocated Containers running on the node
+
+## Features
+
+- aligning workload CPU and memory wrt. the locality of devices used
+- exclusive CPU allocation from pools
+- discovering and using kernel-isolated CPUs for exclusive allocations
+- shared CPU allocation from pools
+- mixed (both exclusive and shared) allocation from pools
+- exposing the allocated CPU to Containers
+- notifying Containers about changes in allocation
+
+## Activating the Topology-Aware Policy
+
+You can activate the tpology-aware policy by setting the `--policy` option of
+`cri-resmgr` to `topology-aware`. For instance like this:
+
+```
+cri-resmgr --policy topology-aware --reserved-resources cpu=750m
+```
+
+## Configuration
+
+### Commandline Options
+
+There are a number of options specific to this policy:
+
+- `--topology-aware-pin-cpu`:
+Whether to pin Containers to the CPUs of the assigned pool.
+
+- `--topology-aware-pin-memory`:
+Whether to pin Containers to the memory of the assigned pool.
+
+- `--topology-aware-prefer-isolated-cpus:
+Whether to try to allocate kernel-isolated CPUs for exclusive usage unless the Pod or Container
+is explicitly annotated otherwise.
+
+- `--topology-aware-prefer-shared-cpus`:
+Whether to allocate shared CPUs unless the Pod or Container is explicitly annotated otherwise.
+
+### Dynamic Configuration
+
+The `topology-aware` policy can be configured dynamically using the
+[`node agent`](/README.md#cri-resource-manager-node-agent). It takes
+a JSON configuration with the following keys corresponding to the above
+mentioned options:
+
+- `PinCPU`
+- `PinMemory`
+- `PreferIsolatedCPUs`
+- `PreferSharedCPUs`
+
+See the [`documentation`](/README.md#dynamic-configuration) for information about
+dynamic configuration.
+
+See the [sample ConfigMap spec](/sample-configs/cri-resmgr-configmap.example.yaml)
+for an example which configures the `topology-aware` policy with the built-in
+defaults.
+
+### Container / `Pod` Allocation Policy Hints
+
+The `topology-aware` policy recognizes a number of policy-specific annotations
+that can be used to provide hints and preferences about how resources should
+be allocated to the Containers. These hints are:
+
+- `cri-resource-manager.intel.com/prefer-isolated-cpus`: isolated exclusive CPU preference
+- `cri-resource-manager.intel.com/prefer-shared-cpus`: shared allocation preference
+
+#### Isolated Exclusive CPUs
+
+When kernel-isolated CPUs are available ,the `topology-aware` policy will prefer
+to allocate those to any Container of a `Pod` in the `Guaranteed QoS class` if
+the Container `resource requirements` ask for exactly 1 CPU. If multiple CPUs are
+requested, exlusive CPUs will be sliced off from the shared CPU set of the pool.
+
+This default behavior can be changed using the `--topology-aware-prefer-isolated-cpus`
+boolean configuration option.
+
+The global default behavior can also be overridden, per Pod or per Container, using
+the `cri-resource-manager.intel.com/prefer-isolated-cpus` `annotation`. Setting the
+value to `true` asks the policy to prefer isoalted CPUs for exclusive allocation even
+if the Container asks for multiple CPUs and only fall back to slicing off shared CPUs
+then there is insufficent free isolated capacity. Similarly, setting the value of the
+`annotation` to `false` opts out every Container in the `Pod` from taking any isolated
+CPUs.
+
+The same mechanism can be used to opt-in or out of isolated CPU usage per Container
+within the `Pod` by setting the value of the `annotation` to the string represenation of
+a JSON object where each key is the name of a Container and each value is either
+`true` or `false`.
+
+#### Shared CPU Allocation
+
+The `topology-aware` policy assumes mixed mode exclusive+shared CPU allocation
+preference by default. Under those assumptions every Container of a `Pod` in the
+´Guaranteed QoS class` will get exclusive CPUs allocated worth the integer part
+of their `CPU request` and a portion of the pool shared CPU set proportional to
+the fractional part of their `CPU request`. So for instance, a Container requesting
+2.5 CPUs or 2500 milli-CPUs will get by default two exclusive CPUs allocated and
+half a CPU worth allocated from the pools CPU set shared with other Container in
+the same pool.
+
+This default behavior can be changed using the `--topology-aware-prefer-shared-cpus`
+boolean configuration option.
+
+Pods or Containers can opt-out of this assumption using the
+`cri-resource-manager.intel.com/prefer-shared-cpus` `annotation`. Setting its value
+to `true` will cause the policy to always allocate the entire requested capacity for
+all Containers of the Pod from the shared CPUs of a pool. Setting the value to `false`
+will cause the policy to allocate any integer portion of the CPU request exclusively
+and any fractional part from the shared CPUs.
+
+The same thing can be accomplished per Container by using as value a `JSON object`
+similarly to the isolated CPU preference `annotation`: using the Container name as
+a key, and `true` or `false` as the value. Moreover, if a negative integer is used
+as the value, it is interpreted as `true` with a Container displacement upward in
+the tree. For instance, setting the annotation value to
+
+```
+  "{\"container-1\": -1, \"container-2\": true}" (or `0` instead of `true`)
+```
+
+requests container-1 to be placed to the parent of the pool with the best fitting
+score and container-2 to be placed in the best fitting pool itself.

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
@@ -1,0 +1,204 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"encoding/json"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+const (
+	keyAllocations = "allocations"
+	keyConfig      = "config"
+)
+
+func (p *policy) saveAllocations() {
+	p.cache.SetPolicyEntry(keyAllocations, cache.Cachable(&p.allocations))
+	p.cache.Save()
+}
+
+func (p *policy) restoreAllocations() bool {
+	return p.cache.GetPolicyEntry(keyAllocations, &p.allocations)
+}
+
+func (p *policy) saveConfig() error {
+	cached := cachedOptions{Options: opt}
+	p.cache.SetPolicyEntry(keyConfig, cache.Cachable(&cached))
+	p.cache.Save()
+	return nil
+}
+
+func (p *policy) restoreConfig() bool {
+	cached := cachedOptions{}
+	if !p.cache.GetPolicyEntry(keyConfig, &cached) {
+		return false
+	}
+
+	// Notes:
+	//   We merge the restored configuration, which is our fallback/default one until we
+	//   get an up-to-date one from the agent, into the current one, which might container
+	//   explicitly overridden defaults. In the merged configuration we want to keep the
+	//   explicitly overridden defaults intact, again until we receive an up-to-date one.
+	//   However, any new fake hints we merge into the restored configuration and save it.
+	restored := &cached.Options
+	opt.mergeFakeHints(restored)
+	restored.Hints = opt.Hints
+	opt.Hints = restored.Hints
+	p.saveConfig()
+
+	if opt.IsExplicit(optPinCpu) {
+		restored.PinCpu = opt.PinCpu
+	}
+	if opt.IsExplicit(optPinMem) {
+		restored.PinMem = opt.PinMem
+	}
+	if opt.IsExplicit(optPreferIsolated) {
+		restored.PreferIsolated = opt.PreferIsolated
+	}
+	if opt.IsExplicit(optPreferShared) {
+		restored.PreferShared = opt.PreferShared
+	}
+
+	opt = *restored
+
+	return true
+}
+
+type cachedGrant struct {
+	Exclusive string
+	Part      int
+	Container string
+	Pool      string
+}
+
+func newCachedGrant(cg CpuGrant) *cachedGrant {
+	ccg := &cachedGrant{}
+	ccg.Exclusive = cg.ExclusiveCpus().String()
+	ccg.Part = cg.SharedPortion()
+	ccg.Container = cg.GetContainer().GetCacheId()
+	ccg.Pool = cg.GetNode().Name()
+
+	return ccg
+}
+
+func (ccg *cachedGrant) ToCpuGrant(policy *policy) (CpuGrant, error) {
+	node, ok := policy.nodes[ccg.Pool]
+	if !ok {
+		return nil, policyError("cache error: failed to restore %v, unknown pool/node", *ccg)
+	}
+	container, ok := policy.cache.LookupContainer(ccg.Container)
+	if !ok {
+		return nil, policyError("cache error: failed to restore %v, unknown container", *ccg)
+	}
+
+	return newCpuGrant(
+		node,
+		container,
+		cpuset.MustParse(ccg.Exclusive),
+		ccg.Part,
+	), nil
+}
+
+func (cg *cpuGrant) MarshalJSON() ([]byte, error) {
+	return json.Marshal(newCachedGrant(cg))
+}
+
+func (cg *cpuGrant) UnmarshalJSON(data []byte) error {
+	ccg := cachedGrant{}
+
+	if err := json.Unmarshal(data, &ccg); err != nil {
+		return policyError("failed to restore cpuGrant: %v", err)
+	}
+
+	cg.exclusive = cpuset.MustParse(ccg.Exclusive)
+
+	return nil
+}
+
+func (a *allocations) MarshalJSON() ([]byte, error) {
+	cgrants := make(map[string]*cachedGrant)
+	for id, cg := range a.Cpu {
+		cgrants[id] = newCachedGrant(cg)
+	}
+
+	return json.Marshal(cgrants)
+}
+
+func (a *allocations) UnmarshalJSON(data []byte) error {
+	var err error
+
+	cgrants := make(map[string]*cachedGrant)
+	if err := json.Unmarshal(data, &cgrants); err != nil {
+		return policyError("failed to restore allocations: %v", err)
+	}
+
+	a.Cpu = make(map[string]CpuGrant, 32)
+	for id, ccg := range cgrants {
+		a.Cpu[id], err = ccg.ToCpuGrant(a.policy)
+		if err != nil {
+			log.Error("removing unresolvable cached grant %v: %v", *ccg, err)
+			delete(a.Cpu, id)
+		} else {
+			log.Debug("resolved cache grant: %v", a.Cpu[id].String())
+		}
+	}
+
+	return nil
+}
+
+func (a *allocations) Get() interface{} {
+	return a
+}
+
+func (a *allocations) Set(value interface{}) {
+	var from *allocations
+
+	switch value.(type) {
+	case allocations:
+		v := value.(allocations)
+		from = &v
+	case *allocations:
+		from = value.(*allocations)
+	}
+
+	a.Cpu = make(map[string]CpuGrant, 32)
+	for id, cg := range from.Cpu {
+		a.Cpu[id] = cg
+	}
+}
+
+func (a *allocations) Dump(logfn func(format string, args ...interface{}), prefix string) {
+	for _, cg := range a.Cpu {
+		logfn(prefix+"%s", cg.String())
+	}
+}
+
+type cachedOptions struct {
+	Options options
+}
+
+func (o *cachedOptions) Get() interface{} {
+	return o
+}
+
+func (o *cachedOptions) Set(value interface{}) {
+	switch value.(type) {
+	case options:
+		o.Options = value.(cachedOptions).Options
+	case *options:
+		o.Options = value.(*cachedOptions).Options
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
@@ -1,0 +1,478 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"fmt"
+	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+// CpuSupply represents avaialbe CPU capacity of a node.
+type CpuSupply interface {
+	// GetNode returns the node supplying this capacity.
+	GetNode() Node
+	// Clone creates a copy of this CpuSupply.
+	Clone() CpuSupply
+	// IsolatedCpus returns the isolated cpuset in this supply.
+	IsolatedCpus() cpuset.CPUSet
+	// SharableCpus returns the sharable cpuset in this supply.
+	SharableCpus() cpuset.CPUSet
+	// Granted returns the locally granted capacity in this supply.
+	Granted() int
+	// Cumulate cumulates the given supply into this one.
+	Cumulate(CpuSupply)
+	// AccountAllocate accounts for (removes) allocated exclusive capacity from the supply.
+	AccountAllocate(CpuGrant)
+	// AccountRelease accounts for (reinserts) released exclusive capacity into the supply.
+	AccountRelease(CpuGrant)
+	// Score calculates how well this supply fits/fulfills the given request.
+	Score(CpuRequest) float64
+	// Allocate allocates CPU capacity from this supply and returns it as a grant.
+	Allocate(CpuRequest) (CpuGrant, error)
+	// Release releases a previously allocated grant.
+	Release(CpuGrant)
+	// String returns a printable representation of this supply.
+	String() string
+}
+
+// CpuRequest represents a CPU resources requested by a container.
+type CpuRequest interface {
+	// GetContainer returns the container requesting CPU capacity.
+	GetContainer() cache.Container
+	// String returns a printable representation of this request.
+	String() string
+}
+
+// CpuGrant represents CPU capacity allocated to a container from a node.
+type CpuGrant interface {
+	// GetContainer returns the container CPU capacity is granted to.
+	GetContainer() cache.Container
+	// GetNode returns the node that granted CPU capacity to the container.
+	GetNode() Node
+	// ExclusiveCpus returns the exclusively granted non-isolated cpuset.
+	ExclusiveCpus() cpuset.CPUSet
+	// SharedCpus returns the shared granted cpuset.
+	SharedCpus() cpuset.CPUSet
+	// SharedPortion returns the amount of CPUs in milli-CPU granted.
+	SharedPortion() int
+	// IsolatedCpus returns the exclusively granted isolated cpuset.
+	IsolatedCpus() cpuset.CPUSet
+	// String returns a printable representation of this grant.
+	String() string
+}
+
+// cpuSupply implements our CpuSupply interface.
+type cpuSupply struct {
+	node     Node          // node supplying CPUs
+	isolated cpuset.CPUSet // isolated CPUs at this node
+	sharable cpuset.CPUSet // sharable CPUs at this node
+	granted  int           // amount of sharable allocated
+}
+
+var _ CpuSupply = &cpuSupply{}
+
+// cpuRequest implements our CpuRequest interface.
+type cpuRequest struct {
+	container cache.Container // container for this request
+	full      int             // number of full CPUs requested
+	fraction  int             // amount of fractional CPU requested
+	exclusive int             // full CPUs requested
+	shared    int             // partial CPU requested in milli-CPUs
+	isolate   bool            // prefer isolated exclusive CPUs
+	elevate   int             // displace allocation up in the tree
+}
+
+var _ CpuRequest = &cpuRequest{}
+
+// cpuGrant implements our CpuGrant interface.
+type cpuGrant struct {
+	container cache.Container // container CPU is granted to
+	node      Node            // node CPU is supplied from
+	exclusive cpuset.CPUSet   // exclusive CPUs
+	portion   int             // milliCPUs granted from shared set
+}
+
+var _ CpuGrant = &cpuGrant{}
+
+// newCpuSupply creates CPU supply for the given node, cpusets and existing grant.
+func newCpuSupply(n Node, isolated, sharable cpuset.CPUSet, granted int) CpuSupply {
+	return &cpuSupply{
+		node:     n,
+		isolated: isolated.Clone(),
+		sharable: sharable.Clone(),
+		granted:  granted,
+	}
+}
+
+// GetNode returns the node supplying CPU.
+func (cs *cpuSupply) GetNode() Node {
+	return cs.node
+}
+
+// Clone clones the given CPU supply.
+func (cs *cpuSupply) Clone() CpuSupply {
+	return newCpuSupply(cs.node, cs.isolated, cs.sharable, cs.granted)
+}
+
+// IsolatedCpus returns the isolated CPUSet of this supply.
+func (cs *cpuSupply) IsolatedCpus() cpuset.CPUSet {
+	return cs.isolated.Clone()
+}
+
+// SharableCpus returns the sharable CPUSet of this supply.
+func (cs *cpuSupply) SharableCpus() cpuset.CPUSet {
+	return cs.sharable.Clone()
+}
+
+// Granted returns the locally granted sharable CPU capacity.
+func (cs *cpuSupply) Granted() int {
+	return cs.granted
+}
+
+// Cumulate more CPU to supply.
+func (cs *cpuSupply) Cumulate(more CpuSupply) {
+	mcs := more.(*cpuSupply)
+
+	cs.isolated = cs.isolated.Union(mcs.isolated)
+	cs.sharable = cs.sharable.Union(mcs.sharable)
+	cs.granted += mcs.granted
+}
+
+// AccountAllocate accounts for (removes) allocated exclusive capacity from the supply.
+func (cs *cpuSupply) AccountAllocate(g CpuGrant) {
+	if cs.node.IsSameNode(g.GetNode()) {
+		return
+	}
+	exclusive := g.ExclusiveCpus()
+	cs.isolated = cs.isolated.Difference(exclusive)
+	cs.sharable = cs.sharable.Difference(exclusive)
+}
+
+// AccountRelease accounts for (reinserts) released exclusive capacity into the supply.
+func (cs *cpuSupply) AccountRelease(g CpuGrant) {
+	if cs.node.IsSameNode(g.GetNode()) {
+		return
+	}
+
+	ncs := cs.node.GetCpu()
+	nodecpus := ncs.IsolatedCpus().Union(ncs.SharableCpus())
+	grantcpus := g.ExclusiveCpus().Intersection(nodecpus)
+
+	isolated := grantcpus.Intersection(ncs.IsolatedCpus())
+	sharable := grantcpus.Intersection(ncs.SharableCpus())
+	cs.isolated = cs.isolated.Union(isolated)
+	cs.sharable = cs.sharable.Union(sharable)
+}
+
+// Score calculates the fitting score of a request for this supply.
+func (cs *cpuSupply) Score(r CpuRequest) float64 {
+	var score, hscore float64
+
+	cr := r.(*cpuRequest)
+	hints := cr.container.GetTopologyHints()
+
+	pod, _ := cr.container.GetPod()
+	fakekey := pod.GetName() + ":" + cr.container.GetName()
+	if fake, ok := opt.Hints[fakekey]; ok {
+		for src, fh := range fake {
+			hints[src] = fh
+		}
+	}
+	if fake, ok := opt.Hints[cr.container.GetName()]; ok {
+		for src, fh := range fake {
+			hints[src] = fh
+		}
+	}
+
+	log.Debug("* scoring %s (for %s)", cs.String(), cr.String())
+	if len(hints) > 0 {
+		log.Debug("  - with topology hints:")
+		for _, h := range hints {
+			log.Debug("   %s", h.String())
+		}
+	} else {
+		log.Debug("  - without topology hints...")
+	}
+
+	full, part, isolate := cr.full, cr.fraction, cr.isolate
+
+	if full == 0 && part == 0 {
+		part = 1
+		isolate = false
+	}
+
+	granted := cs.node.GrantedCpu()
+	hisolated := cs.maskByHints(cs.isolated, hints)
+	hsharable := cs.maskByHints(cs.sharable, hints)
+	hgranted := float64(hsharable.Size()) / float64(cs.sharable.Size()) * float64(granted)
+
+	// hint-score is how big portion of the request we can do in a hint-satisfying manner
+
+	switch {
+	// no exclusive capacity
+	case isolate && (cs.isolated.Size() < full && 1000*cs.sharable.Size()-granted < 1000*full):
+		log.Debug("  - no spare isolated or slicable exclusive capacity: score 0.0")
+		score = 0.0
+
+		// no shared capacity
+	case 1000*cs.sharable.Size()-granted < part:
+		log.Debug("  - no spare shared capacity: score 0.0")
+		score = 0.0
+
+		// perfect isolated exclusive fit
+	case isolate && (full > 0 && part == 0 && cs.isolated.Size() >= full):
+		log.Debug("  - perfect isolated exclusive fit: score 1.0")
+		score = 1.0
+		hscore = float64(hisolated.Size()) / float64(full)
+
+		// perfect shared-only fit
+	case full == 0 && 1000*cs.sharable.Size()-granted >= part:
+		log.Debug("  - perfect sharable fit: score 1.0")
+		score = 1.0
+		if part == 0 {
+			hscore = 1.0
+		} else {
+			hscore = (float64(hsharable.Size()) - hgranted) / float64(part)
+		}
+
+		// perfect isolated + shared fit
+	case isolate && (full > 0 && part > 0 &&
+		cs.isolated.Size() >= full && 1000*cs.sharable.Size()-granted >= part):
+		log.Debug("  - perfect isolated + shared fit: score 1.0")
+		score = 1.0
+
+		hscore = (float64(1000*hisolated.Size()+1000*hsharable.Size()) - hgranted) /
+			float64(1000*full+part)
+
+		// will need to slice off sharable capacity for exclusive usage:
+	default:
+		log.Debug("  - need to slice of %d sharable CPUs", full)
+		score = 1.0
+
+		hscore = (float64(1000*hsharable.Size()) - hgranted - float64(1000*full-part)) /
+			float64(1000*full+part)
+	}
+
+	if hscore > 1 {
+		hscore = 1
+	}
+	if hscore < 0 {
+		hscore = 0
+	}
+
+	log.Debug("  => score: %f, hint-score: %f => score: %f", score, hscore, score*hscore)
+
+	score = score * hscore
+
+	return score
+}
+
+// Allocate allocates a grant from the supply.
+func (cs *cpuSupply) Allocate(r CpuRequest) (CpuGrant, error) {
+	var exclusive cpuset.CPUSet
+	var err error
+
+	cr := r.(*cpuRequest)
+
+	// allocate isolated exclusive CPUs or slice them off the sharable set
+	switch {
+	case cr.full > 0 && cs.isolated.Size() >= cr.full:
+		exclusive, err = takeCPUs(&cs.isolated, nil, cr.full)
+		if err != nil {
+			return nil, policyError("internal error: "+
+				"can't allocate %d exclusive CPUs from %s of %s",
+				cr.full, cs.isolated.String(), cs.node.Name())
+		}
+
+	case cr.full > 0 && (1000*cs.sharable.Size()-cs.granted)/1000 > cr.full:
+		exclusive, err = takeCPUs(&cs.sharable, nil, cr.full)
+		if err != nil {
+			return nil, policyError("internal error: "+
+				"can't slice %d exclusive CPUs from %s(-%d) of %s",
+				cr.full, cs.sharable.String(), cs.granted, cs.node.Name())
+		}
+	}
+
+	// allocate requested portion of the sharable set
+	if cr.fraction > 0 {
+		if 1000*cs.sharable.Size()-cs.granted < cr.fraction {
+			return nil, policyError("internal error: "+
+				"not enough sharable CPU for %d in %s(-%d) of %s",
+				cr.fraction, cs.sharable.String(), cs.granted, cs.node.Name())
+		}
+		cs.granted += cr.fraction
+	}
+
+	grant := newCpuGrant(cs.node, cr.GetContainer(), exclusive, cr.fraction)
+
+	cs.node.DepthFirst(func(n Node) error {
+		n.FreeCpu().AccountAllocate(grant)
+		return nil
+	})
+
+	return grant, nil
+}
+
+// Release returns CPU from the given grant to the supply.
+func (cs *cpuSupply) Release(g CpuGrant) {
+	isolated := g.ExclusiveCpus().Intersection(cs.node.GetCpu().IsolatedCpus())
+	sharable := g.ExclusiveCpus().Difference(isolated)
+
+	cs.isolated = cs.isolated.Union(isolated)
+	cs.sharable = cs.sharable.Union(sharable)
+	cs.granted -= g.SharedPortion()
+
+	cs.node.DepthFirst(func(n Node) error {
+		n.FreeCpu().AccountRelease(g)
+		return nil
+	})
+}
+
+// String returns the CPU supply as a string.
+func (cs *cpuSupply) String() string {
+	none, isolated, sharable, sep := "-", "", "", ""
+
+	if !cs.isolated.IsEmpty() {
+		isolated = fmt.Sprintf("isolated:%s", cs.isolated.String())
+		sep = ", "
+		none = ""
+	}
+	if !cs.sharable.IsEmpty() {
+		sharable = fmt.Sprintf("%ssharable:%s (granted:%d, free: %d)", sep,
+			cs.sharable.String(), cs.granted, 1000*cs.sharable.Size()-cs.granted)
+		none = ""
+	}
+
+	return "<" + cs.node.Name() + " CPU: " + none + isolated + sharable + ">"
+}
+
+// newCpuRequest creates a new CPU request for the given container.
+func newCpuRequest(container cache.Container) CpuRequest {
+	pod, _ := container.GetPod()
+	full, fraction, isolate, elevate := cpuAllocationPreferences(pod, container)
+
+	return &cpuRequest{
+		container: container,
+		full:      full,
+		fraction:  fraction,
+		isolate:   isolate,
+		elevate:   elevate,
+	}
+}
+
+// GetContainer returns the container requesting CPU.
+func (cr *cpuRequest) GetContainer() cache.Container {
+	return cr.container
+}
+
+// String returns aprintable representation of the CPU request.
+func (cr *cpuRequest) String() string {
+	isolated := map[bool]string{false: "", true: "isolated "}[cr.isolate]
+	switch {
+	case cr.full == 0 && cr.fraction == 0:
+		return fmt.Sprintf("<CPU request " + cr.container.GetCacheId() + ": ->")
+
+	case cr.full > 0 && cr.fraction > 0:
+		return fmt.Sprintf("<CPU request "+cr.container.GetCacheId()+": "+
+			"%sfull: %d, shared: %d>", isolated, cr.full, cr.fraction)
+
+	case cr.full > 0:
+		return fmt.Sprintf("<CPU request "+
+			cr.container.GetCacheId()+": %sfull: %d>", isolated, cr.full)
+
+	default:
+		return fmt.Sprintf("<CPU request "+
+			cr.container.GetCacheId()+": shared: %d>", cr.fraction)
+	}
+}
+
+// newCpuGrant creates a CPU grant from the given node for the container.
+func newCpuGrant(n Node, c cache.Container, exclusive cpuset.CPUSet, portion int) CpuGrant {
+	return &cpuGrant{
+		node:      n,
+		container: c,
+		exclusive: exclusive,
+		portion:   portion,
+	}
+}
+
+// GetContainer returns the container this grant is valid for.
+func (cg *cpuGrant) GetContainer() cache.Container {
+	return cg.container
+}
+
+// GetNode returns the Node this grant is allocated to.
+func (cg *cpuGrant) GetNode() Node {
+	return cg.node
+}
+
+// ExclusiveCpus returns the non-isolated exclusive CPUSet in this grant.
+func (cg *cpuGrant) ExclusiveCpus() cpuset.CPUSet {
+	return cg.exclusive
+}
+
+// SharedCpus returns the shared CPUSet in this grant.
+func (cg *cpuGrant) SharedCpus() cpuset.CPUSet {
+	return cg.node.GetCpu().SharableCpus()
+	//return cg.shared
+}
+
+// SharedPortion returns the milli-CPU allocation for the shared CPUSet in this grant.
+func (cg *cpuGrant) SharedPortion() int {
+	return cg.portion
+}
+
+// ExclusiveCpus returns the isolated exclusive CPUSet in this grant.
+func (cg *cpuGrant) IsolatedCpus() cpuset.CPUSet {
+	return cg.node.GetCpu().IsolatedCpus().Intersection(cg.exclusive)
+}
+
+// String returns a printable representation of the CPU grant.
+func (cg *cpuGrant) String() string {
+	var isolated, exclusive, shared, sep string
+
+	isol := cg.IsolatedCpus()
+	if !isol.IsEmpty() {
+		isolated = fmt.Sprintf("isolated: %s", isol.String())
+		sep = ", "
+	}
+	if !cg.exclusive.IsEmpty() {
+		exclusive = fmt.Sprintf("%sexclusive: %s", sep, cg.exclusive.String())
+		sep = ", "
+	}
+	if cg.portion > 0 {
+		shared = fmt.Sprintf("%sshared: %s (%d milli-CPU)", sep,
+			cg.node.FreeCpu().SharableCpus().String(), cg.portion)
+	}
+
+	return fmt.Sprintf("<CPU grant for %s from %s: %s%s%s>",
+		cg.container.GetCacheId(), cg.node.Name(), isolated, exclusive, shared)
+}
+
+// takeCPUs takes up to cnt CPUs from a given CPU set to another.
+func takeCPUs(from, to *cpuset.CPUSet, cnt int) (cpuset.CPUSet, error) {
+	cset, err := cpuallocator.AllocateCpus(from, cnt)
+	if err != nil {
+		return cset, err
+	}
+
+	if to != nil {
+		*to = to.Union(cset)
+	}
+
+	return cset, err
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/error.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/error.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"fmt"
+)
+
+// policyError creates a formatted policy-specific error.
+func policyError(format string, args ...interface{}) error {
+	return fmt.Errorf(PolicyName+": "+format, args...)
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/flags.go
@@ -1,0 +1,157 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"flag"
+	"fmt"
+	"github.com/ghodss/yaml"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"strconv"
+)
+
+const (
+	// optPrefix is our common option prefix.
+	optPrefix = "topology-aware-"
+	// Control whether containers are CPU-pinned using the cpuset cgroup controller.
+	optPinCpu = optPrefix + "pin-cpu"
+	// Control whether containers are memory-pinned using the cpuset cgroup controller.
+	optPinMem = optPrefix + "pin-memory"
+	// Control whether isolated CPUs are preferred for exclusive allocation.
+	optPreferIsolated = optPrefix + "prefer-isolated-cpus"
+	// Control whether shared CPU allocation is preferred over exclusive by default
+	optPreferShared = optPrefix + "prefer-shared-cpus"
+	// Provide pod-/container-based fake topology hint.
+	optFakeHint = optPrefix + "fake-hint"
+)
+
+// Options captures our configurable policy parameters.
+type options struct {
+	PinCpu         bool `json:"PinCPU"`             // pin workloads to CPU
+	PinMem         bool `json:"PinMemory"`          // pin workloads to memory
+	PreferIsolated bool `json:"PreferIsolatedCPUs"` // prefer isolated CPUs for exclusive usage
+	PreferShared   bool `json:"PreferSharedCPUs"`   // prefer shared CPU allocation
+	Hints          map[string]system.TopologyHints
+	explicit       map[string]struct{}
+}
+
+// Our configurable options with their defaults.
+var opt = options{
+	PinCpu:         true,
+	PinMem:         true,
+	PreferIsolated: true,
+	PreferShared:   false,
+	Hints:          make(map[string]system.TopologyHints),
+	explicit:       make(map[string]struct{}),
+}
+
+func parseConfig(raw []byte) (*options, error) {
+	conf := &options{}
+
+	if len(raw) != 0 {
+		if err := yaml.Unmarshal(raw, conf); err != nil {
+			return nil, policyError("failed to parse configuration: %v", err)
+		}
+	}
+
+	return conf, nil
+}
+
+func (o *options) Set(name, value string) error {
+	var err error
+
+	switch name {
+	case optPinCpu:
+		o.PinCpu, err = strconv.ParseBool(value)
+	case optPinMem:
+		o.PinCpu, err = strconv.ParseBool(value)
+	case optPreferIsolated:
+		o.PreferIsolated, err = strconv.ParseBool(value)
+	case optPreferShared:
+		o.PreferShared, err = strconv.ParseBool(value)
+	case optFakeHint:
+		err = o.parseFakeHint(value)
+	default:
+		return policyError("unknown %s policy option '%s' with value '%s'",
+			PolicyName, name, value)
+	}
+
+	if err != nil {
+		return policyError("invalid value '%s' for option '%s': %v", value, name, err)
+	}
+
+	o.explicit[name] = struct{}{}
+
+	return nil
+}
+
+func (o *options) Get(name string) string {
+	switch name {
+	case optPinCpu:
+		return fmt.Sprintf("%v", o.PinCpu)
+	case optPinMem:
+		return fmt.Sprintf("%v", o.PinMem)
+	case optPreferIsolated:
+		return fmt.Sprintf("%v", o.PreferIsolated)
+	case optPreferShared:
+		return fmt.Sprintf("%v", o.PreferShared)
+	case optFakeHint:
+		return ""
+	default:
+		return fmt.Sprintf("<no value, unknown instrumentation option '%s'>", name)
+	}
+}
+
+func (p *options) IsExplicit(option string) bool {
+	_, explicit := p.explicit[option]
+	return explicit
+}
+
+type wrappedOption struct {
+	name     string
+	opt      *options
+	explicit bool
+}
+
+func wrapOption(name, usage string) (*wrappedOption, string, string) {
+	return &wrappedOption{name: name, opt: &opt}, name, usage
+}
+
+func (wo *wrappedOption) Name() string {
+	return wo.name
+}
+
+func (wo *wrappedOption) Set(value string) error {
+	return wo.opt.Set(wo.Name(), value)
+}
+
+func (wo *wrappedOption) String() string {
+	return wo.opt.Get(wo.Name())
+}
+
+// Register our command-line flags.
+func init() {
+	flag.Var(wrapOption(optPinCpu,
+		"Whether container should be CPU-pinned using the cpuset cgroup controller."))
+	flag.Var(wrapOption(optPinMem,
+		"Whether container should be memory-pinned using the cpuset cgroup controller."))
+	flag.Var(wrapOption(optPreferIsolated,
+		"Try to allocate kernel-isolated CPUs for exclusive usage unless the Pod or "+
+			"Container is explicitly annotated otherwise."))
+	flag.Var(wrapOption(optPreferShared,
+		"Allocate shared CPUs unless the Pod or Container is explicitly annotated otherwise."))
+	flag.Var(wrapOption(optFakeHint,
+		"A fake hint to pass to specified the pod or container."))
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
@@ -1,0 +1,175 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"fmt"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"strconv"
+	"strings"
+)
+
+// mask the given cpus by all the given hints.
+func (cs *cpuSupply) maskByHints(cpus cpuset.CPUSet, hints system.TopologyHints) cpuset.CPUSet {
+	log.Debug(" * node %s: masking cpuset %s with topology hints...",
+		cs.node.Name(), cpus.String())
+
+	for _, h := range hints {
+		log.Debug("   - masking with hint %s...", h.String())
+
+		switch {
+		case h.CPUs != "":
+			cpus = cpus.Intersection(cpuset.MustParse(h.CPUs))
+
+		case h.NUMAs != "":
+			for _, idstr := range strings.Split(h.NUMAs, ",") {
+				if id, err := strconv.ParseInt(idstr, 0, 0); err == nil {
+					if node := cs.node.System().Node(system.Id(id)); node != nil {
+						cpus = cpus.Intersection(node.CPUSet())
+					}
+				}
+			}
+
+		case h.Sockets != "":
+			for _, idstr := range strings.Split(h.Sockets, ",") {
+				if id, err := strconv.ParseInt(idstr, 0, 0); err == nil {
+					if pkg := cs.node.System().Package(system.Id(id)); pkg != nil {
+						cpus = cpus.Intersection(pkg.CPUSet())
+					}
+				}
+			}
+		}
+	}
+
+	log.Debug("   = masked cpuset %s", cpus.String())
+
+	return cpus
+}
+
+// return the cpuset for the CPU, NUMA or socket hints, preferred in this particular order.
+func (cs *cpuSupply) hintCpus(h system.TopologyHint) cpuset.CPUSet {
+	var cpus cpuset.CPUSet
+
+	switch {
+	case h.CPUs != "":
+		cpus = cpuset.MustParse(h.CPUs)
+
+	case h.NUMAs != "":
+		for _, idstr := range strings.Split(h.NUMAs, ",") {
+			if id, err := strconv.ParseInt(idstr, 0, 0); err == nil {
+				if node := cs.node.System().Node(system.Id(id)); node != nil {
+					cpus = cpus.Union(node.CPUSet())
+				}
+			}
+		}
+
+	case h.Sockets != "":
+		for _, idstr := range strings.Split(h.Sockets, ",") {
+			if id, err := strconv.ParseInt(idstr, 0, 0); err == nil {
+				if pkg := cs.node.System().Package(system.Id(id)); pkg != nil {
+					cpus = cpus.Union(pkg.CPUSet())
+				}
+			}
+		}
+	}
+
+	return cpus
+}
+
+// a fake hint is of the format: target=[cpus:cpus[/nodes:nodes[/sockets:sockets]]];...
+func (o *options) parseFakeHint(value string) error {
+	specs := strings.Split(value, ";")
+	for _, spec := range specs {
+		targetfake := strings.Split(spec, "=")
+		if len(targetfake) != 2 {
+			return policyError("invalid fake hint spec '%s' among fake hints '%s'", spec, value)
+		}
+
+		target := targetfake[0]
+		fake := targetfake[1]
+
+		if fake == "-" {
+			// mark for deletion during merge
+			log.Debug("marking fake hints of %s for deletion...", target)
+			opt.Hints[target] = system.TopologyHints{}
+			continue
+		}
+
+		hints, ok := opt.Hints[target]
+		if !ok {
+			hints = system.TopologyHints{}
+		}
+		hintCnt := len(hints)
+		hint := system.TopologyHint{Provider: fmt.Sprintf("fake-hint#%d", hintCnt)}
+
+		for _, keyval := range strings.Split(fake, "/") {
+			kv := strings.Split(keyval, ":")
+			if len(kv) != 2 {
+				return policyError("invalid fake hint '%s' among fake hint '%s'", keyval, fake)
+			}
+
+			switch kv[0] {
+			case "cpu", "cpus":
+				hint.CPUs = kv[1]
+			case "node", "nodes", "numas":
+				hint.NUMAs = kv[1]
+			case "socket", "sockets":
+				hint.Sockets = kv[1]
+			default:
+				return policyError("invalid hint parameter %s in fake hint %s", kv[0], keyval)
+			}
+		}
+
+		hints[hint.Provider] = hint
+		opt.Hints[target] = hints
+	}
+
+	return nil
+}
+
+// mergeFakeHints merges two sets of fake hints, removing effective duplicates.
+func (o *options) mergeFakeHints(n *options) {
+	if o.Hints == nil {
+		o.Hints = make(map[string]system.TopologyHints)
+	}
+	for c, nhints := range n.Hints {
+		if ohints, ok := o.Hints[c]; !ok {
+			o.Hints[c] = nhints
+		} else {
+			if len(ohints) == 0 {
+				// was marked for deletion, so do it
+				log.Debug("deleting hints of %s", c)
+				delete(o.Hints, c)
+				continue
+			}
+			for _, nh := range nhints {
+				duplicate := false
+				for _, oh := range ohints {
+					if nh.CPUs == oh.CPUs && nh.NUMAs == oh.NUMAs && nh.Sockets == oh.Sockets {
+						duplicate = true
+						break
+					}
+				}
+				if duplicate {
+					continue
+				}
+				oh := nh
+				oh.Provider = fmt.Sprintf("fake-hint#%d", len(o.Hints[c]))
+				o.Hints[c][oh.Provider] = oh
+			}
+		}
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/logging.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/logging.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"fmt"
+
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+// Create our logger instance.
+var log logger.Logger = logger.NewLogger(PolicyName)
+
+// indent produces an indentation string for the given level.
+const (
+	IndentDepth = 4
+)
+
+func indent(prefix string, level ...int) string {
+	if len(level) < 1 {
+		return prefix
+	}
+
+	depth := level[0] * IndentDepth
+	return prefix + fmt.Sprintf("%*.*s", depth, depth, "")
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
@@ -1,0 +1,515 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"fmt"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+//
+// Nodes (currently) correspond to some tangible entity in the hardware topology
+// hierarchy: full machine (virtual root in multi-socket systems), an individual
+// sockets a NUMA node. These nodes are linked into a tree resembling the topology
+// tree, with the full machine at the top, and CPU cores at the bottom. In a single
+// socket system, the virtual root is replaced with the single socket. In a single
+// NUMA node case, the single node is omitted. Also, CPU cores are not modelled as
+// nodes, instead they are properties of the nodes (as capacity and free CPU).
+//
+
+// NodeKind represents a unique node type.
+type NodeKind string
+
+const (
+	// NilNode is the type of a nil node.
+	NilNode NodeKind = ""
+	// UnknownNode is the type of unknown node type.
+	UnknownNode NodeKind = "unknown"
+	// SocketNode represents a physical CPU package/socket in the system.
+	SocketNode NodeKind = "socket"
+	// NumaNode represents a NUMA node in the system.
+	NumaNode NodeKind = "numa node"
+	// VirtualNode represents a virtual node, currently the root multi-socket setups.
+	VirtualNode NodeKind = "virtual node"
+)
+
+// Node is the abstract interface our partition tree nodes implement.
+type Node interface {
+	// IsNil tests if this node is nil.
+	IsNil() bool
+	// Name returns the name of this node.
+	Name() string
+	// Kind returns the type of this node.
+	Kind() NodeKind
+	// NodeId returns the (enumerated) node id of this node.
+	NodeId() int
+	// Parent returns the parent node of this node.
+	Parent() Node
+	// Children returns the child nodes of this node.
+	Children() []Node
+	// LinkParent sets the given node as the parent node, and appends this node as a its child.
+	LinkParent(Node)
+	// AddChildren appends the nodes to the children, *WITHOUT* updating their parents.
+	AddChildren([]Node)
+	// IsSameNode returns true if the given node is the same as this one.
+	IsSameNode(Node) bool
+	// IsRootNode returns true if this node has no parent.
+	IsRootNode() bool
+	// IsLeafNode returns true if this node has no children.
+	IsLeafNode() bool
+	// Get the distance of this node from the root node.
+	RootDistance() int
+	// Get the height of this node (inverse of depth: tree depth - node depth).
+	NodeHeight() int
+	// System returns the policy sysfs instance.
+	System() *system.System
+	// Policy returns the policy back pointer.
+	Policy() *policy
+	// DiscoverCpu
+	DiscoverCpu() CpuSupply
+	// GetCpu
+	GetCpu() CpuSupply
+	// FreeCpu returns the availble CPU supply of the node.
+	FreeCpu() CpuSupply
+	// GrantedCpu returns the amount of granted shared CPU capacity of this node.
+	GrantedCpu() int
+	// GetMemset
+	GetMemset() system.IdSet
+	// DiscoverMemset
+	DiscoverMemset() system.IdSet
+	// Score calculates the score of the node wrt. the given request.
+	Score(CpuRequest) float64
+	// DepthFirst traverse the tree@node calling the function at each node.
+	DepthFirst(func(Node) error) error
+	// BreadthFirst traverse the tree@node calling the function at each node.
+	BreadthFirst(func(Node) error) error
+	// Dump state of the node.
+	Dump(string, ...int)
+	// Dump type-specific state of the node.
+	dump(string, ...int)
+}
+
+// node represents data common to all node types.
+type node struct {
+	policy   *policy      // policy back pointer
+	self     nodeself     // upcasted/type-specific interface
+	name     string       // node name
+	id       int          // node id
+	kind     NodeKind     // node type
+	depth    int          // node depth in the tree
+	parent   Node         // parent node
+	children []Node       // child nodes
+	nodecpu  CpuSupply    // CPU available at this node
+	freecpu  CpuSupply    // CPU allocatable at this node
+	mem      system.IdSet // memory attached to this node
+}
+
+// nodeself is used to 'upcast' a generic Node interface to a type-specific one.
+type nodeself struct {
+	node Node
+}
+
+// socketnode represents a physical CPU package/socket in the system.
+type socketnode struct {
+	node                   // common node data
+	id     system.Id       // NUMA node socket id
+	syspkg *system.Package // corresponding system.Package
+}
+
+// numanode represents a NUMA node in the system.
+type numanode struct {
+	node                 // common node data
+	id      system.Id    // NUMA node system id
+	sysnode *system.Node // corresponding system.Node
+}
+
+// virtualnode represents a virtual node (ATM only the root in a multi-socket system).
+type virtualnode struct {
+	node // common node data
+}
+
+// special node instance to represent a nonexistent node
+var nilnode Node = &node{
+	name:     "<nil node>",
+	id:       -1,
+	kind:     NilNode,
+	depth:    -1,
+	children: nil,
+}
+
+// Init initializes the resource with common node data.
+func (n *node) init(p *policy, name string, kind NodeKind, parent Node) {
+	n.policy = p
+	n.name = name
+	n.kind = kind
+	n.parent = parent
+
+	n.LinkParent(parent)
+}
+
+// IsNil tests if a node
+func (n *node) IsNil() bool {
+	return n.kind == NilNode
+}
+
+// Name returns the name of this node.
+func (n *node) Name() string {
+	if n.IsNil() {
+		return "<nil node>"
+	}
+	return n.name
+}
+
+// Kind returns the kind of this node.
+func (n *node) Kind() NodeKind {
+	return n.kind
+}
+
+// NodeId returns the node id of this node.
+func (n *node) NodeId() int {
+	if n.IsNil() {
+		return -1
+	}
+	return n.id
+}
+
+// IsSameNode checks if the given node is that same as this one.
+func (n *node) IsSameNode(other Node) bool {
+	return n.NodeId() == other.NodeId()
+}
+
+// IsRootNode returns true if this node has no parent.
+func (n *node) IsRootNode() bool {
+	return n.parent.IsNil()
+}
+
+// IsLeafNode returns true if this node has no children.
+func (n *node) IsLeafNode() bool {
+	return len(n.children) == 0
+}
+
+// RootDistance returns the distance of this node from the root node.
+func (n *node) RootDistance() int {
+	if n.IsNil() {
+		return -1
+	}
+	return n.depth
+}
+
+// NodeHeight returns the hight of this node (tree depth - node depth).
+func (n *node) NodeHeight() int {
+	if n.IsNil() {
+		return -1
+	}
+	return n.policy.depth - n.depth
+}
+
+// Parent returns the parent of this node.
+func (n *node) Parent() Node {
+	if n.IsNil() {
+		return nil
+	}
+
+	return n.parent
+}
+
+// Children returns the children of this node.
+func (n *node) Children() []Node {
+	if n.IsNil() {
+		return nil
+	}
+
+	return n.children
+}
+
+// LinkParent sets the given node as the node parent and appends this node to the parents children.
+func (n *node) LinkParent(parent Node) {
+	n.parent = parent
+	if !parent.IsNil() {
+		parent.AddChildren([]Node{n})
+	}
+
+	n.depth = parent.RootDistance() + 1
+}
+
+// AddChildren appends the nodes to the childres, *WITHOUT* setting their parent.
+func (n *node) AddChildren(nodes []Node) {
+	n.children = append(n.children, nodes...)
+}
+
+// Dump information/state of the node.
+func (n *node) Dump(prefix string, level ...int) {
+	if !log.DebugEnabled() {
+		return
+	}
+
+	lvl := 0
+	if len(level) > 0 {
+		lvl = level[0]
+	}
+	idt := indent(prefix, lvl)
+
+	n.self.node.dump(prefix, lvl)
+	log.Debug("%s  - node CPU: %v", idt, n.nodecpu)
+	log.Debug("%s  - free CPU: %v", idt, n.freecpu)
+	log.Debug("%s  - memory: %v", idt, n.mem)
+	for _, grant := range n.policy.allocations.Cpu {
+		if grant.GetNode().NodeId() == n.id {
+			log.Debug("%s    + %s", idt, grant.String())
+		}
+	}
+	if !n.Parent().IsNil() {
+		log.Debug("%s  - parent: <%s>", idt, n.Parent().Name())
+	}
+	log.Debug("%s  - children:", idt)
+	for _, c := range n.children {
+		c.Dump(prefix, lvl+1)
+	}
+}
+
+// Dump type-specific information about the node.
+func (n *node) dump(prefix string, level ...int) {
+	n.self.node.dump(prefix, level...)
+}
+
+// Do a depth-first traversal starting at node calling the given function at each node.
+func (n *node) DepthFirst(fn func(Node) error) error {
+	for _, c := range n.children {
+		if err := c.DepthFirst(fn); err != nil {
+			return err
+		}
+	}
+
+	return fn(n)
+}
+
+// Do a breadth-first traversal starting at node calling the given function at each node.
+func (n *node) BreadthFirst(fn func(Node) error) error {
+	if err := fn(n); err != nil {
+		return err
+	}
+
+	for _, c := range n.children {
+		if err := c.BreadthFirst(fn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// System returns the policy System instance.
+func (n *node) System() *system.System {
+	return n.policy.sys
+}
+
+// Policy returns the policy back pointer.
+func (n *node) Policy() *policy {
+	return n.policy
+}
+
+// Get CPU available at this node.
+func (n *node) GetCpu() CpuSupply {
+	return n.self.node.GetCpu()
+}
+
+// Discover CPU available at this node.
+func (n *node) DiscoverCpu() CpuSupply {
+	return n.self.node.DiscoverCpu()
+}
+
+// FreeCpu returns the available CPU supply in this node.
+func (n *node) FreeCpu() CpuSupply {
+	return n.freecpu
+}
+
+// Get score for a cpu request.
+func (n *node) Score(req CpuRequest) float64 {
+	f := n.FreeCpu()
+	return f.Score(req)
+}
+
+// Get the set of memory attached to this node.
+func (n *node) GetMemset() system.IdSet {
+	return n.self.node.GetMemset()
+}
+
+// Discover the set of memory attached to this node.
+func (n *node) DiscoverMemset() system.IdSet {
+	return n.self.node.DiscoverMemset()
+}
+
+// Granted returns the amount of granted shared CPU capacity of this node.
+func (n *node) GrantedCpu() int {
+	granted := n.freecpu.Granted()
+	for _, c := range n.children {
+		granted += c.GrantedCpu()
+	}
+	return granted
+}
+
+// NewNumaNode create a node for a CPU socket.
+func (p *policy) NewNumaNode(id system.Id, parent Node) Node {
+	n := &numanode{}
+	n.self.node = n
+	n.node.init(p, fmt.Sprintf("numa node #%v", id), NumaNode, parent)
+	n.id = id
+	n.sysnode = p.sys.Node(id)
+
+	return n
+}
+
+// Dump (the NUMA-specific parts of) this node.
+func (n *numanode) dump(prefix string, level ...int) {
+	log.Debug("%s<NUMA node #%v>", indent(prefix, level...), n.id)
+}
+
+// Get CPU supply available at this node.
+func (n *numanode) GetCpu() CpuSupply {
+	return n.nodecpu.Clone()
+}
+
+// DiscoverCpu discovers the CPU supply available at this node.
+func (n *numanode) DiscoverCpu() CpuSupply {
+	log.Debug("discovering CPU available at node %s...", n.Name())
+
+	nodecpus := n.sysnode.CPUSet()
+	isolated := nodecpus.Intersection(n.policy.isolated)
+	sharable := nodecpus.Difference(isolated)
+	n.nodecpu = newCpuSupply(n, isolated, sharable, 0)
+
+	n.freecpu = n.nodecpu.Clone()
+	return n.nodecpu.Clone()
+}
+
+// GetMemset() returns the set of memory attached to this node.
+func (n *numanode) GetMemset() system.IdSet {
+	return n.mem.Clone()
+}
+
+// DiscoverMemset discovers the set of memory attached to this node.
+func (n *numanode) DiscoverMemset() system.IdSet {
+	n.mem = system.NewIdSet(n.sysnode.Id())
+	return n.mem.Clone()
+}
+
+// NewSocketNode create a node for a CPU socket.
+func (p *policy) NewSocketNode(id system.Id, parent Node) Node {
+	n := &socketnode{}
+	n.self.node = n
+	n.node.init(p, fmt.Sprintf("socket #%v", id), SocketNode, parent)
+	n.id = id
+	n.syspkg = p.sys.Package(id)
+
+	return n
+}
+
+// Dump (the socket-specific parts of) this node.
+func (n *socketnode) dump(prefix string, level ...int) {
+	log.Debug("%s<socket #%v>", indent(prefix, level...), n.id)
+}
+
+// Get CPU supply available at this node.
+func (n *socketnode) GetCpu() CpuSupply {
+	return n.nodecpu.Clone()
+}
+
+// DiscoverCpu discovers the CPU supply available at this socket.
+func (n *socketnode) DiscoverCpu() CpuSupply {
+	log.Debug("discovering CPU available at node %s...", n.Name())
+
+	if n.IsLeafNode() {
+		sockcpus := n.syspkg.CPUSet()
+		isolated := sockcpus.Intersection(n.policy.isolated)
+		sharable := sockcpus.Difference(isolated)
+		n.nodecpu = newCpuSupply(n, isolated, sharable, 0)
+	} else {
+		n.nodecpu = newCpuSupply(n, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0)
+		for _, c := range n.children {
+			n.nodecpu.Cumulate(c.DiscoverCpu())
+		}
+	}
+
+	n.freecpu = n.nodecpu.Clone()
+	return n.nodecpu.Clone()
+}
+
+// GetMemset() returns the set of memory attached to this socket.
+func (n *socketnode) GetMemset() system.IdSet {
+	return n.mem.Clone()
+}
+
+// DiscoverMemset discovers the set of memory attached to this socket.
+func (n *socketnode) DiscoverMemset() system.IdSet {
+	n.mem = system.NewIdSet()
+	for _, c := range n.children {
+		n.mem.Add(c.GetMemset().Members()...)
+	}
+
+	return n.mem.Clone()
+}
+
+// NewVirtualNode creates a new virtual node.
+func (p *policy) NewVirtualNode(name string, parent Node) Node {
+	n := &virtualnode{}
+	n.self.node = n
+	n.node.init(p, fmt.Sprintf("%s", name), VirtualNode, parent)
+
+	return n
+}
+
+// Dump (the virtual-node specific parts of) this node.
+func (n *virtualnode) dump(prefix string, level ...int) {
+	log.Debug("%s<virtual %s>", indent(prefix, level...), n.name)
+}
+
+// Get CPU supply available at this node.
+func (n *virtualnode) GetCpu() CpuSupply {
+	return n.nodecpu.Clone()
+}
+
+// DiscoverCpu discovers the CPU supply available at this node.
+func (n *virtualnode) DiscoverCpu() CpuSupply {
+	log.Debug("discovering CPU available at node %s...", n.Name())
+
+	n.nodecpu = newCpuSupply(n, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0)
+	for _, c := range n.children {
+		n.nodecpu.Cumulate(c.DiscoverCpu())
+	}
+
+	n.freecpu = n.nodecpu.Clone()
+	return n.nodecpu.Clone()
+}
+
+// GetMemset() returns the set of memory attached to this socket.
+func (n *virtualnode) GetMemset() system.IdSet {
+	return n.mem.Clone()
+}
+
+// DiscoverMemset discovers the set of memory attached to this socket.
+func (n *virtualnode) DiscoverMemset() system.IdSet {
+	n.mem = system.NewIdSet()
+	for _, c := range n.children {
+		n.mem.Add(c.GetMemset().Members()...)
+	}
+	return n.mem.Clone()
+}
+
+// Finalize the setup of nilnode.
+func init() {
+	nilnode.(*node).self.node = nilnode
+	nilnode.(*node).parent = nilnode.(*node).self.node
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
@@ -1,0 +1,142 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"encoding/json"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+)
+
+const (
+	// annotation key for opting in to multiple isolated exclusive CPUs per container.
+	keyIsolationPreference = "prefer-isolated-cpus"
+	// annotation key for opting out of exclusive allocation and relaxed topology fitting.
+	keySharedCPUPreference = "prefer-shared-cpus"
+)
+
+// podIsolationPreference checks if containers explicitly prefers to run on multiple isolated CPUs.
+func podIsolationPreference(pod cache.Pod, container cache.Container) (bool, bool) {
+	value, ok := pod.GetResmgrAnnotation(keyIsolationPreference)
+	if !ok {
+		return opt.PreferIsolated, false
+	}
+	if value == "false" || value == "true" {
+		return (value[0] == 't'), true
+	}
+
+	preferences := map[string]bool{}
+	if err := json.Unmarshal([]byte(value), &preferences); err != nil {
+		log.Error("failed to parse isolation preference %s = '%s': %v",
+			keyIsolationPreference, value, err)
+		return opt.PreferIsolated, false
+	}
+
+	name := container.GetName()
+	if pref, ok := preferences[name]; ok {
+		log.Debug("%s per-container isolation preference '%v'", name, pref)
+		return pref, true
+	}
+
+	log.Debug("%s defaults to isolation preference '%v'", name, opt.PreferIsolated)
+	return opt.PreferIsolated, false
+}
+
+// podSharedCPUPreference checks if a container wants to opt-out from exclusive allocation.
+func podSharedCPUPreference(pod cache.Pod, container cache.Container) (bool, int) {
+	value, ok := pod.GetResmgrAnnotation(keySharedCPUPreference)
+	if !ok {
+		return opt.PreferShared, 0
+	}
+	if value == "false" || value == "true" {
+		return value[0] == 't', 0
+	}
+
+	preferences := map[string]string{}
+	if err := json.Unmarshal([]byte(value), &preferences); err != nil {
+		log.Error("failed to parse shared CPU preference %s = '%s': %v",
+			keySharedCPUPreference, value, err)
+		return opt.PreferShared, 0
+	}
+
+	name := container.GetName()
+	pref, ok := preferences[name]
+	if !ok {
+		return opt.PreferShared, 0
+	}
+	if pref == "false" || pref == "true" {
+		return pref[0] == 't', 0
+	}
+
+	elevate, err := strconv.ParseInt(pref, 0, 8)
+	if err != nil {
+		log.Error("invalid shared CPU preference for container %s (%s): %v", name, pref, err)
+		return opt.PreferShared, 0
+	}
+
+	if elevate > 0 {
+		log.Error("invalid (> 0) node displacement for container %s: %d", name, elevate)
+		return opt.PreferShared, 0
+	}
+
+	return true, int(elevate)
+}
+
+// cpuAllocationPreferences figures out the amount and kind of CPU to allocate.
+func cpuAllocationPreferences(pod cache.Pod, container cache.Container) (int, int, bool, int) {
+	req, ok := container.GetResourceRequirements().Requests[corev1.ResourceCPU]
+	if !ok {
+		return 0, 0, true, 0
+	}
+
+	qos := pod.GetQOSClass()
+
+	preferIsol, explicit := podIsolationPreference(pod, container)
+	preferShared, elevate := podSharedCPUPreference(pod, container)
+
+	full, fraction, isolate := 0, 0, false
+	switch {
+	case container.GetNamespace() == metav1.NamespaceSystem:
+		full, fraction = 0, int(req.MilliValue())
+
+	case qos == corev1.PodQOSBurstable || preferShared:
+		full, fraction = 0, int(req.MilliValue())
+
+	case qos == corev1.PodQOSGuaranteed:
+		full = int(req.MilliValue()) / 1000
+		fraction = int(req.MilliValue()) % 1000
+	}
+
+	if !preferShared {
+		switch {
+		case full == 1:
+			if explicit {
+				isolate = preferIsol
+			} else {
+				isolate = true
+			}
+		case full > 1:
+			isolate = preferIsol && explicit
+		}
+	} else {
+		elevate = -elevate
+	}
+
+	return full, fraction, isolate, elevate
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -1,0 +1,255 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"sort"
+)
+
+// buildPoolsByTopology builds a hierarchical tree of pools based on HW topology.
+func (p *policy) buildPoolsByTopology() error {
+	var n Node
+
+	socketCnt := p.sys.SocketCount()
+	nodeCnt := p.sys.NUMANodeCount()
+	if nodeCnt < 2 {
+		nodeCnt = 0
+	}
+	poolCnt := socketCnt + nodeCnt + map[bool]int{false: 0, true: 1}[socketCnt > 1]
+
+	p.nodes = make(map[string]Node, poolCnt)
+	p.pools = make([]Node, poolCnt)
+
+	// create virtual root if necessary
+	if socketCnt > 1 {
+		p.root = p.NewVirtualNode("root", nilnode)
+		p.nodes[p.root.Name()] = p.root
+	}
+
+	// create nodes for sockets
+	sockets := make(map[system.Id]Node, socketCnt)
+	for _, id := range p.sys.PackageIds() {
+		if socketCnt > 1 {
+			n = p.NewSocketNode(id, p.root)
+		} else {
+			n = p.NewSocketNode(id, nilnode)
+			p.root = n
+		}
+		p.nodes[n.Name()] = n
+		sockets[id] = n
+	}
+
+	// create nodes for NUMA nodes
+	if nodeCnt > 0 {
+		for _, id := range p.sys.NodeIds() {
+			n = p.NewNumaNode(id, sockets[p.sys.Node(id).PackageId()])
+			p.nodes[n.Name()] = n
+		}
+	}
+
+	// enumerate nodes, calculate tree depth, discover node resource capacity
+	p.root.DepthFirst(func(n Node) error {
+		p.pools[p.nodeCnt] = n
+		n.(*node).id = p.nodeCnt
+		p.nodeCnt++
+
+		if p.depth < n.(*node).depth {
+			p.depth = n.(*node).depth
+		}
+
+		n.DiscoverCpu()
+		n.DiscoverMemset()
+
+		return nil
+	})
+
+	return nil
+}
+
+// Pick a pool and allocate resource from it to the container.
+func (p *policy) allocatePool(container cache.Container) (CpuGrant, error) {
+	log.Debug("* allocating resources for %s", container.GetCacheId())
+
+	request := newCpuRequest(container)
+	scores, pools := p.sortPoolsByScore(request)
+
+	if log.DebugEnabled() {
+		for idx, n := range pools {
+			log.Debug("* fitting %s: #%d: node %s, score %f",
+				request.String(), idx, n.Name(), scores[n.NodeId()])
+		}
+	}
+
+	pool := pools[0]
+	cpus := pool.FreeCpu()
+
+	grant, err := cpus.Allocate(request)
+	if err != nil {
+		return nil, policyError("failed to allocate %s from %s: %v",
+			request.String(), cpus.String(), err)
+	}
+
+	p.allocations.Cpu[container.GetCacheId()] = grant
+	p.saveAllocations()
+
+	return grant, nil
+}
+
+// Apply the result of allocation to the requesting container.
+func (p *policy) applyGrant(grant CpuGrant) error {
+	log.Debug("* applying grant %s", grant.String())
+
+	container := grant.GetContainer()
+	exclusive := grant.ExclusiveCpus()
+	shared := grant.SharedCpus()
+	portion := grant.SharedPortion()
+
+	cpus := ""
+	kind := ""
+	if exclusive.IsEmpty() {
+		cpus = shared.String()
+		kind = "shared"
+	} else {
+		cpus = exclusive.Union(shared).String()
+		kind = "exclusive"
+		if portion > 0 {
+			kind += "+shared"
+		}
+	}
+
+	mems := ""
+	node := grant.GetNode()
+	if !node.IsRootNode() && opt.PinMem {
+		mems = node.GetMemset().String()
+	}
+
+	if opt.PinCpu {
+		if cpus != "" {
+			log.Debug("  => pinning to (%s) cpuset %s", kind, cpus)
+		} else {
+			log.Debug("  => not pinning CPUs, allocated cpuset is empty...")
+		}
+		container.SetCpusetCpus(cpus)
+		if exclusive.IsEmpty() {
+			container.SetCpuShares(int64(cache.MilliCPUToShares(portion)))
+		} else {
+			// Notes:
+			//   Hmm... I think setting CPU shares according to the normal formula
+			//   can be dangerous when we do mixed allocations (both exclusive and
+			//   shared CPUs assigned). If the exclusive cpuset is not isolated and
+			//   there are other processes (unbeknown to us) running on some of the
+			//   same exclusive CPU(s) with CPU shares not set by us, those processes
+			//   can starve our containers with supposedly exclusive CPUs...
+			//   There's not much we can do though... if we don't set the CPU shares
+			//   then any process/thread in the container that might sched_setaffinity
+			//   itself to the shared subset will not get properly weighted wrt. other
+			//   processes sharing the same CPUs.
+			//
+			container.SetCpuShares(int64(cache.MilliCPUToShares(portion)))
+		}
+	}
+
+	if mems != "" {
+		log.Debug("  => pinning to memory %s", mems)
+	} else {
+		log.Debug("  => not pinning memory, memory set is empty...")
+	}
+
+	return nil
+}
+
+// Release resources allocated by this grant.
+func (p *policy) releasePool(container cache.Container) (CpuGrant, bool, error) {
+	log.Debug("* releasing resources allocated to %s", container.GetCacheId())
+
+	grant, ok := p.allocations.Cpu[container.GetCacheId()]
+	if !ok {
+		log.Debug("  => no grant found, nothing to do...")
+		return nil, false, nil
+	}
+
+	log.Debug("  => releasing grant %s...", grant.String())
+
+	pool := grant.GetNode()
+	cpus := pool.FreeCpu()
+
+	cpus.Release(grant)
+	delete(p.allocations.Cpu, container.GetCacheId())
+	p.saveAllocations()
+
+	return grant, true, nil
+}
+
+// Update shared allocations effected by agrant.
+func (p *policy) updateSharedAllocations(grant CpuGrant) error {
+	log.Debug("* updating shared allocations affected by %s", grant.String())
+
+	for _, other := range p.allocations.Cpu {
+		if other.SharedPortion() == 0 {
+			log.Debug("  => %s not affected (no shared portion)...", other.String())
+			continue
+		}
+
+		if opt.PinCpu {
+			shared := other.GetNode().FreeCpu().SharableCpus().String()
+			log.Debug("  => updating %s with shared CPUs of %s: %s...",
+				other.String(), other.GetNode().Name(), shared)
+			other.GetContainer().SetCpusetCpus(shared)
+		}
+	}
+
+	return nil
+}
+
+// Score pools against the request and sort them by score.
+func (p *policy) sortPoolsByScore(request CpuRequest) (map[int]float64, []Node) {
+	scores := make(map[int]float64, p.nodeCnt)
+
+	p.root.DepthFirst(func(n Node) error {
+		scores[n.NodeId()] = n.Score(request)
+		return nil
+	})
+
+	sort.Slice(p.pools, func(i, j int) bool {
+		return p.comparePools(request, scores, i, j)
+	})
+
+	return scores, p.pools
+}
+
+// Compare two pools by scores for allocation preference.
+func (p *policy) comparePools(request CpuRequest, scores map[int]float64, i int, j int) bool {
+	n1, n2 := p.pools[i], p.pools[j]
+	d1, d2 := n1.RootDistance(), n2.RootDistance()
+	id1, id2 := n1.NodeId(), n2.NodeId()
+	s1, s2 := scores[id1], scores[id2]
+
+	switch {
+	case s1 > s2:
+		return true
+	case s1 < s2:
+		return false
+
+	case d1 == d2:
+		return id1 < id2
+
+	case len(request.GetContainer().GetTopologyHints()) > 0:
+		return d1 > d2
+	default:
+		return d1 < d2
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -1,0 +1,309 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	resapi "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"strings"
+)
+
+const (
+	// PolicyName is the symbol used to pull us in as a builtin policy.
+	PolicyName = "topology-aware"
+	// PolicyDescription is a short description of this policy.
+	PolicyDescription = "A policy for HW-topology aware workload placement."
+)
+
+// allocations is our cache.Cachable for saving resource allocations in the cache.
+type allocations struct {
+	policy *policy
+	Cpu    map[string]CpuGrant
+}
+
+// policy is our runtime state for the topology aware policy.
+type policy struct {
+	options     policyapi.PolicyOpts // options we were created or reconfigured with
+	cache       cache.Cache          // pod/container cache
+	sys         *system.System       // system/HW topology info
+	allowed     cpuset.CPUSet        // bounding set of CPUs we're allowed to use
+	reserved    cpuset.CPUSet        // system-/kube-reserved CPUs
+	reserveCnt  int                  // number of CPUs to reserve if given as resource.Quantity
+	isolated    cpuset.CPUSet        // (our allowed set of) isolated CPUs
+	nodes       map[string]Node      // pool nodes by name
+	pools       []Node               // pre-populated node slice for scoring, etc...
+	root        Node                 // root of our pool/partition tree
+	nodeCnt     int                  // number of pools
+	depth       int                  // tree depth
+	allocations allocations          // container pool assignments
+
+}
+
+// Make sure policy implements the policy.Backend interface.
+var _ policyapi.Backend = &policy{}
+
+// CreateTopologyAwarePolicy creates a new policy instance.
+func CreateTopologyAwarePolicy(opts *policyapi.PolicyOpts) policyapi.Backend {
+	p := &policy{options: *opts}
+
+	p.nodes = make(map[string]Node)
+	p.allocations = allocations{policy: p, Cpu: make(map[string]CpuGrant, 32)}
+
+	if err := p.discoverSystemTopology(); err != nil {
+		log.Fatal("failed to create topology-aware policy: %v", err)
+	}
+
+	if err := p.checkConstraints(); err != nil {
+		log.Fatal("failed to create topology-aware policy: %v", err)
+	}
+
+	if err := p.buildPoolsByTopology(); err != nil {
+		log.Fatal("failed to create topology-aware policy: %v", err)
+	}
+
+	p.root.Dump("<pre-start>")
+
+	return p
+}
+
+// Name returns the name of this policy.
+func (p *policy) Name() string {
+	return PolicyName
+}
+
+// Description returns the description for this policy.
+func (p *policy) Description() string {
+	return PolicyDescription
+}
+
+// Start prepares this policy for accepting allocation/release requests.
+func (p *policy) Start(cch cache.Cache) error {
+	p.cache = cch
+
+	if err := p.restoreCache(); err != nil {
+		return policyError("failed to start: %v", err)
+	}
+
+	p.root.Dump("<post-start>")
+
+	return nil
+}
+
+// AllocateResources is a resource allocation request for this policy.
+func (p *policy) AllocateResources(container cache.Container) error {
+	log.Debug("allocating resources for %s...", container.GetCacheId())
+
+	grant, err := p.allocatePool(container)
+	if err != nil {
+		return policyError("failed to allocate resources for %s: %v",
+			container.GetCacheId(), err)
+	}
+
+	if err := p.applyGrant(grant); err != nil {
+		if _, _, err = p.releasePool(container); err != nil {
+			log.Warn("failed to undo/release unapplicable grant %s: %v",
+				grant.String(), err)
+			return policyError("failed to undo/release unapplicable grant %s: %v",
+				grant.String(), err)
+		}
+	}
+
+	if err := p.updateSharedAllocations(grant); err != nil {
+		log.Warn("failed to update shared allocations affected by %s: %v",
+			container.GetCacheId(), err)
+	}
+
+	p.root.Dump("<post-alloc>")
+
+	return nil
+}
+
+// ReleaseResources is a resource release request for this policy.
+func (p *policy) ReleaseResources(container cache.Container) error {
+	log.Debug("releasing resources of %s...", container.GetCacheId())
+
+	grant, found, err := p.releasePool(container)
+	if err != nil {
+		return policyError("failed to release resources of %s: %v",
+			container.GetCacheId(), err)
+	}
+
+	if found {
+		if err = p.updateSharedAllocations(grant); err != nil {
+			log.Warn("failed to update shared allocations affected by %s: %v",
+				container.GetCacheId(), err)
+		}
+	}
+
+	p.root.Dump("<post-release>")
+
+	return nil
+}
+
+// UpdateResources is a resource allocation update request for this policy.
+func (p *policy) UpdateResources(c cache.Container) error {
+	log.Debug("(not) updating container %s...", c.GetCacheId())
+	return nil
+}
+
+// ExportResourceData provides resource data to export for the container.
+func (p *policy) ExportResourceData(c cache.Container, syntax policyapi.DataSyntax) []byte {
+	return nil
+}
+
+func (p *policy) PostStart(cch cache.Container) error {
+	log.Debug("post start container...")
+	return nil
+}
+
+// SetConfig sets the policy backend configuration.
+func (p *policy) SetConfig(rawConf string) error {
+	if rawConf = strings.TrimSpace(rawConf); rawConf == "" {
+		return nil
+	}
+
+	conf, err := parseConfig([]byte(rawConf))
+	if err != nil {
+		return err
+	}
+
+	if opt.PinCpu != conf.PinCpu {
+		opt.PinCpu = conf.PinCpu
+		log.Info("pin containers to CPUs: %v", opt.PinCpu)
+	}
+
+	if opt.PinMem != conf.PinMem {
+		opt.PinMem = conf.PinMem
+		log.Info("pin containers to memory: %v", opt.PinMem)
+	}
+
+	if opt.PreferIsolated != conf.PreferIsolated {
+		opt.PreferIsolated = conf.PreferIsolated
+		log.Info("use kernel-isolated CPUs for exclusive allocation: %v",
+			opt.PreferIsolated)
+	}
+
+	if opt.PreferShared != conf.PreferShared {
+		opt.PreferShared = conf.PreferShared
+		log.Info("prefer shared CPU allocation: %v", opt.PreferShared)
+	}
+
+	// TODO: We probably should release and reallocate resources for all containers
+	//   to honor the latest configuration. Depending on the changes that might be
+	//   disruptive to some containers, so whether we do so or not should probably
+	//   be part of the configuration as well.
+
+	p.saveConfig()
+
+	return nil
+}
+
+// Discover system topology.
+func (p *policy) discoverSystemTopology() error {
+	var err error
+
+	log.Info("discovering system topology...")
+	if p.sys, err = system.DiscoverSystem(); err != nil {
+		return policyError("failed to discover system topology: %v", err)
+	}
+
+	return nil
+}
+
+// Check the constraints passed to us.
+func (p *policy) checkConstraints() error {
+	if c, ok := p.options.Available[policyapi.DomainCpu]; ok {
+		p.allowed = c.(cpuset.CPUSet)
+	} else {
+		// default to all online cpus
+		p.allowed = p.sys.CPUSet().Difference(p.sys.Offlined())
+	}
+
+	p.isolated = p.sys.Isolated().Intersection(p.allowed)
+
+	if c, ok := p.options.Reserved[policyapi.DomainCpu]; !ok {
+		return policyError("cannot start without CPU reservation")
+	} else {
+		switch c.(type) {
+		case cpuset.CPUSet:
+			p.reserved = c.(cpuset.CPUSet)
+			// check that all reserved CPUs are in the allowed set
+			if !p.reserved.Difference(p.allowed).IsEmpty() {
+				return policyError("invalid reserved cpuset %s, some CPUs (%s) are not "+
+					"part of the online allowed cpuset (%s)", p.reserved.String(),
+					p.reserved.Difference(p.allowed).String(), p.allowed.String())
+			}
+			// check that none of the reserved CPUs are isolated
+			if !p.reserved.Intersection(p.isolated).IsEmpty() {
+				return policyError("invalid reserved cpuset %s, some CPUs (%s) are also isolated",
+					p.reserved.Intersection(p.isolated).String())
+			}
+
+		case resapi.Quantity:
+			qty := c.(resapi.Quantity)
+			p.reserveCnt = (int(qty.MilliValue()) + 999) / 1000
+		}
+	}
+
+	return nil
+}
+
+func (p *policy) restoreCache() error {
+	if !p.restoreConfig() {
+		log.Warn("no saved configuration found in cache...")
+		p.saveConfig()
+	}
+
+	if !p.restoreAllocations() {
+		log.Warn("no allocations found in cache...")
+		p.saveAllocations()
+	} else {
+		p.allocations.Dump(log.Info, "restored ")
+	}
+
+	return nil
+}
+
+//
+// Automatically register us as a policy implementation.
+//
+
+// Implementation is the implementation we register with the policy module.
+type Implementation func(*policyapi.PolicyOpts) policyapi.Backend
+
+// Name returns the name of this policy implementation.
+func (Implementation) Name() string {
+	return PolicyName
+}
+
+// Description returns the desccription of this policy implementation.
+func (Implementation) Description() string {
+	return PolicyDescription
+}
+
+// CreateFn returns the functions used to instantiate this policy.
+func (i Implementation) CreateFn() policyapi.CreateFn {
+	return policyapi.CreateFn(i)
+}
+
+var _ policyapi.Implementation = Implementation(nil)
+
+func init() {
+	policyapi.Register(Implementation(CreateTopologyAwarePolicy))
+}

--- a/pkg/instrumentation/flags.go
+++ b/pkg/instrumentation/flags.go
@@ -146,7 +146,7 @@ func (o *options) Get(name string) string {
 	case optMetrics:
 		return o.metrics
 	default:
-		return fmt.Sprintf("<no value, unknown instrumnetation option '%s'>", name)
+		return fmt.Sprintf("<no value, unknown instrumentation option '%s'>", name)
 	}
 }
 

--- a/pkg/sysfs/idset.go
+++ b/pkg/sysfs/idset.go
@@ -54,25 +54,25 @@ func NewIdSetFromIntSlice(ids ...int) IdSet {
 	return s
 }
 
-// Add adds an id to the set, return whether it was already present.
-func (s IdSet) Add(id Id) bool {
-	_, present := s[id]
-	if !present {
-		s[id] = struct{}{}
-	}
-	return present
+// Clone returns a copy of this IdSet.
+func (s IdSet) Clone() IdSet {
+	return NewIdSet(s.Members()...)
 }
 
-// Del deletes an id from the set, return whether it was present.
-func (s IdSet) Del(id Id) bool {
-	if s == nil {
-		return false
+// Add adds the given ids into the set.
+func (s IdSet) Add(ids ...Id) {
+	for _, id := range ids {
+		s[id] = struct{}{}
 	}
-	_, present := s[id]
-	if present {
-		delete(s, id)
+}
+
+// Del deletes the given ids from the set.
+func (s IdSet) Del(ids ...Id) {
+	if s != nil {
+		for _, id := range ids {
+			delete(s, id)
+		}
 	}
-	return present
 }
 
 // Size returns the number of ids in the set.
@@ -80,13 +80,20 @@ func (s IdSet) Size() int {
 	return len(s)
 }
 
-// Has tests if an id is present in a set.
-func (s IdSet) Has(id Id) bool {
+// Has tests if all the ids are present in the set.
+func (s IdSet) Has(ids ...Id) bool {
 	if s == nil {
 		return false
 	}
-	_, present := s[id]
-	return present
+
+	for _, id := range ids {
+		_, ok := s[id]
+		if !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Members returns all ids in the set as a randomly ordered slice.
@@ -128,7 +135,7 @@ func FromCPUSet(cset cpuset.CPUSet) IdSet {
 
 // String returns the set as a string.
 func (s IdSet) String() string {
-	return s.StringWithSeparator(" ")
+	return s.StringWithSeparator(",")
 }
 
 // StringWithSeparator returns the set as a string, separated with the given separator.

--- a/pkg/sysfs/parsers.go
+++ b/pkg/sysfs/parsers.go
@@ -1,0 +1,168 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysfs
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+// unit multipliers
+const (
+	k = (int64(1) << 10)
+	M = (int64(1) << 20)
+	G = (int64(1) << 30)
+	T = (int64(1) << 40)
+)
+
+// unit name to multiplier mapping
+var units map[string]int64 = map[string]int64{
+	"k": k, "kB": k,
+	"M": M, "MB": M,
+	"G": G, "GB": G,
+	"T": T, "TB": T,
+}
+
+// PickEntryFn picks a given input line apart into an entry of key and value.
+type PickEntryFn func(string) (string, string, error)
+
+// splitNumericAndUnit splits a string into a numeric and a unit part.
+func splitNumericAndUnit(path string, value string) (string, int64, error) {
+	fields := strings.Fields(value)
+
+	switch len(fields) {
+	case 1:
+		return fields[0], 1, nil
+	case 2:
+		num := fields[0]
+		unit, ok := units[fields[1]]
+		if !ok {
+			return "", -1, sysfsError(path, "failed to parse '%s', invalid unit '%s'",
+				value, num, unit)
+		}
+		return num, unit, nil
+	}
+
+	return "", -1, sysfsError(path, "invalid numeric value %s", value)
+}
+
+// PparseNumberic parses a numeric string into integer of the right size.
+func parseNumeric(path, value string, ptr interface{}) error {
+	var numstr string
+	var num, unit int64
+	var f float64
+	var err error
+
+	if numstr, unit, err = splitNumericAndUnit(path, value); err != nil {
+		return err
+	}
+
+	switch ptr.(type) {
+	case *int:
+		num, err = strconv.ParseInt(numstr, 0, strconv.IntSize)
+		*ptr.(*int) = int(num * unit)
+	case *int8:
+		num, err = strconv.ParseInt(numstr, 0, 8)
+		*ptr.(*int8) = int8(num * unit)
+	case *int16:
+		num, err = strconv.ParseInt(numstr, 0, 16)
+		*ptr.(*int16) = int16(num * unit)
+	case *int32:
+		num, err = strconv.ParseInt(numstr, 0, 32)
+		*ptr.(*int32) = int32(num * unit)
+	case *int64:
+		num, err = strconv.ParseInt(numstr, 0, 64)
+		*ptr.(*int64) = int64(num * unit)
+	case *uint:
+		num, err = strconv.ParseInt(numstr, 0, strconv.IntSize)
+		*ptr.(*uint) = uint(num * unit)
+	case *uint8:
+		num, err = strconv.ParseInt(numstr, 0, 8)
+		*ptr.(*uint8) = uint8(num * unit)
+	case *uint16:
+		num, err = strconv.ParseInt(numstr, 0, 16)
+		*ptr.(*uint16) = uint16(num * unit)
+	case *uint32:
+		num, err = strconv.ParseInt(numstr, 0, 32)
+		*ptr.(*uint32) = uint32(num * unit)
+	case *uint64:
+		num, err = strconv.ParseInt(numstr, 0, 64)
+		*ptr.(*uint64) = uint64(num * unit)
+	case *float32:
+		f, err = strconv.ParseFloat(numstr, 32)
+		*ptr.(*float32) = float32(f) * float32(unit)
+	case *float64:
+		f, err = strconv.ParseFloat(numstr, 64)
+		*ptr.(*float64) = f * float64(unit)
+
+	default:
+		err = sysfsError(path, "can't parse numeric value '%s' into type %T", value, ptr)
+	}
+
+	return err
+}
+
+// ParseFileEntries parses a sysfs files for the given entries.
+func ParseFileEntries(path string, values map[string]interface{}, pickFn PickEntryFn) error {
+	var err error
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		sysfsError(path, "failed to read file: %v", err)
+	}
+
+	left := len(values)
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, err := pickFn(line)
+		if err != nil {
+			return err
+		}
+
+		ptr, ok := values[key]
+		if !ok {
+			continue
+		}
+
+		switch ptr.(type) {
+		case *int, *int8, *int32, *int16, *int64, *uint, *uint8, *uint16, *uint32, *uint64:
+			if err = parseNumeric(path, value, ptr); err != nil {
+				return err
+			}
+		case *float32, *float64:
+			if err = parseNumeric(path, value, ptr); err != nil {
+				return err
+			}
+		case *string:
+			*ptr.(*string) = value
+		case *bool:
+			*ptr.(*bool), err = strconv.ParseBool(value)
+			if err != nil {
+				return sysfsError(path, "failed to parse line %s, value '%s' for boolean key '%s'",
+					line, value, key)
+			}
+		default:
+			return sysfsError(path, "don't know how to parse key '%s' of type %T", key, ptr)
+
+		}
+
+		left--
+		if left == 0 {
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/sysfs/topology.go
+++ b/pkg/sysfs/topology.go
@@ -124,6 +124,25 @@ func MergeTopologyHints(org, hints TopologyHints) (res TopologyHints) {
 	return
 }
 
+// String returns the hints as a string.
+func (h *TopologyHint) String() string {
+	cpus, nodes, sockets, sep := "", "", "", ""
+
+	if h.CPUs != "" {
+		cpus = "CPUs:" + h.CPUs
+		sep = ", "
+	}
+	if h.NUMAs != "" {
+		nodes = sep + "NUMAs:" + h.NUMAs
+		sep = ", "
+	}
+	if h.Sockets != "" {
+		sockets = sep + "sockets:" + h.Sockets
+	}
+
+	return "<hints " + cpus + nodes + sockets + " (from " + h.Provider + ")>"
+}
+
 // FindSysFsDevice for given argument returns physical device where it is linked to.
 // For device nodes it will return path for device itself. For regular files or directories
 // this function returns physical device where this inode resides (storage device).

--- a/pkg/sysfs/utils.go
+++ b/pkg/sysfs/utils.go
@@ -225,6 +225,9 @@ func parseValueList(str, sep string, valuep interface{}) error {
 	}
 
 	for _, s := range strings.Split(str, sep) {
+		if s == "" {
+			break
+		}
 		switch value.(type) {
 		case IdSet:
 			if rng := strings.Split(s, "-"); len(rng) == 1 {

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -4,6 +4,11 @@ metadata:
   name: cri-resmgr-config
   namespace: kube-system
 data:
+  policy.topology-aware: |+
+    PinCPU: true
+    PinMemory: true
+    PreferIsolatedCPUs: true
+    PreferSharedCPUs: false
   policy.static: |
     RelaxedIsolation: true
   policy.stp: |+


### PR DESCRIPTION
    Add a new policy that splits the system up into a number of
    hierarchically organised, partially overlapping pools (a tree),
    based on hardware topology: full system / individual sockets /
    NUMA nodes, CPUs/cores.

    Containers are allocated resources from the best fitting pool.
    The 'best fitting' pool is selected by calculating a score for
    each available pool, taking into account container resource
    requests, devices (including ones deduced from mounts), etc.
    The scoring algorithm is not quite what it should be, it only
    takes CPU into account ATM, is probably incomplete at best and
    outright broken at worst. Work in progress...

    The other preparing patches in this series add functionality required
    by the topology-aware policy to sysfs and the cache, and fix a few
    minor related bugs.