### PR TITLE
topology-aware: expose allocated shared, exclusive and isolated CPUs to contianers

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
@@ -156,7 +156,9 @@ func (o *options) mergeFakeHints(n *options) {
 
 	for c, nhints := range n.Hints {
 		if ohints, ok := o.Hints[c]; !ok {
-			o.Hints[c] = nhints
+			if len(nhints) != 0 {
+				o.Hints[c] = nhints
+			}
 		} else {
 			for _, nh := range nhints {
 				duplicate := false

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
@@ -145,16 +145,19 @@ func (o *options) mergeFakeHints(n *options) {
 	if o.Hints == nil {
 		o.Hints = make(map[string]system.TopologyHints)
 	}
+
+	for c, ohints := range o.Hints {
+		if len(ohints) == 0 {
+			log.Debug("deleting hints of %s", c)
+			delete(o.Hints, c)
+			delete(n.Hints, c)
+		}
+	}
+
 	for c, nhints := range n.Hints {
 		if ohints, ok := o.Hints[c]; !ok {
 			o.Hints[c] = nhints
 		} else {
-			if len(ohints) == 0 {
-				// was marked for deletion, so do it
-				log.Debug("deleting hints of %s", c)
-				delete(o.Hints, c)
-				continue
-			}
 			for _, nh := range nhints {
 				duplicate := false
 				for _, oh := range ohints {


### PR DESCRIPTION
Add code to expose the allocated CPUs to containers similarly to the `static-plus` policy.

Container resource allocation (currently CPU only) is exposed using a container-specific directory wich is bind-mounted to `/.cri-resmgr` inside the container. It is populated with a single entry, `resource.sh`, which is a shell-source-able file containing information about the various kinds of CPUs allocated to the container. The contents of this file can be used by `isolation-aware` and `multi-CPU exclusive` containers to further pin their corresponding `threads` to the exclusively allocated (isolated or other) CPUs using `sched_setaffinity`. This file can also be monitored with `inotify` to get notifications about possible changes in CPU assignments.

The other patch in this PR fixes a small glitch in the handling of fake hints.