### PR TITLE
topology-aware: fix omitted memory pinning.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -173,6 +173,7 @@ func (p *policy) applyGrant(grant CPUGrant) error {
 
 	if mems != "" {
 		log.Debug("  => pinning to memory %s", mems)
+		container.SetCpusetMems(mems)
 	} else {
 		log.Debug("  => not pinning memory, memory set is empty...")
 	}


### PR DESCRIPTION
Don't just log about memory pinning, pin it for real.