### PR TITLE
policy: add single-shot policy synchronization.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -66,8 +66,21 @@ func (eda *eda) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (eda *eda) Start(cch cache.Cache) error {
+func (eda *eda) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
 	eda.Debug("preparing for making decisions...")
+	return nil
+}
+
+// Sync synchronizes the state of this policy.
+func (eda *eda) Sync(add []cache.Container, del []cache.Container) error {
+	eda.Debug("synchronizing state...")
+	for _, c := range del {
+		eda.ReleaseResources(c)
+	}
+	for _, c := range add {
+		eda.AllocateResources(c)
+	}
+
 	return nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -51,8 +51,14 @@ func (n *none) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (n *none) Start(cch cache.Cache) error {
+func (n *none) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
 	n.Debug("got started...")
+	return nil
+}
+
+// Sync synchronizes the active policy state.
+func (n *none) Sync(add []cache.Container, del []cache.Container) error {
+	n.Debug("(not) synchronizing policy state")
 	return nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -99,7 +99,7 @@ func (p *staticplus) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (p *staticplus) Start(cch cache.Cache) error {
+func (p *staticplus) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
 	p.cache = cch
 
 	if err := p.restoreCache(); err != nil {
@@ -108,6 +108,19 @@ func (p *staticplus) Start(cch cache.Cache) error {
 
 	if err := p.updatePools(); err != nil {
 		return policyError("failed to start: %v", err)
+	}
+
+	return p.Sync(add, del)
+}
+
+// Sync synchronizes the state ofd this policy.
+func (p *staticplus) Sync(add []cache.Container, del []cache.Container) error {
+	p.Debug("synchronizing state...")
+	for _, c := range del {
+		p.ReleaseResources(c)
+	}
+	for _, c := range add {
+		p.AllocateResources(c)
 	}
 
 	return nil

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -124,7 +124,7 @@ func (stp *stp) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (stp *stp) Start(cch cache.Cache) error {
+func (stp *stp) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
 	var err error
 
 	err = stp.updateNode(*stp.conf)
@@ -137,7 +137,24 @@ func (stp *stp) Start(cch cache.Cache) error {
 	}
 	stp.Debug("retrieved stp container states from cache:\n%s", stringify(*stp.getContainerRegistry()))
 
+	if err = stp.Sync(add, del); err != nil {
+		return err
+	}
+
 	stp.Debug("preparing for making decisions...")
+
+	return nil
+}
+
+// Sync synchronizes the state of this policy.
+func (stp *stp) Sync(add []cache.Container, del []cache.Container) error {
+	stp.Debug("synchronizing state...")
+	for _, c := range del {
+		stp.ReleaseResources(c)
+	}
+	for _, c := range add {
+		stp.AllocateResources(c)
+	}
 
 	return nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -97,7 +97,7 @@ func (s *static) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (s *static) Start(state cache.Cache) error {
+func (s *static) Start(state cache.Cache, add []cache.Container, del []cache.Container) error {
 	s.Debug("starting up...")
 
 	if s.config != "" {
@@ -119,6 +119,19 @@ func (s *static) Start(state cache.Cache) error {
 	}
 
 	s.validateAssignments()
+
+	return s.Sync(add, del)
+}
+
+// Sync synchronizes the active policy state.
+func (s *static) Sync(add []cache.Container, del []cache.Container) error {
+	s.Debug("synchronizing state...")
+	for _, c := range del {
+		s.ReleaseResources(c)
+	}
+	for _, c := range add {
+		s.AllocateResources(c)
+	}
 
 	return nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -93,7 +93,7 @@ func (p *policy) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (p *policy) Start(cch cache.Cache) error {
+func (p *policy) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
 	p.cache = cch
 
 	if err := p.restoreCache(); err != nil {
@@ -101,6 +101,19 @@ func (p *policy) Start(cch cache.Cache) error {
 	}
 
 	p.root.Dump("<post-start>")
+
+	return p.Sync(add, del)
+}
+
+// Sync synchronizes the state of this policy.
+func (p *policy) Sync(add []cache.Container, del []cache.Container) error {
+	log.Debug("synchronizing state...")
+	for _, c := range del {
+		p.ReleaseResources(c)
+	}
+	for _, c := range add {
+		p.AllocateResources(c)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Added `policy.Sync()` to the `Policy` and `Backend` interfaces.
`Sync()` is called with two slices of containers: those `added`
since the previous startup or sync, and those `deleted`.

This should enable policies to synchronize themselves much
more efficiently during startup. The active policy now gets
the target desired state atomically in a single go instead
of the old 'peephole' style of going through first a loop of
deleting stale containers followed by a loop of adding newly
discovered ones.

`Start()` has been extended in a logically identical manner.
It now gets called with the same extra arguments for initial
synchronization.

This patch also changes all policies to call internally `Sync()`
during `Start()` to do their initial synchronization. It also
adds default implementations of `Sync()` to all policy backends.
These simply synchronize themselves by looping through the
range of deleted and added containers calling `ReleaseResources()`
and `AllocateResources()` respectively.

At the moment `Sync()` is only ever triggered internally by `Start()`,
never externally by the resource manager yet.