### PR TITLE
fixes: update state of started container

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -163,6 +163,8 @@ type Container interface {
 	GetName() string
 	// GetNamespace returns the namespace of the container.
 	GetNamespace() string
+	// UpdateState updates the state of the container.
+	UpdateState(ContainerState)
 	// GetState returns the ContainerState of the container.
 	GetState() ContainerState
 	// GetQOSClass returns the QoS class the pod would have if this was its only container.

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -244,6 +244,10 @@ func (c *container) GetNamespace() string {
 	return c.Namespace
 }
 
+func (c *container) UpdateState(state ContainerState) {
+	c.State = state
+}
+
 func (c *container) GetState() ContainerState {
 	return c.State
 }

--- a/pkg/cri/resource-manager/policy.go
+++ b/pkg/cri/resource-manager/policy.go
@@ -266,6 +266,11 @@ func (m *resmgr) processWithPolicy(ctx context.Context, method string, req inter
 		rpl, err := handler(ctx, req)
 
 		m.Info("StartContainerRequest response %v", rpl)
+
+		if err == nil {
+			c.UpdateState(cache.ContainerStateRunning)
+		}
+
 		policyErr := m.policy.PostStart(c)
 		if policyErr != nil {
 			m.Warn("failed to update affected container %s: %v", c.GetID(), policyErr)


### PR DESCRIPTION
Update the state of a container to 'running' if/when it has been successfully started.