### PR TITLE
Implement RDT support

### DIFF
--- a/docs/rdt.md
+++ b/docs/rdt.md
@@ -1,0 +1,42 @@
+# RDT (Intel® Resource Director Technology)
+
+## Overview
+
+Intel® RDT provides capabilities for cache and memory allocation and
+monitoring. In Linux system the functionality is exposed to the user space via
+the [resctrl](https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt)
+filesystem. Cache and memory allocation in RDT is handled by using resource
+control groups. Resource allocation is specified on the group level and each
+task (process/thread) is assigned to one group.
+
+Out of the RDT technologies, CRI Resource Manager currently supports L3 cache
+allocation and memory bandwidth allocation. Based on the configuration, it
+creates a set of resource control groups which the policies can assign
+containers to.
+
+## Configuration
+
+### Command Line Flags
+
+| Flag      | Description                           |
+| --------- | ------------------------------------- |
+| `-no-rdt` | Disable RDT resource management
+
+### Dynamic Configuration
+
+CRI utilizes configuration received from
+[`cri-resmgr-agent`](../README.md#cri-resource-manager-node-agent), under the
+key `rdt` in the ConfigMap containing `cri-resmgr` configuration data. The
+configuration specifies a set of RDT classes (or resource control groups) that
+the policies assign containers to. The configuration can be dynamically updated
+by editing the ConfigMap. The set of RDT classes can be freely specified, but,
+one must ensure that classes required by the active policy are specified, and,
+that the maxmimum number of classes (CLOSes) supported by the underlying system
+is not exceeded.
+
+CRI-RM has a built-in default configuration containing three classes
+corresponding to the Pod QOS classes of Kubernetes. These are utilized by the
+`static` policy.
+
+See `rdt` in the [example ConfigMap spec](../sample-configs/cri-resmgr-configmap.example.yaml)
+for an example configuration.

--- a/pkg/cri/resource-manager/config/config.go
+++ b/pkg/cri/resource-manager/config/config.go
@@ -50,3 +50,13 @@ func (c *RawConfig) HasIdenticalData(data map[string]string) bool {
 
 	return true
 }
+
+// Get returns one config section
+func (c *RawConfig) Get(key string) string {
+	if c.Data != nil {
+		if value, ok := c.Data[key]; ok {
+			return value
+		}
+	}
+	return defaultConfig(key)
+}

--- a/pkg/cri/resource-manager/config/defaults.go
+++ b/pkg/cri/resource-manager/config/defaults.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+var defaultRdtRawConf = `{
+  "resctrlGroups": {
+    "Guaranteed": {
+	  "l3schema": {
+        "all": "100%"
+      }
+    },
+    "Burstable": {
+	  "l3schema": {
+        "all": "100%"
+      }
+    },
+    "BestEffort": {
+	  "l3schema": {
+        "all": "100%"
+      }
+    }
+  }
+}`
+
+func defaultConfig(key string) string {
+	switch {
+	case key == "rdt":
+		return defaultRdtRawConf
+	}
+	return ""
+}

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -29,6 +29,8 @@ type options struct {
 	RelayDir      string
 	AgentSocket   string
 	ConfigSocket  string
+	NoRdt         bool
+	ResctrlPath   string
 }
 
 // Relay options with their defaults.
@@ -48,4 +50,8 @@ func init() {
 		"local socket of the cri-resmgr agent to connect")
 	flag.StringVar(&opt.ConfigSocket, "config-socket", sockets.ResourceManagerConfig,
 		"Unix domain socket path where the resource manager listens for cri-resmgr-agent")
+	flag.BoolVar(&opt.NoRdt, "no-rdt", false,
+		"Disable RDT resource management")
+	flag.StringVar(&opt.ResctrlPath, "resctrl-path", "",
+		"Path of the resctrl filesystem mountpoint")
 }

--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -48,7 +48,7 @@ var _ policy.Backend = &eda{}
 //
 
 // CreateEdaPolicy creates a new policy instance.
-func CreateEdaPolicy(opts *policy.Options) policy.Backend {
+func CreateEdaPolicy(opts *policy.BackendOptions) policy.Backend {
 	eda := &eda{Logger: logger.NewLogger(PolicyName)}
 	eda.Info("creating policy...")
 	// TODO: policy configuration (if any)
@@ -149,7 +149,7 @@ func edaError(format string, args ...interface{}) error {
 //
 
 // Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.Options) policy.Backend
+type Implementation func(*policy.BackendOptions) policy.Backend
 
 // Name returns the name of this policy implementation.
 func (i Implementation) Name() string {

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -34,7 +34,7 @@ type none struct {
 var _ policy.Backend = &none{}
 
 // CreateNonePolicy creates a new policy instance.
-func CreateNonePolicy(opts *policy.Options) policy.Backend {
+func CreateNonePolicy(opts *policy.BackendOptions) policy.Backend {
 	n := &none{Logger: logger.NewLogger(PolicyName)}
 	n.Info("creating policy...")
 	return n
@@ -100,7 +100,7 @@ func (n *none) SetConfig(string) error {
 //
 
 // Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.Options) policy.Backend
+type Implementation func(*policy.BackendOptions) policy.Backend
 
 // Name returns the name of this policy implementation.
 func (n Implementation) Name() string {

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -71,7 +71,7 @@ type staticplus struct {
 var _ policy.Backend = &staticplus{}
 
 // CreateStaticPlusPolicy creates a new policy instance.
-func CreateStaticPlusPolicy(opts *policy.Options) policy.Backend {
+func CreateStaticPlusPolicy(opts *policy.BackendOptions) policy.Backend {
 	p := &staticplus{
 		Logger: logger.NewLogger(PolicyName),
 	}
@@ -763,7 +763,7 @@ func MilliCPUToShares(milliCPU int) int64 {
 //
 
 // Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.Options) policy.Backend
+type Implementation func(*policy.BackendOptions) policy.Backend
 
 // Name returns the name of this policy implementation.
 func (n Implementation) Name() string {

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -74,7 +74,7 @@ func stringify(r interface{}) string {
 //
 
 // CreateStpPolicy creates a new policy instance.
-func CreateStpPolicy(opts *policy.Options) policy.Backend {
+func CreateStpPolicy(opts *policy.BackendOptions) policy.Backend {
 	var err error
 	stp := &stp{Logger: logger.NewLogger(PolicyName), agent: opts.AgentCli}
 
@@ -568,7 +568,7 @@ func (stp *stp) setContainerRegistry(ccr *stpContainerCache) {
 //
 
 // Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.Options) policy.Backend
+type Implementation func(*policy.BackendOptions) policy.Backend
 
 // Name returns the name of this policy implementation.
 func (i Implementation) Name() string {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -39,19 +39,19 @@ type allocations struct {
 
 // policy is our runtime state for the topology aware policy.
 type policy struct {
-	options     policyapi.Options // options we were created or reconfigured with
-	cache       cache.Cache       // pod/container cache
-	sys         *system.System    // system/HW topology info
-	allowed     cpuset.CPUSet     // bounding set of CPUs we're allowed to use
-	reserved    cpuset.CPUSet     // system-/kube-reserved CPUs
-	reserveCnt  int               // number of CPUs to reserve if given as resource.Quantity
-	isolated    cpuset.CPUSet     // (our allowed set of) isolated CPUs
-	nodes       map[string]Node   // pool nodes by name
-	pools       []Node            // pre-populated node slice for scoring, etc...
-	root        Node              // root of our pool/partition tree
-	nodeCnt     int               // number of pools
-	depth       int               // tree depth
-	allocations allocations       // container pool assignments
+	options     policyapi.BackendOptions // options we were created or reconfigured with
+	cache       cache.Cache              // pod/container cache
+	sys         *system.System           // system/HW topology info
+	allowed     cpuset.CPUSet            // bounding set of CPUs we're allowed to use
+	reserved    cpuset.CPUSet            // system-/kube-reserved CPUs
+	reserveCnt  int                      // number of CPUs to reserve if given as resource.Quantity
+	isolated    cpuset.CPUSet            // (our allowed set of) isolated CPUs
+	nodes       map[string]Node          // pool nodes by name
+	pools       []Node                   // pre-populated node slice for scoring, etc...
+	root        Node                     // root of our pool/partition tree
+	nodeCnt     int                      // number of pools
+	depth       int                      // tree depth
+	allocations allocations              // container pool assignments
 
 }
 
@@ -59,7 +59,7 @@ type policy struct {
 var _ policyapi.Backend = &policy{}
 
 // CreateTopologyAwarePolicy creates a new policy instance.
-func CreateTopologyAwarePolicy(opts *policyapi.Options) policyapi.Backend {
+func CreateTopologyAwarePolicy(opts *policyapi.BackendOptions) policyapi.Backend {
 	p := &policy{options: *opts}
 
 	p.nodes = make(map[string]Node)
@@ -319,7 +319,7 @@ func (p *policy) restoreCache() error {
 //
 
 // Implementation is the implementation we register with the policy module.
-type Implementation func(*policyapi.Options) policyapi.Backend
+type Implementation func(*policyapi.BackendOptions) policyapi.Backend
 
 // Name returns the name of this policy implementation.
 func (Implementation) Name() string {

--- a/pkg/cri/resource-manager/resource-control/control.go
+++ b/pkg/cri/resource-manager/resource-control/control.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcecontrol
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/rdt"
+	"github.com/intel/cri-resource-manager/pkg/utils"
+)
+
+// CriRdt is the RDT control interface for resource-manager
+type CriRdt interface {
+	rdt.Control
+
+	SetContainerClass(cache.Container, string) error
+}
+
+type criRdt struct {
+	rdt.Control
+}
+
+// NewCriRdt creates a new CriRdt instance
+func NewCriRdt(resctrlpath string, config string) (CriRdt, error) {
+	var err error
+	c := &criRdt{}
+	c.Control, err = rdt.NewControl(resctrlpath, config)
+	return c, err
+
+}
+
+// SetContainerClass assigns all processes of a container into am RDT class
+func (c *criRdt) SetContainerClass(container cache.Container, class string) error {
+	cID := container.GetID()
+	pod, ok := container.GetPod()
+	if !ok {
+		return controlError("Pod of container %q not found", cID)
+	}
+	cgroupParent := pod.GetCgroupParentDir()
+
+	pids, err := utils.GetProcessInContainer(cgroupParent, cID)
+	if err != nil {
+		return controlError("failed to get PIDs of container %s: %v", cID, err)
+	}
+
+	for _, pid := range pids {
+		if err = c.SetProcessClass(class, strconv.Itoa(pid)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func controlError(format string, args ...interface{}) error {
+	return fmt.Errorf("resource-control: "+format, args...)
+}

--- a/pkg/rdt/bitmask.go
+++ b/pkg/rdt/bitmask.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdt
+
+import (
+	"math/bits"
+	"strconv"
+	"strings"
+)
+
+//
+// RDT cache specific bitmask
+//
+
+// CacheBitmask represents a cache bitmask in the system's resctrl kernel
+// interface. The "width" i.e. the number of bits available depends on the
+// underlying hardware.
+type CacheBitmask Bitmask
+
+// UnmarshalJSON is the unmarshaller function for "encoding/json"
+func (b *CacheBitmask) UnmarshalJSON(data []byte) error {
+	// Number of bits available in CacheBitmask
+	cacheBitmaskNumBits := uint64(rdtInfo.l3.cbmMask.lsbZero())
+
+	// Drop string quotes
+	str := strings.TrimSpace(string(data[1 : len(data)-1]))
+
+	if strings.HasPrefix(str, "0x") {
+		// Hex value
+		value, err := strconv.ParseUint(str[2:], 16, int(cacheBitmaskNumBits))
+		if err != nil {
+			return err
+		}
+		*b = CacheBitmask(value)
+
+		return nil
+	} else if str[len(str)-1] == '%' {
+		// Percentages of the max number of bits
+		split := strings.SplitN(str[0:len(str)-1], "-", 2)
+		var low, high uint64
+		var err error
+
+		if len(split) == 1 {
+			high, err = strconv.ParseUint(split[0], 10, 7)
+			if err != nil {
+				return err
+			}
+		} else {
+			low, err = strconv.ParseUint(split[0], 10, 7)
+			if err != nil {
+				return err
+			}
+			high, err = strconv.ParseUint(split[1], 10, 7)
+			if err != nil {
+				return err
+			}
+		}
+		if low == 0 {
+			low = 1
+		}
+		if low > high || low > 100 || high > 100 {
+			return rdtError("invalid percentage range %q", str)
+		}
+
+		// Convert percentage limits to bit numbers
+		// Our effective range is 1%-100%, use substraction (-1) because of
+		// arithmetics, so that we don't overflow on 100%
+		lsb := (low - 1) * cacheBitmaskNumBits / 100
+		msb := (high - 1) * cacheBitmaskNumBits / 100
+
+		*b = ((1 << (msb - lsb + 1)) - 1) << lsb
+
+		return nil
+	}
+
+	// Last, try "list" format (i.e. smthg like 0,2,5-9,...)
+	value, err := ListStrToBitmask(str)
+	if err != nil {
+		return err
+	}
+	*b = CacheBitmask(value)
+	return nil
+}
+
+//
+// Generic bitbmask
+//
+
+// Bitmask represents a generic 64 bit wide bitmask
+type Bitmask uint64
+
+// ListStr prints the bitmask in human-readable format, similar to e.g. the
+// cpuset format of the Linux kernel
+func (b Bitmask) ListStr() string {
+	str := ""
+	sep := ""
+
+	shift := int(0)
+	lsbOne := b.lsbOne()
+
+	// Process "ranges of ones"
+	for lsbOne != -1 {
+		b >>= uint(lsbOne)
+
+		// Get range lenght from the position of the first zero
+		numOnes := b.lsbZero()
+
+		if numOnes == 1 {
+			str += sep + strconv.Itoa(lsbOne+shift)
+		} else {
+			str += sep + strconv.Itoa(lsbOne+shift) + "-" + strconv.Itoa(lsbOne+numOnes-1+shift)
+		}
+
+		// Shift away the bits that have been processed
+		b >>= uint(numOnes)
+		shift += lsbOne + numOnes
+
+		// Get next bit that is set (if any)
+		lsbOne = b.lsbOne()
+
+		sep = ","
+	}
+
+	return str
+}
+
+// ListStrToBitmask parses a string containing a human-readable list of bit
+// numbers into a bitmask
+func ListStrToBitmask(str string) (Bitmask, error) {
+	b := Bitmask(0)
+
+	// Empty bitmask
+	if len(str) == 0 {
+		return b, nil
+	}
+
+	ranges := strings.Split(str, ",")
+	for _, ran := range ranges {
+		split := strings.SplitN(ran, "-", 2)
+
+		bitNum, err := strconv.ParseUint(split[0], 10, 6)
+		if err != nil {
+			return b, rdtError("invalid bitmask %q: %v", str, err)
+		}
+
+		if len(split) == 1 {
+			b |= 1 << bitNum
+		} else {
+			endNum, err := strconv.ParseUint(split[1], 10, 6)
+			if err != nil {
+				return b, rdtError("invalid bitmask %q: %v", str, err)
+			}
+			if endNum <= bitNum {
+				return b, rdtError("invalid range %q in bitmask %q", ran, str)
+			}
+			b |= (1<<(endNum-bitNum+1) - 1) << bitNum
+		}
+	}
+	return b, nil
+}
+
+func (b Bitmask) lsbOne() int {
+	if b == 0 {
+		return -1
+	}
+	return bits.TrailingZeros64(uint64(b))
+}
+
+func (b Bitmask) lsbZero() int {
+	return bits.TrailingZeros64(^uint64(b))
+}

--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdt
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+// ResctrlGroupConfig represents configuration of one CTRL group in the Linux
+// resctrl interface
+type ResctrlGroupConfig struct {
+	L3Schema L3Schema `json:"l3Schema,omitempty"`
+	MBSchema MBSchema `json:"mbSchema,omitempty"`
+}
+
+// L3Schema represents an L3 part of the schemata of a resctrl group
+type L3Schema struct {
+	allocations map[uint64]CacheBitmask
+}
+
+// MBSchema represents an MB part of the schemata of a resctrl group
+type MBSchema struct {
+	allocations map[uint64]uint64
+}
+
+// IsNil returns true if the schema is empty
+func (s *L3Schema) IsNil() bool {
+	return s.allocations == nil
+}
+
+// ToStr returns the L3 schema in a format accepted by the Linux kernel
+// resctrl (schemata) interface
+func (s *L3Schema) ToStr() string {
+	if len(s.allocations) == 0 {
+		return ""
+	}
+
+	schema := "L3:"
+	sep := ""
+
+	// We get cache ids but that doesn't matter
+	for id, bitmask := range s.allocations {
+		schema += fmt.Sprintf("%s%d=%x", sep, id, bitmask)
+		sep = ";"
+	}
+
+	return schema + "\n"
+}
+
+// DefaultStr returns the L3 default schema
+func (s *L3Schema) DefaultStr() string {
+	schema := "L3:"
+	sep := ""
+
+	for _, id := range rdtInfo.cacheIds {
+		// Set all to full mask (i.e. 100%)
+		schema += fmt.Sprintf("%s%d=%x", sep, id, rdtInfo.l3.cbmMask)
+		sep = ";"
+	}
+
+	return schema + "\n"
+}
+
+func (s *L3Schema) UnmarshalJSON(b []byte) error {
+	var allocations map[string]CacheBitmask
+
+	err := yaml.Unmarshal(b, &allocations)
+	if err != nil {
+		return err
+	}
+
+	s.allocations = map[uint64]CacheBitmask{}
+
+	// Set default allocations
+	defaultMask, ok := allocations["all"]
+	if !ok {
+		// Set to 100% if "all" is not specified
+		defaultMask = CacheBitmask(rdtInfo.l3.cbmMask)
+	}
+	delete(allocations, "all")
+
+	for _, i := range rdtInfo.cacheIds {
+		s.allocations[i] = defaultMask
+	}
+
+	// Parse per-cacheId allocations
+	for key, mask := range allocations {
+		ids, err := listStrToArray(key)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			if _, ok := s.allocations[uint64(id)]; ok {
+				s.allocations[uint64(id)] = mask
+			}
+		}
+	}
+
+	return nil
+}
+
+// IsNil returns true if the schema is empty
+func (s *MBSchema) IsNil() bool {
+	return s.allocations == nil
+}
+
+// ToStr returns the MB schema in a format accepted by the Linux kernel
+// resctrl (schemata) interface
+func (s *MBSchema) ToStr() string {
+	schema := "MB:"
+	sep := ""
+
+	// We get cache ids but that doesn't matter
+	for id, percentage := range s.allocations {
+		schema += fmt.Sprintf("%s%d=%d", sep, id, percentage)
+		sep = ";"
+	}
+
+	return schema + "\n"
+}
+
+// DefaultStr returns the L3 default schema
+func (s *MBSchema) DefaultStr() string {
+	schema := "MB:"
+	sep := ""
+
+	for _, id := range rdtInfo.cacheIds {
+		// Set all to 100 percent
+		schema += fmt.Sprintf("%s%d=100", sep, id)
+		sep = ";"
+	}
+
+	return schema + "\n"
+}
+
+func (s *MBSchema) UnmarshalJSON(b []byte) error {
+	var allocations map[string]uint64
+
+	err := yaml.Unmarshal(b, &allocations)
+	if err != nil {
+		return err
+	}
+
+	s.allocations = map[uint64]uint64{}
+
+	// Set default allocations
+	defaultVal, ok := allocations["all"]
+	if !ok {
+		// Set to 100 if "all" is not specified
+		defaultVal = 100
+	}
+	delete(allocations, "all")
+
+	for _, i := range rdtInfo.cacheIds {
+		s.allocations[i] = defaultVal
+	}
+
+	// Parse per-cacheId allocations
+	for key, val := range allocations {
+		ids, err := listStrToArray(key)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			if _, ok := s.allocations[uint64(id)]; ok {
+				s.allocations[uint64(id)] = val
+			}
+		}
+	}
+
+	return nil
+}
+
+// listStrToArray parses a string containing a human-readable list of numbers
+// into an integer array
+func listStrToArray(str string) ([]int, error) {
+	a := []int{}
+
+	// Empty list
+	if len(str) == 0 {
+		return a, nil
+	}
+
+	ranges := strings.Split(str, ",")
+	for _, ran := range ranges {
+		split := strings.SplitN(ran, "-", 2)
+
+		// We limit to 8 bits in order to avoid accidental super long slices
+		num, err := strconv.ParseInt(split[0], 10, 8)
+		if err != nil {
+			return a, rdtError("invalid integer %q: %v", str, err)
+		}
+
+		if len(split) == 1 {
+			a = append(a, int(num))
+		} else {
+			endNum, err := strconv.ParseInt(split[1], 10, 8)
+			if err != nil {
+				return a, rdtError("invalid integer in range %q: %v", str, err)
+			}
+			if endNum <= num {
+				return a, rdtError("invalid integer range %q in %q", ran, str)
+			}
+			for i := num; i <= endNum; i++ {
+				a = append(a, int(i))
+			}
+		}
+	}
+	sort.Ints(a)
+	return a, nil
+}

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdt
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+const resctrlGroupPrefix = "cri-resmgr."
+
+// Control is the interface managing Intel RDT resources
+type Control interface {
+	// GetClasses returns the names of RDT classes (or resctrl control groups)
+	// available
+	GetClasses() []string
+
+	// SetProcessClass assigns a set of processes to a RDT class
+	SetProcessClass(string, ...string) error
+
+	// SetConfig re-configures RDT resources
+	SetConfig(string) error
+}
+
+var rdtInfo Info
+
+type control struct {
+	logger.Logger
+
+	conf config
+}
+
+type config struct {
+	ResctrlGroups map[string]ResctrlGroupConfig `json:"resctrlGroups"`
+}
+
+// NewControl returns new instance of the RDT Control interface
+func NewControl(resctrlpath string, config string) (Control, error) {
+	var err error
+	r := &control{Logger: logger.NewLogger("rdt")}
+
+	// Get info from the resctrl filesystem
+	rdtInfo, err = getRdtInfo(resctrlpath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure resctrl
+	r.conf, err = parseConfData([]byte(config))
+	if err != nil {
+		return nil, err
+	}
+	if err := r.configureResctrl(r.conf); err != nil {
+		return nil, rdtError("configuration failed: %v", err)
+	}
+
+	return r, nil
+}
+
+func (r *control) GetClasses() []string {
+	ret := make([]string, len(r.conf.ResctrlGroups))
+
+	i := 0
+	for k := range r.conf.ResctrlGroups {
+		ret[i] = k
+		i++
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+func (r *control) SetProcessClass(class string, pids ...string) error {
+	if _, ok := r.conf.ResctrlGroups[class]; !ok {
+		return rdtError("unknown RDT class %q", class)
+	}
+
+	path := filepath.Join(r.resctrlGroupPath(class), "tasks")
+	for _, pid := range pids {
+		if err := ioutil.WriteFile(path, []byte(pid), 0644); err != nil {
+			return rdtError("failed to assign process %s to class %q: %v", pid, class, err)
+		}
+	}
+	return nil
+}
+
+func (r *control) SetConfig(newConfRaw string) error {
+	newConf, err := parseConfData([]byte(newConfRaw))
+	if err != nil {
+		return err
+	}
+
+	err = r.configureResctrl(newConf)
+	if err != nil {
+		// Try to roll-back
+		r.Error("failed to configure resctrl: %v", err)
+		r.Error("attempting configuration roll-back")
+		if err := r.configureResctrl(r.conf); err != nil {
+			r.Error("rollback failed: %v", err)
+		}
+		return rdtError("resctrl confuguration failed: %v", err)
+	}
+
+	r.conf = newConf
+
+	return nil
+}
+
+func (r *control) configureResctrl(conf config) error {
+	// Remove stale resctrl groups
+	existingGroups, err := r.getResctrlGroups()
+	if err != nil {
+		return err
+	}
+
+	for _, name := range existingGroups {
+		if _, ok := conf.ResctrlGroups[name]; !ok {
+			path := r.resctrlGroupPath(name)
+			tasks, err := r.resctrlGroupTasks(name)
+			if err != nil {
+				return rdtError("failed to get resctrl group tasks: %v", err)
+			}
+			if len(tasks) > 0 {
+				return rdtError("refusing to remove non-empty resctrl group %q", path)
+			}
+			err = os.Remove(path)
+			if err != nil {
+				return rdtError("failed to remove resctrl group %q: %v", path, err)
+			}
+		}
+	}
+
+	// Try to apply given configuration
+	for name, conf := range conf.ResctrlGroups {
+		err := r.configureResctrlGroup(name, conf)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func parseConfData(raw []byte) (config, error) {
+	conf := config{}
+
+	err := yaml.Unmarshal(raw, &conf)
+	if err != nil {
+		return conf, rdtError("failed to parse configuration: %v", err)
+	}
+	return conf, nil
+}
+
+func (r *control) configureResctrlGroup(name string, config ResctrlGroupConfig) error {
+	path := r.resctrlGroupPath(name)
+	if err := os.Mkdir(path, 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	schemata := ""
+	if !config.L3Schema.IsNil() {
+		// User specified L3 allocation so use it
+		schemata += config.L3Schema.ToStr()
+	} else if rdtInfo.l3.Supported() {
+		// L3 is enabled but user did not specify a config -> use to defaults
+		schemata += config.L3Schema.DefaultStr()
+	}
+
+	if !config.MBSchema.IsNil() {
+		// User specified MB allocation so use it
+		schemata += config.MBSchema.ToStr()
+	} else if rdtInfo.mb.Supported() {
+		// MB is enabled but user did not specify a config -> use to defaults
+		schemata += config.MBSchema.DefaultStr()
+	}
+
+	if len(schemata) > 0 {
+		r.Debug("writing schemata %q", schemata)
+		if err := ioutil.WriteFile(filepath.Join(path, "schemata"), []byte(schemata), 0644); err != nil {
+			return err
+		}
+	} else {
+		r.Debug("empty schemata")
+	}
+
+	return nil
+}
+
+func (r *control) resctrlGroupPath(name string) string {
+	return filepath.Join(rdtInfo.resctrlPath, resctrlGroupPrefix+name)
+}
+
+func (r *control) getResctrlGroups() ([]string, error) {
+
+	files, err := ioutil.ReadDir(rdtInfo.resctrlPath)
+	if err != nil {
+		return nil, err
+	}
+	groups := make([]string, 0, len(files))
+	for _, file := range files {
+		fullName := file.Name()
+		if strings.HasPrefix(fullName, resctrlGroupPrefix) {
+			groups = append(groups, fullName[len(resctrlGroupPrefix):])
+		}
+	}
+	return groups, nil
+}
+
+func (r *control) resctrlGroupTasks(name string) ([]string, error) {
+	path := filepath.Join(r.resctrlGroupPath(name), "tasks")
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return []string{}, err
+	}
+	split := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(split[0]) > 0 {
+		return split, nil
+	}
+	return []string{}, nil
+}
+
+func rdtError(format string, args ...interface{}) error {
+	return fmt.Errorf("rdt: "+format, args...)
+}

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdt
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBitMap(t *testing.T) {
+	// Test ListStr()
+	testSet := map[Bitmask]string{
+		0x0:                "",
+		0x1:                "0",
+		0x2:                "1",
+		0xf:                "0-3",
+		0x555:              "0,2,4,6,8,10",
+		0xaaa:              "1,3,5,7,9,11",
+		0x1d1a:             "1,3-4,8,10-12",
+		0xffffffffffffffff: "0-63",
+	}
+	for i, s := range testSet {
+		// Test conversion to string
+		listStr := i.ListStr()
+		if listStr != s {
+			t.Errorf("from %#x expected %q, got %q", i, s, listStr)
+		}
+
+		// Test conversion from string
+		b, err := ListStrToBitmask(s)
+		if err != nil {
+			t.Errorf("unexpected err when converting %q: %v", s, err)
+		}
+		if b != i {
+			t.Errorf("from %q expected %#x, got %#x", s, i, b)
+		}
+	}
+
+	// Negative tests for ListStrToBitmask
+	negTestSet := []string{
+		",",
+		"-",
+		"1,",
+		",12",
+		"-4",
+		"0-",
+		"13-13",
+		"14-13",
+		"a-2",
+		"b",
+		"3-c",
+		"64",
+		"1,2,,3",
+		"1,2,3-",
+	}
+	for _, s := range negTestSet {
+		b, err := ListStrToBitmask(s)
+		if err == nil {
+			t.Errorf("expected err but got %#x when converting %q", b, s)
+		}
+	}
+}
+
+func TestListStrToArray(t *testing.T) {
+	testSet := map[string][]int{
+		"":              {},
+		"0":             {0},
+		"1":             {1},
+		"0-3":           {0, 1, 2, 3},
+		"4,2,0,6,10,8":  {0, 2, 4, 6, 8, 10},
+		"1,3,5,7,9,11":  {1, 3, 5, 7, 9, 11},
+		"1,3-4,10-12,8": {1, 3, 4, 8, 10, 11, 12},
+	}
+	for s, expected := range testSet {
+		// Test conversion from string to list of integers
+		a, err := listStrToArray(s)
+		if err != nil {
+			t.Errorf("unexpected error when converting %q: %v", s, err)
+		}
+		if !cmp.Equal(a, expected) {
+			t.Errorf("from %q expected %v, got %v", s, expected, a)
+		}
+	}
+
+	// Negative test cases
+	negTestSet := []string{
+		",",
+		"-",
+		"1,",
+		",12",
+		"-4",
+		"0-",
+		"13-13",
+		"14-13",
+		"a-2",
+		"b",
+		"3-c",
+		"1,2,,3",
+		"1,2,3-",
+	}
+	for _, s := range negTestSet {
+		a, err := listStrToArray(s)
+		if err == nil {
+			t.Errorf("expected err but got %v when converting %q", a, s)
+		}
+	}
+}

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -48,4 +48,28 @@ data:
         - Cpuset: 28,29,30,31
           Socket: 3
         exclusive: false
-
+  rdt: |+
+    # This example config specifies three RDT classes (or resctrl groups) with L3
+    # CAT configured
+    resctrlGroups:
+      Guaranteed:
+        l3schema:
+          all: "100%"
+    # Specify CacheId (typically correspons CPU socket) specific setting
+    #      1: "80%"
+    # MBA (Memory Bandwidth Allocation)
+    #    mbschema:
+    #      all: 100
+    #      1-3: 80
+      Burstable:
+        l3schema:
+          all: "66%"
+    # MBA (Memory Bandwidth Allocation)
+    #    mbschema:
+    #      all: 66
+      BestEffort:
+        l3schema:
+          all: "33%"
+    # MBA (Memory Bandwidth Allocation)
+    #    mbschema:
+    #      all: 33


### PR DESCRIPTION
This patch implements RDT support. The resource manager now has a common
confugration of a set of RDT classes (or resctrl CTRL groups) which the
policies are able to assign containers to. This RDT configuration is
dynamically updatable via the resource manager node agent
(cri-resmgr-agent). Resource manager has a built-in default
configuration containing three classes corresponding to the Pod QOS
classes of Kubernetes. The set of classes can be freely specified in the
configuration, but, one must ensure that classes required by the active
policies have been defined, and, that the maxmimum number of classes
(CLOSes) supported by the hardware is not exceeded.

This patch integrates RDT support to the static policy. The policy
simply assigns each container to an RDT class corresponding its Pod QOS
class (i.e.  'Burstable', 'BestEffort' or 'Guaranteed').

RDT support can be disabled by using the '-no-rdt' command line option.

TODO:
- [ ] better unit test coverage
- [ ] support CDP (codee and data priorization) schemas (i.e. separate
  L3data and L3code)
- [ ] policy-level tri-state (on/off/auto) knob for rdt
- [ ] change rdt class configuration to allow soft (preferred) requirements for rdt features (i.e. e.g. enforce MB if supported by system)
- [ ] per-node overrides for rdt config
