### PR TITLE
build-system: clean up Makefile, add install and dist targets, autoversioning.

### DIFF
--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -1,0 +1,37 @@
+# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
+# reproducible by choosing an image by its hash and installing an OS version
+# with --version=:
+# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
+# CLEAR_LINUX_VERSION="--version=29970"
+#
+# This is used on release branches before tagging a stable version.
+# The master branch defaults to using the latest Clear Linux.
+ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+
+FROM ${CLEAR_LINUX_BASE} as builder
+
+ARG CLEAR_LINUX_VERSION=
+
+RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+RUN swupd bundle-add make ${CLEAR_LINUX_VERSION}
+RUN mkdir /install_root \
+    && swupd os-install \
+    ${CLEAR_LINUX_VERSION} \
+    --path /install_root \
+    --statedir /swupd-state \
+    --bundles=os-core \
+    --no-boot-update \
+    && rm -rf /install_root/var/lib/swupd/*
+
+ARG DIR=/go/src/build
+WORKDIR $DIR
+ADD . $DIR
+
+ENV GO111MODULE=on GOFLAGS=-mod=vendor
+RUN make BUILD_DIRS=cri-resmgr-agent
+
+FROM scratch as final
+ARG DIR=/go/src/build
+COPY --from=builder /install_root /
+COPY --from=builder $DIR/bin/cri-resmgr-agent /bin/cri-resmgr-agent
+ENTRYPOINT ["/bin/cri-resmgr-agent"]

--- a/cmd/cri-resmgr-agent/agent-deployment.yaml
+++ b/cmd/cri-resmgr-agent/agent-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cri-resmgr-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cri-resmgr-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - configmaps
+  - labels
+  - annotations
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cri-resmgr-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cri-resmgr-agent
+subjects:
+- kind: ServiceAccount
+  name: cri-resmgr-agent
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: cri-resmgr-agent
+  name: cri-resmgr-agent
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: cri-resmgr-agent
+  template:
+    metadata:
+      labels:
+        app: cri-resmgr-agent
+    spec:
+      serviceAccount: cri-resmgr-agent
+      containers:
+        - name: cri-resmgr-agent
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: mandark.fi.intel.com:5000/cri-resmgr-agent:testing
+          imagePullPolicy: Always # for testing
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: resmgrsockets
+            mountPath: /var/run/cri-resmgr
+      volumes:
+      - name: resmgrsockets
+        hostPath:
+          path: /var/run/cri-resmgr

--- a/cmd/cri-resmgr/cri-resource-manager.service
+++ b/cmd/cri-resmgr/cri-resource-manager.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=A CRI proxy with (hardware) resource aware container placement policies.
+Documentation=https://github.com/intel/cri-resource-manager
+Requires=cri-resource-manager-agent.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/sysconfig/cri-resource-manager
+ExecStart=/usr/bin/cri-resmgr --policy $POLICY $POLICY_OPTIONS $DEBUG_OPTIONS
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/cri-resmgr/cri-resource-manager.sysconf
+++ b/cmd/cri-resmgr/cri-resource-manager.sysconf
@@ -1,0 +1,8 @@
+# Name of the policy to activate.
+POLICY=topology-aware
+# Any extra options for the active policy.
+POLICY_OPTIONS="--reserved-resources=cpu=750m"
+# Debug flags to enable.
+DEBUG_OPTIONS="--logger-debug resource-manager,policy,cache,$POLICY"
+# Config file for accessing the cluster through the API server.
+KUBE_CONFIG="--kubeconfig /root/.kube/config"

--- a/cmd/cri-resmgr/main.go
+++ b/cmd/cri-resmgr/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/instrumentation"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	version "github.com/intel/cri-resource-manager/pkg/version"
 )
 
 func main() {
@@ -36,6 +37,8 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
+
+	log.Info("cri-resmgr (version %s, build %s) starting...", version.Version, version.Build)
 
 	if err := instrumentation.Setup("CRI-RM"); err != nil {
 		log.Fatal("failed to set up instrumentation: %v", err)

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -1,21 +1,41 @@
-# Build webhook
-FROM golang:alpine as builder
+# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
+# reproducible by choosing an image by its hash and installing an OS version
+# with --version=:
+# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
+# CLEAR_LINUX_VERSION="--version=29970"
+#
+# This is used on release branches before tagging a stable version.
+# The master branch defaults to using the latest Clear Linux.
+ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
 
-RUN apk add --no-cache gcc git
+FROM ${CLEAR_LINUX_BASE} as builder
 
-ADD . /go/src/build
+ARG CLEAR_LINUX_VERSION=
 
-WORKDIR /go/src/build
+RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+RUN swupd bundle-add make ${CLEAR_LINUX_VERSION}
+RUN mkdir /install_root \
+    && swupd os-install \
+    ${CLEAR_LINUX_VERSION} \
+    --path /install_root \
+    --statedir /swupd-state \
+    --bundles=os-core \
+    --no-boot-update \
+    && rm -rf /install_root/var/lib/swupd/*
 
-ENV GO111MODULE=on
-RUN go build -o cmd/webhook/webhook ./cmd/webhook/*go
+ARG DIR=/go/src/build
+WORKDIR $DIR
+ADD . $DIR
 
-# Create production image without the build deps
-FROM alpine
+ENV GO111MODULE=on GOFLAGS=-mod=vendor
+RUN make BUILD_DIRS=webhook
 
-RUN apk add --no-cache libc6-compat
+FROM scratch as final
+ARG DIR=/go/src/build
+COPY --from=builder /install_root /
 
-COPY --from=builder /go/src/build/cmd/webhook/webhook /bin/webhook
+COPY --from=builder /go/src/build/bin/webhook /bin/webhook
 COPY --from=builder /go/src/build/test/data/cri-resmgr-webhook.cri-resmgr.svc.* /etc/cri-resmgr-webhook/certs.d/
 
 ENTRYPOINT ["/bin/webhook", "-cert-file=/etc/cri-resmgr-webhook/certs.d/cri-resmgr-webhook.cri-resmgr.svc.crt", "-key-file=/etc/cri-resmgr-webhook/certs.d/cri-resmgr-webhook.cri-resmgr.svc.key"]
+

--- a/packaging/rpm/cri-resource-manager.spec.in
+++ b/packaging/rpm/cri-resource-manager.spec.in
@@ -1,0 +1,41 @@
+Name:    cri-resource-manager
+Version: __VERSION__
+Release: 0
+Summary: CRI Resource Manager, a CRI proxy with various in-node workload placement policies
+License: ASL 2.0 
+URL:     https://github.com/intel/cri-resource-manager
+Source0: https://github.com/intel/cri-resource-manager/archive/cri-resource-manager-%{version}.tar.bz2
+BuildRequires: go >= 1.12, /usr/bin/make, /usr/bin/install
+
+%package doc
+Summary: Documentation el al. collateral for Resource Manager Cluster/Node Agent
+Requires: %{name} = %{version}
+
+%description
+Kubernetes Container Runtime Interface proxy service with hardware resource aware workload
+placement policies.
+
+%description doc
+LICENSE, README, and any other potential documentation.
+
+%prep
+%setup -q -n cri-resource-manager-%{version}
+
+%build
+make build BUILD_DIRS=cri-resmgr
+
+%install
+%make_install UNITDIR=%{_unitdir} SYSCONFDIR=%{_sysconfdir} BUILD_DIRS=cri-resmgr
+install -m 0700 -d %{?buildroot}%{_sharedstatedir}/cri-resmgr
+
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*
+%{_sysconfdir}/sysconfig/*
+%{_unitdir}/*
+%dir %attr(0700,root,root) %{_sharedstatedir}/cri-resmgr
+
+%files doc
+%defattr(-,root,root,-)
+%doc CONTRIBUTING.md LICENSE README.md SECURITY.md TODO.md

--- a/pkg/cri/relay/relay.go
+++ b/pkg/cri/relay/relay.go
@@ -136,5 +136,5 @@ func (r *relay) Server() server.Server {
 
 // relayError creates a formatted relay-specific error.
 func relayError(format string, args ...interface{}) error {
-	return fmt.Errorf("cir/relay: "+format, args...)
+	return fmt.Errorf("cri/relay: "+format, args...)
 }

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -42,7 +42,7 @@ func init() {
 		"Unix domain socket path where CRI runtime service requests should be relayed to.")
 	flag.StringVar(&opt.RelaySocket, "relay-socket", sockets.ResourceManagerRelay,
 		"Unix domain socket path where the resource manager should serve requests on.")
-	flag.StringVar(&opt.RelayDir, "relay-dir", "/var/lib/cri-relay",
+	flag.StringVar(&opt.RelayDir, "relay-dir", "/var/lib/cri-resmgr",
 		"Permanent storage directory path for the resource manager to store its state in.")
 	flag.StringVar(&opt.AgentSocket, "agent-socket", sockets.ResourceManagerAgent,
 		"local socket of the cri-resmgr agent to connect")

--- a/pkg/cri/resource-manager/sockets/sockets.go
+++ b/pkg/cri/resource-manager/sockets/sockets.go
@@ -18,9 +18,9 @@ const (
 	// DockerShim is the CRI socket dockershim listens on.
 	DockerShim = "/var/run/dockershim.sock"
 	// ResourceManagerRelay is the CRI socket the resource manager listens on.
-	ResourceManagerRelay = "/var/run/cri-relay.sock"
+	ResourceManagerRelay = "/var/run/cri-resmgr/cri-resmgr.sock"
 	// ResourceManagerAgent is the socket the resource manager node agent listens on.
-	ResourceManagerAgent = "/var/run/cri-resmgr-agent.sock"
+	ResourceManagerAgent = "/var/run/cri-resmgr/cri-resmgr-agent.sock"
 	// ResourceManagerConfig for resource manager configuration notifications.
-	ResourceManagerConfig = "/var/run/cri-resmgr-config.sock"
+	ResourceManagerConfig = "/var/run/cri-resmgr/cri-resmgr-config.sock"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// This module lets one tag built binaries with version metadata.
+//
+// Currently two pieces of metadata tracked/provided:
+//   - Version: version number, by convention one provided by 'git describe'
+//   - Build:   build id, by convention the git SHA1 the binary has been built from.
+//
+// To enable automatic versioning metadata for your binary, you need to
+//
+//   1) import this package
+//   2) add the linker flags to override the dummy package variables, for instance:
+//        LDFLAGS=-ldflags \
+//          "-X=github.com/intel/cri-resource-manager/pkg/version.Version=<version> \
+//           -X=github.com/intel/cri-resource-manager/pkg/version.Build=<build-id>"
+//
+// Note that further metadata can be trivially added in a similar fashion:
+//
+//   1) add the corresponding variables to this modules
+//   2) arrange the default values to be correctly overridden during linking
+//   3) add printing of the new metadata to PrintVersionInfo()
+//
+
+package version
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// Default values of variables we'll override with the linker.
+var (
+	// Version is our version as given by 'git describe'.
+	Version = "<If you see this, you ain't doin' it right, Jimbo...>"
+	// Build is the SHA1 of the repository we've been built from.
+	Build = "<If you see this, you ain't doin' it right, Jimbo...>"
+)
+
+// PrintVersionInfo prints version information about this binary.
+func PrintVersionInfo() {
+	fmt.Printf("%s version information:\n", filepath.Base(os.Args[0]))
+	fmt.Printf("  - version: %s\n", Version)
+	fmt.Printf("  - build:   %s\n", Build)
+}
+
+// Dummy struct used to hook into flag.Value.Set of -version during commandline parsing.
+type version struct{}
+
+// IsBoolFlag tell flag that we only have optional arguments.
+func (version) IsBoolFlag() bool {
+	return true
+}
+
+// Set is our dummy flag.Value setter.
+func (version) Set(value string) error {
+	print, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	if print {
+		PrintVersionInfo()
+		os.Exit(0)
+	}
+
+	return nil
+}
+
+// String is our dummy flag.Value stringification function.
+func (*version) String() string {
+	return "false"
+}
+
+// Put in place a '--version' command line option for us.
+func init() {
+	flag.Var(&version{}, "version", "Print version information about "+filepath.Base(os.Args[0]))
+}

--- a/scripts/build/docker-build
+++ b/scripts/build/docker-build
@@ -1,12 +1,26 @@
 #!/bin/bash
 
-# usage: docker-image [--image name] [ --tag tag ] [--registry registry] dir-with-Dockerfile
+# usage: docker-image [--image name] [ --tag tag ] [--publish registry] dir-with-Dockerfile
 
 DIR=""
-TAG="latest"
+TAG="testing"
+
+fatal () {
+    echo "[docker-build] fatal error: $@" 1>&2
+    exit 1
+}
+
+log () {
+    echo "[docker-build] $@"
+}
+
+xeq () {
+    [ -z "$Q" ] && log "$@"
+    $@ || exit 1
+}
 
 print_usage () {
-    echo "usage: $0 [--image name] [--tag tag] [--registry docker-registry ] dir-with-Dockerfile"
+    echo "usage: $0 [--image name] [--tag tag] [--publish docker-registry ] dir-with-Dockerfile"
     exit ${1:-1}
 }
 
@@ -21,7 +35,7 @@ parse_commandline () {
                 TAG="$2"
                 shift 2
                 ;;
-            --registry|-r)
+            --publish|-p)
                 REGISTRY="$2"
                 shift 2
                 ;;
@@ -36,8 +50,9 @@ parse_commandline () {
                 set -x
                 shift
                 ;;
-            --*)
-                print_usage
+            -*)
+                BUILD_OPTIONS="$BUILD_OPTIONS $1"
+                shift
                 ;;
             *)
                 if [ -n "$DIR" ]; then
@@ -50,15 +65,14 @@ parse_commandline () {
     done
 
     if [ -z "$DIR" ]; then
-        print_usage
+        fatal "no directory given with Dockerfile"
     fi
 }
 
 check_dockerfile () {
     DOCKERFILE=$DIR/Dockerfile
     if [ ! -e $DOCKERFILE ]; then
-        echo "Dockerfile $DOCKERFILE not found."
-        print_usage
+        fatal "Dockerfile $DOCKERFILE not found in $DIR."
     fi
 }
 
@@ -107,22 +121,24 @@ check_imagename () {
 }
 
 show_summary () {
-    echo "[docker-build] * Generating docker image $IMAGE:$TAG..."
-    echo "[docker-build]     - Dockerfile: $DOCKERFILE"
-    echo "[docker-build]     - publishing: ${REGISTRY}"
+    log "Building docker image $IMAGE:$TAG..."
+    log "  - using docker file $DOCKERFILE"
+    if [ -n "$REGISTRY" ]; then
+        log "  - publishing to $REGISTRY"
+    fi
 }
 
 docker_build () {
-    cmd="docker build -f $DOCKERFILE -t $IMAGE:$TAG . $Q"
-    echo "[docker-build] building images $IMAGE:$TAG (\"$cmd\")..."
-    $cmd || exit 1
+    log "building image $IMAGE:$TAG..."
+    xeq docker build $BUILD_OPTIONS -f $DOCKERFILE -t $IMAGE:$TAG . $Q
 }
 
 docker_publish () {
     if [ -n "$REGISTRY" -a "$REGISTRY" != "-" ]; then
-        cmd="docker tag $IMAGE:$TAG $REGISTRY/$IMAGE:$TAG"
-        echo "[docker-build] publishing built image $IMAGE:$TAG to $REGISTRY (\"$cmd\")..."
-        $cmd || exit 1
+        log "tagging image $IMAGE:$TAG for $REGISTRY..."
+        xeq docker tag $IMAGE:$TAG $REGISTRY/$IMAGE:$TAG
+        log "publishing image as $REGISTRY/$IMAGE:$TAG..."
+        xeq docker push $REGISTRY/$IMAGE:$TAG
     fi
 }
 

--- a/scripts/build/git-id
+++ b/scripts/build/git-id
@@ -1,0 +1,74 @@
+#!/bin/bash
+# get/save/load git-described version + SHA1 build id, usage: git-id [dir-to-save/read-ids]
+
+unknown_version() {
+    v=0.0.0
+    if [ -d .git ]; then
+        sha=$(git rev-parse --short HEAD)
+        commits=$(git rev-list --count HEAD)
+        dirty=$(git diff --quiet || echo "-dirty")
+        echo "v$v-$commits-g$sha$dirty"
+    else
+        echo "v$v-$(date +%Y%m%d%H%M)"
+    fi
+}
+
+get_gitids () {
+    if [ -d .git ]; then
+        version=$(git describe --long --dirty 2>/dev/null || unknown_version)
+        buildid=$(git rev-parse --short HEAD || echo unknown)
+        if [ -n "$DIR" ]; then
+            if [ "$version" != "$(cat $DIR/git-version 2>/dev/null)" ]; then
+                echo "$version" > $DIR/git-version
+            fi
+            if [ "$buildid" != "$(cat $DIR/git-buildid 2>/dev/null)" ]; then
+                echo "$buildid" > $DIR/git-buildid
+            fi
+        fi
+    else
+        DIR=${DIR:-.}
+        version=$(cat $DIR/git-version || unknown_version)
+        buildid=$(cat $DIR/git-buildid || echo unknown)
+    fi
+}
+
+print_gitids () {
+    # semverish described tags: <numver>[-<alnum-prerel>][-<commits>-g<shaone>][-dirty]
+    case $version in
+        v[0-9.]**-g[0-9a-f]*)
+            fulltag=${version#v}
+            numver=${fulltag%%-*}
+            remain=${fulltag#*-}; clean=${remain%-dirty}; dirty=${remain#$clean}
+            shaone=${clean##*-g}; remain=${clean%-g[0-9a-z]*}
+            prerel=${remain%-[0-9]*}; commits=${remain#${prerel}-}
+            [ "$prerel" = "$commits" ] && prerel=""
+            [ -n "$prerel" ] && prerel="+$prerel"
+            [ "$commits" != "0" ] && commits="-$commits-g${shaone}" || commits=""
+            #echo "version:[$version], numver:[$numver], prerel:[$prerel], commits:[$commits], shaone:[$shaone], dirty:[$dirty]" 1>&2
+            version=$numver$prerel$commits$dirty
+            buildid=$buildid
+            ;;
+        *)
+            version="$(unknown_version)"
+            ;;
+    esac
+    echo "gitversion=$version"
+    echo "gitbuildid=$buildid"
+}
+
+#######
+version=""
+buildid=""
+DIR=""
+
+case $# in
+    0) ;;
+    1) DIR=$1; mkdir -p $DIR;;
+    *)
+        echo "$0: unknown options/arguments: $@" 1>&2
+        echo "usage: $0 [dir-to-save/read-ids]" 1>&2
+        exit 1;;
+esac
+
+get_gitids
+print_gitids


### PR DESCRIPTION
This patch set
  - cleans up (rather heavy-handedly) our Makefile, keeping it mostly target-compatible  
  - adds a Makefile `install` and `dist` targets
  - adds helper package and Makefile glue for collecting version/build info in the binaries
  - adds sample/very simple `RPM` packaging
  - adds deployment YAML and `Dockerfile` w/ClearLinux for cri-resmgr-agent
  - switches webhook's `Dockerfile` to use ClearLinux
  - switches to more consistent socket naming
  - adds dedicated socket directory for safer mounting into agent container

The version information can be queried with the new `--version` command line option. 
The printing function is really dumb, directly dumping raw data. For the version data this could be easily improved, for instance to separate any potential tag, additional number of commits and the dirty flag from each other and print them in a more user-friendly way.

Anyway, here are some examples of how the output looks like now.

- untagged repo:
```
cri-resmgr version information:
  - version: 0.0.0+20190918
  - build:   912e8ba
```

- exact-tagged clean repo:
```
cri-resmgr version information:
  - version: 0.0.2
  - build:   912e8ba
```

- past-tagged clean repo:
```
cri-resmgr version information:
  - version: 0.0.2-3-g912e8ba
  - build:   912e8ba
```

- past-tagged dirty repo:
```
cri-resmgr version information:
  - version: 0.0.2-3-g912e8ba-dirty
  - build:   912e8ba
```
