### PR TITLE
Add intra-pod container affinity/anti-affinity support.

### DIFF
--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -1,0 +1,256 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+	"github.com/ghodss/yaml"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
+	"strings"
+)
+
+const (
+	// SelfReference indicates a container self-referencing value.
+	//SelfReference = "@self:"
+
+	// annotation key for specifying container affinity rules
+	keyAffinity = "affinity"
+	// annotation key for specifying container anti-affinity rules
+	keyAntiAffinity = "anti-affinity"
+)
+
+// simpleAffinity is an alternative, simplified syntax for intra-pod container affinity.
+type simpleAffinity map[string][]string
+
+// PodContainerAffinity defines a set of per-container affinities and anti-affinities.
+type podContainerAffinity map[string][]*Affinity
+
+// Affinity specifies a single container affinity.
+type Affinity struct {
+	Scope  *Expression `json:"scope,omitempty"`  // scope for evaluating this affinity
+	Match  *Expression `json:"match"`            // affinity expression
+	Weight int32       `json:"weight,omitempty"` // (optional) weight for this affinity
+}
+
+// Expression is used to describe a criteria to select objects within a domain.
+type Expression struct {
+	//  Domain  Domain   `json:"domain"`          // domain of operation, ATM implicitly labels
+	Key    string   `json:"key"`              // domain key
+	Op     Operator `json:"operator"`         // operator to apply to value of Key and Values
+	Values []string `json:"values,omitempty"` // value(s) for domain key
+}
+
+/*
+// Domain specifies possible domains to evaluate Expressions in.
+type Domain string
+
+const (
+	// ScopeLabels specifies the operation to be performed
+	LabelsDomain Domain = "labels"
+)
+*/
+
+// Operator defines the possible operators for an Expression.
+type Operator string
+
+const (
+	// Equals tests for equality with a single value.
+	Equals Operator = "Equals"
+	// NotEqual test for inequality with a single value.
+	NotEqual Operator = "NotEqual"
+	// In tests if the key's value is one of the specified set.
+	In Operator = "In"
+	// NotIn tests if the key's value is not one of the specified set.
+	NotIn Operator = "NotIn"
+	// Exists evalutes to true if the named key exists.
+	Exists Operator = "Exists"
+	// NotExist evalutes to true if the named key does not exist.
+	NotExist Operator = "NotExist"
+)
+
+// Validate checks the affinity for (obvious) invalidity.
+func (a *Affinity) Validate() error {
+	if err := a.Scope.Validate(); err != nil {
+		return cacheError("invalid affinity scope: %v", err)
+	}
+
+	if err := a.Match.Validate(); err != nil {
+		return cacheError("invalid affinity match: %v", err)
+	}
+
+	return nil
+}
+
+// Validate checks the expression for (obvious) invalidity.
+func (e *Expression) Validate() error {
+	if e == nil {
+		return cacheError("nil expression")
+	}
+
+	switch e.Op {
+	case Equals, NotEqual:
+		if len(e.Values) != 1 {
+			return cacheError("invalid expression, '%s' requires a single value", e.Op)
+		}
+	case Exists, NotExist:
+		if e.Values != nil && len(e.Values) != 0 {
+			return cacheError("invalid expression, '%s' does not take any values", e.Op)
+		}
+	}
+
+	return nil
+}
+
+// EvaluateAffinity evaluates the given affinity against all known in-scope containers.
+func (cch *cache) EvaluateAffinity(a *Affinity) map[string]int32 {
+	results := make(map[string]int32)
+	for _, c := range cch.FilterScope(a.Scope) {
+		if a.Match.Evaluate(c) {
+			id := c.GetCacheID()
+			results[id] += a.Weight
+		}
+	}
+	return results
+}
+
+// FilterScope returns the containers selected by the scope expression.
+func (cch *cache) FilterScope(scope *Expression) []Container {
+	cch.Debug("calculating scope %s", scope.String())
+	result := []Container{}
+	for _, c := range cch.GetContainers() {
+		if scope.Evaluate(c) {
+			cch.Debug("  + container %s: IN scope", c.PrettyName())
+			result = append(result, c)
+		} else {
+			cch.Debug("  - container %s: NOT IN scope", c.PrettyName())
+		}
+	}
+	return result
+}
+
+// Evaluate evaluates an expression against a container.
+func (e *Expression) Evaluate(container Container) bool {
+	value, ok := e.KeyValue(container)
+	result := false
+
+	switch e.Op {
+	case Equals:
+		result = ok && (value == e.Values[0] || e.Values[0] == "*")
+	case NotEqual:
+		result = !ok || value != e.Values[0]
+	case In:
+		result = false
+		if ok {
+			for _, v := range e.Values {
+				if value == v || v == "*" {
+					result = true
+				}
+			}
+		}
+	case NotIn:
+		result = true
+		if ok {
+			for _, v := range e.Values {
+				if value == v || v == "*" {
+					result = false
+				}
+			}
+		}
+	case Exists:
+		result = ok
+	case NotExist:
+		result = !ok
+	}
+
+	return result
+}
+
+// KeyValue extracts the value of the expresssion key from a container.
+func (e *Expression) KeyValue(container Container) (string, bool) {
+	value, ok := container.GetLabel(e.Key)
+	return value, ok
+}
+
+// String returns the affinity as a string.
+func (a *Affinity) String() string {
+	kind := ""
+	if a.Weight < 0 {
+		kind = "anti-"
+	}
+	return fmt.Sprintf("<%saffinity: scope %s %s => %d>",
+		kind, a.Scope.String(), a.Match.String(), a.Weight)
+}
+
+// String returns the expression as a string.
+func (e *Expression) String() string {
+	return fmt.Sprintf("<%s %s %s>", e.Key, e.Op, strings.Join(e.Values, ","))
+}
+
+// Try to parse affinities in simplified notation from the given annotation value.
+func (pca *podContainerAffinity) parseSimple(pod Pod, value string, weight int32) bool {
+	parsed := simpleAffinity{}
+	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
+		return false
+	}
+
+	podScope := pod.ScopeExpression()
+	for name, values := range parsed {
+		(*pca)[name] = append((*pca)[name],
+			&Affinity{
+				Scope: podScope,
+				Match: &Expression{
+					Key:    kubernetes.ContainerNameLabel,
+					Op:     In,
+					Values: values,
+				},
+				Weight: weight,
+			})
+	}
+
+	return true
+}
+
+// Try to parse affinities in full notation from the given annotation value.
+func (pca *podContainerAffinity) parseFull(pod Pod, value string, weight int32) error {
+	parsed := podContainerAffinity{}
+	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
+		return cacheError("failed to parse affinity annotation '%s': %v", value, err)
+	}
+
+	podScope := pod.ScopeExpression()
+	for name, pa := range parsed {
+		ca, ok := (*pca)[name]
+		if !ok {
+			ca = make([]*Affinity, 0, len(pa))
+		}
+		for _, a := range pa {
+			if a.Scope == nil {
+				a.Scope = podScope
+			}
+			if a.Weight == 0 {
+				a.Weight = weight
+			}
+
+			if err := a.Validate(); err != nil {
+				return err
+			}
+
+			ca = append(ca, a)
+		}
+		(*pca)[name] = ca
+	}
+
+	return nil
+}

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -144,6 +144,8 @@ const (
 
 // Container is the exposed interface from a cached container.
 type Container interface {
+	// PrettyName returns the user-friendly <podname>:<containername> for the container.
+	PrettyName() string
 	// GetPod returns the pod of the container.
 	GetPod() (Pod, bool)
 	// GetID returns the ID of the container.
@@ -375,9 +377,14 @@ type Cache interface {
 	// AbortTransaction discards container changes.
 	AbortTransaction()
 
+	// GetPods returns all the pods known to the cache.
+	GetPods() []Pod
+	// GetContainers returns all the containers known to the cache.
+	GetContainers() []Container
+
 	// GetContainerCacheIds returns the cache ids of all containers.
 	GetContainerCacheIds() []string
-	// GetContaineIds returne the ids of all containers.
+	// GetContaineIds return the ids of all containers.
 	GetContainerIds() []string
 
 	// SetPolicyEntry sets the policy entry for a key.
@@ -816,6 +823,27 @@ func (cch *cache) GetContainerIds() []string {
 	}
 
 	return ids[0:idx]
+}
+
+// GetPods returns all pods present in the cache.
+func (cch *cache) GetPods() []Pod {
+	pods := make([]Pod, 0, len(cch.Pods))
+	for _, pod := range cch.Pods {
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
+// GetContainers returns all the containers present in the cache.
+func (cch *cache) GetContainers() []Container {
+	containers := make([]Container, 0, len(cch.Containers)/2)
+	for id, container := range cch.Containers {
+		if id != container.CacheID {
+			continue
+		}
+		containers = append(containers, container)
+	}
+	return containers
 }
 
 // Set the policy entry for a key.

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -106,6 +106,10 @@ type Pod interface {
 	// necessary associated annotation put in place by the CRI resource manager
 	// webhook was found.
 	GetPodResourceRequirements() PodResourceRequirements
+	// GetContainerAffinity returns the affinity expressions for the named container.
+	GetContainerAffinity(string) []*Affinity
+	// ScopeExpression returns an affinity expression for defining this pod as the scope.
+	ScopeExpression() *Expression
 }
 
 // A cached pod.
@@ -122,6 +126,7 @@ type pod struct {
 	CgroupParent string            // cgroup parent directory
 
 	Resources *PodResourceRequirements // annotated resource requirements
+	Affinity  *podContainerAffinity    // annotated container affinity
 }
 
 // ContainerState is the container state in the runtime.
@@ -274,6 +279,9 @@ type Container interface {
 	UpdateCriCreateRequest(*cri.CreateContainerRequest) error
 	// CriUpdateRequest creates a CRI UpdateContainerResourcesRequest for the container.
 	CriUpdateRequest() (*cri.UpdateContainerResourcesRequest, error)
+
+	// GetAffinity returns the annotated affinity expressions for this container.
+	GetAffinity() []*Affinity
 }
 
 // A cached container.
@@ -386,6 +394,11 @@ type Cache interface {
 	GetContainerCacheIds() []string
 	// GetContaineIds return the ids of all containers.
 	GetContainerIds() []string
+
+	// FilterScope returns the containers selected by the scope expression.
+	FilterScope(*Expression) []Container
+	// EvaluateAffinity evaluates the given affinity against all known in-scope containers
+	EvaluateAffinity(*Affinity) map[string]int32
 
 	// SetPolicyEntry sets the policy entry for a key.
 	SetPolicyEntry(string, interface{})

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -688,3 +688,18 @@ func getKubeletHint(cpus, mems string) (ret sysfs.TopologyHints) {
 	}
 	return
 }
+
+func (c *container) GetAffinity() []*Affinity {
+	pod, ok := c.GetPod()
+	if !ok {
+		c.cache.Error("internal error: can't find Pod for container %s", c.PrettyName())
+	}
+
+	affinity := pod.GetContainerAffinity(c.GetName())
+	c.cache.Debug("affinity for container %s:", c.PrettyName())
+	for _, a := range affinity {
+		c.cache.Debug("  - %s", a.String())
+	}
+
+	return affinity
+}

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -211,6 +211,14 @@ func (c *container) CriUpdateRequest() (*cri.UpdateContainerResourcesRequest, er
 	}, nil
 }
 
+func (c *container) PrettyName() string {
+	pod, ok := c.GetPod()
+	if !ok {
+		return c.PodID + ":" + c.Name
+	}
+	return pod.GetName() + ":" + c.Name
+}
+
 func (c *container) GetPod() (Pod, bool) {
 	pod, found := c.cache.Pods[c.PodID]
 	return pod, found

--- a/pkg/cri/resource-manager/kubernetes/kubernetes.go
+++ b/pkg/cri/resource-manager/kubernetes/kubernetes.go
@@ -16,9 +16,21 @@ limitations under the License.
 
 package kubernetes
 
+import (
+	core "k8s.io/kubernetes/pkg/apis/core"
+	kubelet "k8s.io/kubernetes/pkg/kubelet/types"
+)
+
 const (
 	// ResmgrKeyNamespace is a CRI Resource Manager namespace
 	ResmgrKeyNamespace = "cri-resource-manager.intel.com"
+
+	// NamespaceSystem is the kubernetes system namespace.
+	NamespaceSystem = core.NamespaceSystem
+	// PodNameLabel is the label key for the kubernetes pod name.
+	PodNameLabel = kubelet.KubernetesPodNameLabel
+	// ContainerNameLabel is the label key for the kubernetes container name.
+	ContainerNameLabel = kubelet.KubernetesContainerNameLabel
 )
 
 // ResmgrKey returns a full namespaced name of a resource manager specific key

--- a/pkg/cri/resource-manager/policy.go
+++ b/pkg/cri/resource-manager/policy.go
@@ -340,7 +340,7 @@ func (m *resmgr) updateContainer(ctx context.Context, c cache.Container) error {
 
 	req, err := c.CriUpdateRequest()
 	if err != nil {
-		return resmgrError("can't update container %s: %v", c.GetCacheID(), err)
+		return resmgrError("can't update container %s: %v", c.PrettyName(), err)
 	}
 
 	_, err = m.relay.Client().UpdateContainerResources(ctx, req)

--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -112,13 +112,13 @@ func (eda *eda) AllocateResources(c cache.Container) error {
 
 // ReleaseResources is a resource release request for this policy.
 func (eda *eda) ReleaseResources(c cache.Container) error {
-	eda.Debug("releasing resources of container %s...", c.GetCacheID())
+	eda.Debug("releasing resources of container %s...", c.PrettyName())
 	return nil
 }
 
 // UpdateResources is a resource allocation update request for this policy.
 func (eda *eda) UpdateResources(c cache.Container) error {
-	eda.Debug("updating resource allocations of container %s...", c.GetCacheID())
+	eda.Debug("updating resource allocations of container %s...", c.PrettyName())
 	return nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -64,19 +64,19 @@ func (n *none) Sync(add []cache.Container, del []cache.Container) error {
 
 // AllocateResources is a resource allocation request for this policy.
 func (n *none) AllocateResources(c cache.Container) error {
-	n.Debug("(not) allocating container %s...", c.GetCacheID())
+	n.Debug("(not) allocating container %s...", c.PrettyName())
 	return nil
 }
 
 // ReleaseResources is a resource release request for this policy.
 func (n *none) ReleaseResources(c cache.Container) error {
-	n.Debug("(not) releasing container %s...", c.GetCacheID())
+	n.Debug("(not) releasing container %s...", c.PrettyName())
 	return nil
 }
 
 // UpdateResources is a resource allocation update request for this policy.
 func (n *none) UpdateResources(c cache.Container) error {
-	n.Debug("(not) updating container %s...", c.GetCacheID())
+	n.Debug("(not) updating container %s...", c.PrettyName())
 	return nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -162,7 +162,7 @@ func (p *staticplus) ReleaseResources(c cache.Container) error {
 
 // UpdateResources is a resource allocation update request for this policy.
 func (p *staticplus) UpdateResources(c cache.Container) error {
-	p.Debug("(not) updating container %s...", c.GetCacheID())
+	p.Debug("(not) updating container %s...", c.PrettyName())
 	return nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -234,14 +234,14 @@ func (stp *stp) AllocateResources(c cache.Container) error {
 
 // ReleaseResources is a resource release request for this policy.
 func (stp *stp) ReleaseResources(c cache.Container) error {
-	stp.Debug("releasing resources of container %s...", c.GetCacheID())
+	stp.Debug("releasing resources of container %s...", c.PrettyName())
 	stp.releaseStpResources(c.GetCacheID())
 	return nil
 }
 
 // UpdateResources is a resource allocation update request for this policy.
 func (stp *stp) UpdateResources(c cache.Container) error {
-	stp.Debug("updating resource allocations of container %s...", c.GetCacheID())
+	stp.Debug("updating resource allocations of container %s...", c.PrettyName())
 	return nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -138,7 +138,7 @@ func (s *static) Sync(add []cache.Container, del []cache.Container) error {
 
 // AllocateResources is a resource allocation request for this policy.
 func (s *static) AllocateResources(c cache.Container) error {
-	s.Info("allocating resource for container %s...", c.GetCacheID())
+	s.Info("allocating resource for container %s...", c.PrettyName())
 
 	container := c
 	containerID := c.GetCacheID()
@@ -154,7 +154,7 @@ func (s *static) AllocateResources(c cache.Container) error {
 
 // ReleaseResources is a resource release request for this policy.
 func (s *static) ReleaseResources(c cache.Container) error {
-	s.Info("releasing resources of container %s...", c.GetCacheID())
+	s.Info("releasing resources of container %s...", c.PrettyName())
 
 	containerID := c.GetCacheID()
 	err := s.RemoveContainer(containerID)
@@ -164,7 +164,7 @@ func (s *static) ReleaseResources(c cache.Container) error {
 
 // UpdateResources is a resource allocation update request for this policy.
 func (s *static) UpdateResources(c cache.Container) error {
-	s.Debug("(not) updating container %s...", c.GetCacheID())
+	s.Debug("(not) updating container %s...", c.PrettyName())
 	return nil
 }
 
@@ -670,7 +670,7 @@ func (s *static) SetCpusetCpus(id, value string) error {
 	}
 
 	c.SetCpusetCpus(value)
-	s.Info("container %s/%s: CpusetCpus set to %s", c.GetCacheID(), c.GetID(), value)
+	s.Info("container %s: CpusetCpus set to %s", c.PrettyName(), value)
 
 	return nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
@@ -39,8 +39,8 @@ type CPUSupply interface {
 	AccountAllocate(CPUGrant)
 	// AccountRelease accounts for (reinserts) released exclusive capacity into the supply.
 	AccountRelease(CPUGrant)
-	// Score calculates how well this supply fits/fulfills the given request.
-	Score(CPURequest) float64
+	// GetScore calculates how well this supply fits/fulfills the given request.
+	GetScore(CPURequest) CPUScore
 	// Allocate allocates CPU capacity from this supply and returns it as a grant.
 	Allocate(CPURequest) (CPUGrant, error)
 	// Release releases a previously allocated grant.
@@ -55,6 +55,15 @@ type CPURequest interface {
 	GetContainer() cache.Container
 	// String returns a printable representation of this request.
 	String() string
+
+	// FullCPUs return the number of full CPUs requested.
+	FullCPUs() int
+	// CPUFraction returns the amount of fractional milli-CPU requested.
+	CPUFraction() int
+	// Isolate returns whether isolated CPUs are preferred for this request.
+	Isolate() bool
+	// Elevate returns the requested elevation/allocation displacement for this request.
+	Elevate() int
 }
 
 // CPUGrant represents CPU capacity allocated to a container from a node.
@@ -75,7 +84,24 @@ type CPUGrant interface {
 	String() string
 }
 
-// cpuSupply implements our CpuSupply interface.
+// CPUScore represents how well a supply can satisfy a request.
+type CPUScore interface {
+	// Calculate the actual score from the collected parameters.
+	Eval() float64
+	// CPUSupply returns the supply associated with this score.
+	CPUSupply() CPUSupply
+	// CPURequest returns the request associated with this score.
+	CPURequest() CPURequest
+
+	IsolatedCapacity() int
+	SharedCapacity() int
+	Colocated() int
+	HintScores() map[string]float64
+
+	String() string
+}
+
+// cpuSupply implements our CPUSupply interface.
 type cpuSupply struct {
 	node     Node          // node supplying CPUs
 	isolated cpuset.CPUSet // isolated CPUs at this node
@@ -90,8 +116,6 @@ type cpuRequest struct {
 	container cache.Container // container for this request
 	full      int             // number of full CPUs requested
 	fraction  int             // amount of fractional CPU requested
-	exclusive int             // full CPUs requested
-	shared    int             // partial CPU requested in milli-CPUs
 	isolate   bool            // prefer isolated exclusive CPUs
 	elevate   int             // displace allocation up in the tree
 }
@@ -107,6 +131,18 @@ type cpuGrant struct {
 }
 
 var _ CPUGrant = &cpuGrant{}
+
+// cpuScore implements our CPUScore interface.
+type cpuScore struct {
+	supply    CPUSupply          // CPU supply (node)
+	request   CPURequest         // CPU request (container)
+	isolated  int                // remaining isolated CPUs
+	shared    int                // remaining shared capacity
+	colocated int                // number of colocated containers
+	hints     map[string]float64 // hint scores
+}
+
+var _ CPUScore = &cpuScore{}
 
 // newCPUSupply creates CPU supply for the given node, cpusets and existing grant.
 func newCPUSupply(n Node, isolated, sharable cpuset.CPUSet, granted int) CPUSupply {
@@ -176,109 +212,6 @@ func (cs *cpuSupply) AccountRelease(g CPUGrant) {
 	sharable := grantcpus.Intersection(ncs.SharableCPUs())
 	cs.isolated = cs.isolated.Union(isolated)
 	cs.sharable = cs.sharable.Union(sharable)
-}
-
-// Score calculates the fitting score of a request for this supply.
-func (cs *cpuSupply) Score(r CPURequest) float64 {
-	var score, hscore float64
-
-	cr := r.(*cpuRequest)
-	hints := cr.container.GetTopologyHints()
-
-	pod, _ := cr.container.GetPod()
-	fakekey := pod.GetName() + ":" + cr.container.GetName()
-	if fake, ok := opt.Hints[fakekey]; ok {
-		for src, fh := range fake {
-			hints[src] = fh
-		}
-	}
-	if fake, ok := opt.Hints[cr.container.GetName()]; ok {
-		for src, fh := range fake {
-			hints[src] = fh
-		}
-	}
-
-	log.Debug("* scoring %s (for %s)", cs.String(), cr.String())
-	if len(hints) > 0 {
-		log.Debug("  - with topology hints:")
-		for _, h := range hints {
-			log.Debug("   %s", h.String())
-		}
-	} else {
-		log.Debug("  - without topology hints...")
-	}
-
-	full, part, isolate := cr.full, cr.fraction, cr.isolate
-
-	if full == 0 && part == 0 {
-		part = 1
-		isolate = false
-	}
-
-	granted := cs.node.GrantedCPU()
-	hisolated := cs.maskByHints(cs.isolated, hints)
-	hsharable := cs.maskByHints(cs.sharable, hints)
-	hgranted := float64(hsharable.Size()) / float64(cs.sharable.Size()) * float64(granted)
-
-	// hint-score is how big portion of the request we can do in a hint-satisfying manner
-
-	switch {
-	// no exclusive capacity
-	case isolate && (cs.isolated.Size() < full && 1000*cs.sharable.Size()-granted < 1000*full):
-		log.Debug("  - no spare isolated or slicable exclusive capacity: score 0.0")
-		score = 0.0
-
-		// no shared capacity
-	case 1000*cs.sharable.Size()-granted < part:
-		log.Debug("  - no spare shared capacity: score 0.0")
-		score = 0.0
-
-		// perfect isolated exclusive fit
-	case isolate && (full > 0 && part == 0 && cs.isolated.Size() >= full):
-		log.Debug("  - perfect isolated exclusive fit: score 1.0")
-		score = 1.0
-		hscore = float64(hisolated.Size()) / float64(full)
-
-		// perfect shared-only fit
-	case full == 0 && 1000*cs.sharable.Size()-granted >= part:
-		log.Debug("  - perfect sharable fit: score 1.0")
-		score = 1.0
-		if part == 0 {
-			hscore = 1.0
-		} else {
-			hscore = (float64(hsharable.Size()) - hgranted) / float64(part)
-		}
-
-		// perfect isolated + shared fit
-	case isolate && (full > 0 && part > 0 &&
-		cs.isolated.Size() >= full && 1000*cs.sharable.Size()-granted >= part):
-		log.Debug("  - perfect isolated + shared fit: score 1.0")
-		score = 1.0
-
-		hscore = (float64(1000*hisolated.Size()+1000*hsharable.Size()) - hgranted) /
-			float64(1000*full+part)
-
-		// will need to slice off sharable capacity for exclusive usage:
-	default:
-		log.Debug("  - need to slice of %d sharable CPUs", full)
-		score = 1.0
-
-		hscore = (float64(1000*hsharable.Size()) - hgranted - float64(1000*full-part)) /
-			float64(1000*full+part)
-	}
-
-	if hscore > 1 {
-		hscore = 1
-	}
-	if hscore < 0 {
-		hscore = 0
-	}
-
-	log.Debug("  => score: %f, hint-score: %f => score: %f", score, hscore, score*hscore)
-
-	score = score * hscore
-
-	return score
 }
 
 // Allocate allocates a grant from the supply.
@@ -384,20 +317,135 @@ func (cr *cpuRequest) String() string {
 	isolated := map[bool]string{false: "", true: "isolated "}[cr.isolate]
 	switch {
 	case cr.full == 0 && cr.fraction == 0:
-		return fmt.Sprintf("<CPU request " + cr.container.GetCacheID() + ": ->")
+		return fmt.Sprintf("<CPU request " + cr.container.PrettyName() + ": ->")
 
 	case cr.full > 0 && cr.fraction > 0:
-		return fmt.Sprintf("<CPU request "+cr.container.GetCacheID()+": "+
+		return fmt.Sprintf("<CPU request "+cr.container.PrettyName()+": "+
 			"%sfull: %d, shared: %d>", isolated, cr.full, cr.fraction)
 
 	case cr.full > 0:
 		return fmt.Sprintf("<CPU request "+
-			cr.container.GetCacheID()+": %sfull: %d>", isolated, cr.full)
+			cr.container.PrettyName()+": %sfull: %d>", isolated, cr.full)
 
 	default:
 		return fmt.Sprintf("<CPU request "+
-			cr.container.GetCacheID()+": shared: %d>", cr.fraction)
+			cr.container.PrettyName()+": shared: %d>", cr.fraction)
 	}
+}
+
+// FullCPUs return the number of full CPUs requested.
+func (cr *cpuRequest) FullCPUs() int {
+	return cr.full
+}
+
+// CPUFraction returns the amount of fractional milli-CPU requested.
+func (cr *cpuRequest) CPUFraction() int {
+	return cr.fraction
+}
+
+// Isolate returns whether isolated CPUs are preferred for this request.
+func (cr *cpuRequest) Isolate() bool {
+	return cr.isolate
+}
+
+// Elevate returns the requested elevation/allocation displacement for this request.
+func (cr *cpuRequest) Elevate() int {
+	return cr.elevate
+}
+
+// Score collects data for scoring this supply wrt. the given request.
+func (cs *cpuSupply) GetScore(request CPURequest) CPUScore {
+	score := &cpuScore{
+		supply:  cs,
+		request: request,
+	}
+
+	cr := request.(*cpuRequest)
+	full, part := cr.full, cr.fraction
+	if full == 0 && part == 0 {
+		part = 1
+	}
+
+	// calculate free shared capacity
+	score.shared = 1000*cs.sharable.Size() - cs.node.GrantedCPU()
+
+	// calculate isolated node capacity CPU
+	if cr.isolate {
+		score.isolated = cs.isolated.Size() - full
+	}
+
+	// if we don't want isolated or there is not enough, calculate slicable capacity
+	if !cr.isolate || score.isolated < 0 {
+		score.shared -= 1000 * full
+	}
+
+	// calculate fractional capacity
+	score.shared -= part
+
+	// calculate colocation score
+	for _, grant := range cs.node.Policy().allocations.CPU {
+		if grant.GetNode().NodeID() == cs.node.NodeID() {
+			score.colocated++
+		}
+	}
+
+	// calculate real hint scores
+	hints := cr.container.GetTopologyHints()
+	score.hints = make(map[string]float64, len(hints))
+
+	for provider, hint := range cr.container.GetTopologyHints() {
+		score.hints[provider] = cs.node.HintScore(hint)
+	}
+
+	// calculate any fake hint scores
+	pod, _ := cr.container.GetPod()
+	key := pod.GetName() + ":" + cr.container.GetName()
+	if fakeHints, ok := opt.Hints[key]; ok {
+		for provider, hint := range fakeHints {
+			score.hints[provider] = cs.node.HintScore(hint)
+		}
+	}
+	if fakeHints, ok := opt.Hints[cr.container.GetName()]; ok {
+		for provider, hint := range fakeHints {
+			score.hints[provider] = cs.node.HintScore(hint)
+		}
+	}
+
+	return score
+}
+
+// Eval...
+func (score *cpuScore) Eval() float64 {
+	return 1.0
+}
+
+func (score *cpuScore) CPUSupply() CPUSupply {
+	return score.supply
+}
+
+func (score *cpuScore) CPURequest() CPURequest {
+	return score.request
+}
+
+func (score *cpuScore) IsolatedCapacity() int {
+	return score.isolated
+}
+
+func (score *cpuScore) SharedCapacity() int {
+	return score.shared
+}
+
+func (score *cpuScore) Colocated() int {
+	return score.colocated
+}
+
+func (score *cpuScore) HintScores() map[string]float64 {
+	return score.hints
+}
+
+func (score *cpuScore) String() string {
+	return fmt.Sprintf("<CPU score: node %s, isolated:%d, shared:%d, colocated:%d>",
+		score.supply.GetNode().Name(), score.isolated, score.shared, score.colocated)
 }
 
 // newCPUGrant creates a CPU grant from the given node for the container.
@@ -428,7 +476,6 @@ func (cg *cpuGrant) ExclusiveCPUs() cpuset.CPUSet {
 // SharedCPUs returns the shared CPUSet in this grant.
 func (cg *cpuGrant) SharedCPUs() cpuset.CPUSet {
 	return cg.node.GetCPU().SharableCPUs()
-	//return cg.shared
 }
 
 // SharedPortion returns the milli-CPU allocation for the shared CPUSet in this grant.
@@ -460,7 +507,7 @@ func (cg *cpuGrant) String() string {
 	}
 
 	return fmt.Sprintf("<CPU grant for %s from %s: %s%s%s>",
-		cg.container.GetCacheID(), cg.node.Name(), isolated, exclusive, shared)
+		cg.container.PrettyName(), cg.node.Name(), isolated, exclusive, shared)
 }
 
 // takeCPUs takes up to cnt CPUs from a given CPU set to another.

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
@@ -102,7 +102,7 @@ func podSharedCPUPreference(pod cache.Pod, container cache.Container) (bool, int
 func cpuAllocationPreferences(pod cache.Pod, container cache.Container) (int, int, bool, int) {
 	req, ok := container.GetResourceRequirements().Requests[corev1.ResourceCPU]
 	if !ok {
-		return 0, 0, true, 0
+		return 0, 0, false, 0
 	}
 
 	qos := pod.GetQOSClass()

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
@@ -15,7 +15,7 @@
 package topologyaware
 
 import (
-	"encoding/json"
+	"github.com/ghodss/yaml"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +42,7 @@ func podIsolationPreference(pod cache.Pod, container cache.Container) (bool, boo
 	}
 
 	preferences := map[string]bool{}
-	if err := json.Unmarshal([]byte(value), &preferences); err != nil {
+	if err := yaml.Unmarshal([]byte(value), &preferences); err != nil {
 		log.Error("failed to parse isolation preference %s = '%s': %v",
 			keyIsolationPreference, value, err)
 		return opt.PreferIsolated, false
@@ -69,7 +69,7 @@ func podSharedCPUPreference(pod cache.Pod, container cache.Container) (bool, int
 	}
 
 	preferences := map[string]string{}
-	if err := json.Unmarshal([]byte(value), &preferences); err != nil {
+	if err := yaml.Unmarshal([]byte(value), &preferences); err != nil {
 		log.Error("failed to parse shared CPU preference %s = '%s': %v",
 			keySharedCPUPreference, value, err)
 		return opt.PreferShared, 0

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -120,12 +120,12 @@ func (p *policy) Sync(add []cache.Container, del []cache.Container) error {
 
 // AllocateResources is a resource allocation request for this policy.
 func (p *policy) AllocateResources(container cache.Container) error {
-	log.Debug("allocating resources for %s...", container.GetCacheID())
+	log.Debug("allocating resources for %s...", container.PrettyName())
 
 	grant, err := p.allocatePool(container)
 	if err != nil {
 		return policyError("failed to allocate resources for %s: %v",
-			container.GetCacheID(), err)
+			container.PrettyName(), err)
 	}
 
 	if err := p.applyGrant(grant); err != nil {
@@ -139,7 +139,7 @@ func (p *policy) AllocateResources(container cache.Container) error {
 
 	if err := p.updateSharedAllocations(grant); err != nil {
 		log.Warn("failed to update shared allocations affected by %s: %v",
-			container.GetCacheID(), err)
+			container.PrettyName(), err)
 	}
 
 	p.root.Dump("<post-alloc>")
@@ -149,18 +149,18 @@ func (p *policy) AllocateResources(container cache.Container) error {
 
 // ReleaseResources is a resource release request for this policy.
 func (p *policy) ReleaseResources(container cache.Container) error {
-	log.Debug("releasing resources of %s...", container.GetCacheID())
+	log.Debug("releasing resources of %s...", container.PrettyName())
 
 	grant, found, err := p.releasePool(container)
 	if err != nil {
 		return policyError("failed to release resources of %s: %v",
-			container.GetCacheID(), err)
+			container.PrettyName(), err)
 	}
 
 	if found {
 		if err = p.updateSharedAllocations(grant); err != nil {
 			log.Warn("failed to update shared allocations affected by %s: %v",
-				container.GetCacheID(), err)
+				container.PrettyName(), err)
 		}
 	}
 
@@ -171,7 +171,7 @@ func (p *policy) ReleaseResources(container cache.Container) error {
 
 // UpdateResources is a resource allocation update request for this policy.
 func (p *policy) UpdateResources(c cache.Container) error {
-	log.Debug("(not) updating container %s...", c.GetCacheID())
+	log.Debug("(not) updating container %s...", c.PrettyName())
 	return nil
 }
 


### PR DESCRIPTION
    Using the new pod level affinity and anti-affinity annotations
    one can assign signed weights to pairs of containers running on
    the node.
    
    This should allow policies to let users express soft 'pull' and
    'push' preferences between containers. Containers that pull each
    other should be put close together and containers that push each
    other should be put apart from each other wrt. HW-topology.
    
    The topology-aware policy implements this semantics in its container
    placement algorithm. Of course, policies are free to define/use any
    other semantics for affinity as they see fit.
    
    Here is an example of an annotation which defines an affinity
    from container4 to container1 and 3, and anti-affinity to
    container2.
    
    metadata:
      name: "test-affinity"
      annotations:
        cri-resource-manager.intel.com/affinity: |
          container4: [ container1, container3 ]
        cri-resource-manager.intel.com/anti-affinity: |
          container4: [ container2 ]
