### PR TITLE
rdt: make it possible to specify L3 and/or MB optional

### DIFF
--- a/pkg/cri/resource-manager/config/defaults.go
+++ b/pkg/cri/resource-manager/config/defaults.go
@@ -17,20 +17,37 @@ limitations under the License.
 package config
 
 var defaultRdtRawConf = `{
+  "options": {
+    "l3": {
+      "optional": true
+    },
+    "mb": {
+      "optional": true
+    }
+  },
   "resctrlGroups": {
     "Guaranteed": {
-	  "l3schema": {
+      "l3schema": {
         "all": "100%"
+      },
+      "mbschema": {
+        "all": 100
       }
     },
     "Burstable": {
-	  "l3schema": {
+      "l3schema": {
         "all": "100%"
+      },
+      "mbschema": {
+        "all": 100
       }
     },
     "BestEffort": {
-	  "l3schema": {
+      "l3schema": {
         "all": "100%"
+      },
+      "mbschema": {
+        "all": 100
       }
     }
   }

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/utils"
 )
 
 const (
@@ -59,15 +59,6 @@ type stp struct {
 }
 
 var _ policy.Backend = &stp{}
-
-// Dump json-compatible struct in human-readable form
-func stringify(r interface{}) string {
-	out, err := yaml.Marshal(r)
-	if err != nil {
-		return fmt.Sprintf("!!!!!\nUnable to stringify %T: %v\n!!!!!", r, err)
-	}
-	return string(out)
-}
 
 //
 // Policy backend implementation
@@ -108,7 +99,7 @@ func CreateStpPolicy(opts *policy.BackendOptions) policy.Backend {
 		stp.Fatal("No STP policy configuration loaded")
 	}
 
-	stp.Debug("policy configuration:\n%s", stringify(stp.conf))
+	stp.Debug("policy configuration:\n%s", utils.DumpJSON(stp.conf))
 
 	return stp
 }
@@ -135,7 +126,7 @@ func (stp *stp) Start(cch cache.Cache, add []cache.Container, del []cache.Contai
 	if err := stp.initializeState(cch); err != nil {
 		return err
 	}
-	stp.Debug("retrieved stp container states from cache:\n%s", stringify(*stp.getContainerRegistry()))
+	stp.Debug("retrieved stp container states from cache:\n%s", utils.DumpJSON(*stp.getContainerRegistry()))
 
 	if err = stp.Sync(add, del); err != nil {
 		return err
@@ -268,7 +259,7 @@ func (stp *stp) SetConfig(conf string) error {
 
 	stp.Info("config updated successfully")
 	stp.conf = newConf
-	stp.Debug("new policy configuration:\n%s", stringify(stp.conf))
+	stp.Debug("new policy configuration:\n%s", utils.DumpJSON(stp.conf))
 	return nil
 }
 

--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -32,6 +32,22 @@ type ResctrlGroupConfig struct {
 	MBSchema MBSchema `json:"mbSchema,omitempty"`
 }
 
+// SchemaOptions contains the common settings for all resctrl groups
+type SchemaOptions struct {
+	L3 L3Options `json:"l3,omitempty"`
+	MB MBOptions `json:"mb,omitempty"`
+}
+
+// L3 contains the common settings for L3 cache allocation
+type L3Options struct {
+	Optional bool `json:"optional,omitempty"`
+}
+
+// MB contains the common settings for memory bandwidth allocation
+type MBOptions struct {
+	Optional bool `json:"optional,omitempty"`
+}
+
 // L3Schema represents an L3 part of the schemata of a resctrl group
 type L3Schema struct {
 	allocations map[uint64]CacheBitmask

--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -50,23 +50,23 @@ type MBOptions struct {
 
 // L3Schema represents an L3 part of the schemata of a resctrl group
 type L3Schema struct {
-	allocations map[uint64]CacheBitmask
+	Allocations map[uint64]CacheBitmask
 }
 
 // MBSchema represents an MB part of the schemata of a resctrl group
 type MBSchema struct {
-	allocations map[uint64]uint64
+	Allocations map[uint64]uint64
 }
 
 // IsNil returns true if the schema is empty
 func (s *L3Schema) IsNil() bool {
-	return s.allocations == nil
+	return s.Allocations == nil
 }
 
 // ToStr returns the L3 schema in a format accepted by the Linux kernel
 // resctrl (schemata) interface
 func (s *L3Schema) ToStr() string {
-	if len(s.allocations) == 0 {
+	if len(s.Allocations) == 0 {
 		return ""
 	}
 
@@ -74,7 +74,7 @@ func (s *L3Schema) ToStr() string {
 	sep := ""
 
 	// We get cache ids but that doesn't matter
-	for id, bitmask := range s.allocations {
+	for id, bitmask := range s.Allocations {
 		schema += fmt.Sprintf("%s%d=%x", sep, id, bitmask)
 		sep = ";"
 	}
@@ -104,7 +104,7 @@ func (s *L3Schema) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s.allocations = map[uint64]CacheBitmask{}
+	s.Allocations = map[uint64]CacheBitmask{}
 
 	// Set default allocations
 	defaultMask, ok := allocations["all"]
@@ -115,7 +115,7 @@ func (s *L3Schema) UnmarshalJSON(b []byte) error {
 	delete(allocations, "all")
 
 	for _, i := range rdtInfo.cacheIds {
-		s.allocations[i] = defaultMask
+		s.Allocations[i] = defaultMask
 	}
 
 	// Parse per-cacheId allocations
@@ -125,8 +125,8 @@ func (s *L3Schema) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		for _, id := range ids {
-			if _, ok := s.allocations[uint64(id)]; ok {
-				s.allocations[uint64(id)] = mask
+			if _, ok := s.Allocations[uint64(id)]; ok {
+				s.Allocations[uint64(id)] = mask
 			}
 		}
 	}
@@ -136,7 +136,7 @@ func (s *L3Schema) UnmarshalJSON(b []byte) error {
 
 // IsNil returns true if the schema is empty
 func (s *MBSchema) IsNil() bool {
-	return s.allocations == nil
+	return s.Allocations == nil
 }
 
 // ToStr returns the MB schema in a format accepted by the Linux kernel
@@ -146,7 +146,7 @@ func (s *MBSchema) ToStr() string {
 	sep := ""
 
 	// We get cache ids but that doesn't matter
-	for id, percentage := range s.allocations {
+	for id, percentage := range s.Allocations {
 		schema += fmt.Sprintf("%s%d=%d", sep, id, percentage)
 		sep = ";"
 	}
@@ -176,7 +176,7 @@ func (s *MBSchema) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s.allocations = map[uint64]uint64{}
+	s.Allocations = map[uint64]uint64{}
 
 	// Set default allocations
 	defaultVal, ok := allocations["all"]
@@ -187,7 +187,7 @@ func (s *MBSchema) UnmarshalJSON(b []byte) error {
 	delete(allocations, "all")
 
 	for _, i := range rdtInfo.cacheIds {
-		s.allocations[i] = defaultVal
+		s.Allocations[i] = defaultVal
 	}
 
 	// Parse per-cacheId allocations
@@ -197,8 +197,8 @@ func (s *MBSchema) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		for _, id := range ids {
-			if _, ok := s.allocations[uint64(id)]; ok {
-				s.allocations[uint64(id)] = val
+			if _, ok := s.Allocations[uint64(id)]; ok {
+				s.Allocations[uint64(id)] = val
 			}
 		}
 	}

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/utils"
 )
 
 const resctrlGroupPrefix = "cri-resmgr."
@@ -129,6 +130,8 @@ func (r *control) SetConfig(newConfRaw string) error {
 }
 
 func (r *control) configureResctrl(conf config) error {
+	r.Debug("applying new configuration:\n%s", utils.DumpJSON(conf))
+
 	// Remove stale resctrl groups
 	existingGroups, err := r.getResctrlGroups()
 	if err != nil {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -53,6 +53,7 @@ type control struct {
 }
 
 type config struct {
+	Options       SchemaOptions                 `json:"options,omitempty"`
 	ResctrlGroups map[string]ResctrlGroupConfig `json:"resctrlGroups"`
 }
 
@@ -152,8 +153,8 @@ func (r *control) configureResctrl(conf config) error {
 	}
 
 	// Try to apply given configuration
-	for name, conf := range conf.ResctrlGroups {
-		err := r.configureResctrlGroup(name, conf)
+	for name, grpConf := range conf.ResctrlGroups {
+		err := r.configureResctrlGroup(name, grpConf, conf.Options)
 		if err != nil {
 			return err
 		}
@@ -172,27 +173,43 @@ func parseConfData(raw []byte) (config, error) {
 	return conf, nil
 }
 
-func (r *control) configureResctrlGroup(name string, config ResctrlGroupConfig) error {
+func (r *control) configureResctrlGroup(name string, config ResctrlGroupConfig, options SchemaOptions) error {
 	path := r.resctrlGroupPath(name)
 	if err := os.Mkdir(path, 0755); err != nil && !os.IsExist(err) {
 		return err
 	}
 
 	schemata := ""
-	if !config.L3Schema.IsNil() {
-		// User specified L3 allocation so use it
-		schemata += config.L3Schema.ToStr()
-	} else if rdtInfo.l3.Supported() {
-		// L3 is enabled but user did not specify a config -> use to defaults
-		schemata += config.L3Schema.DefaultStr()
+	if rdtInfo.l3.Supported() {
+		if !config.L3Schema.IsNil() {
+			// User specified L3 allocation so use it
+			schemata += config.L3Schema.ToStr()
+		} else {
+			// L3 is enabled but user did not specify a config -> use to defaults
+			schemata += config.L3Schema.DefaultStr()
+		}
+	} else if !config.L3Schema.IsNil() {
+		if options.L3.Optional {
+			r.Debug("omitting optional L3 schema")
+		} else {
+			return rdtError("L3 schema specified but not supported by the system")
+		}
 	}
 
-	if !config.MBSchema.IsNil() {
-		// User specified MB allocation so use it
-		schemata += config.MBSchema.ToStr()
-	} else if rdtInfo.mb.Supported() {
-		// MB is enabled but user did not specify a config -> use to defaults
-		schemata += config.MBSchema.DefaultStr()
+	if rdtInfo.mb.Supported() {
+		if !config.MBSchema.IsNil() {
+			// User specified MB allocation so use it
+			schemata += config.MBSchema.ToStr()
+		} else {
+			// MB is enabled but user did not specify a config -> use to defaults
+			schemata += config.MBSchema.DefaultStr()
+		}
+	} else if !config.MBSchema.IsNil() {
+		if options.MB.Optional {
+			r.Debug("omitting optional MB schema")
+		} else {
+			return rdtError("MB schema specified but not supported by the system")
+		}
 	}
 
 	if len(schemata) > 0 {

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+// DumpJSON dumps a json-compatible struct in human-readable form
+func DumpJSON(r interface{}) string {
+	out, err := yaml.Marshal(r)
+	if err != nil {
+		return fmt.Sprintf("!!!!!\nUnable to stringify %T: %v\n!!!!!", r, err)
+	}
+	return string(out)
+}

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -49,6 +49,12 @@ data:
           Socket: 3
         exclusive: false
   rdt: |+
+    # Common options
+    options:
+      l3:
+        optional: true
+      mb:
+        optional: true
     # This example config specifies three RDT classes (or resctrl groups) with L3
     # CAT configured
     resctrlGroups:


### PR DESCRIPTION
Adds a new 'options' section into the RDT configuration, targeted for
common RDT-related config options. Under 'options', the patch specifies
two sub-sections 'l3' and 'mb' which both have one boolean setting, i.e.
'optional'. This can be used to specify that the corresponding schema in
the group configurations is optional, i.e. it is simply ignored if not
supported by the system. This setting defaults to false which results in
an error in case the schema (L3 or MB) is specified in the group
configuration but the technology (L3 or MB allocation) is not available
in the underlying system.