### PR TITLE
static policy: add config setting for enabling/disabling RDT

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/flags.go
@@ -16,6 +16,7 @@ package static
 
 import (
 	"flag"
+	"strconv"
 
 	"github.com/ghodss/yaml"
 )
@@ -23,15 +24,53 @@ import (
 // Policy options configurable via the command line.
 type options struct {
 	// relax exclusive isolated CPU allocation criteria
-	RelaxedIsolation bool `json:"RelaxedIsolation"`
+	RelaxedIsolation bool     `json:"RelaxedIsolation"`
+	Rdt              Tristate `json:"Rdt"`
+}
+
+type Tristate int
+
+const (
+	TristateOff = iota
+	TristateOn
+	TristateAuto
+)
+
+// UnmarshalJSON implements the unmarshaller function for "encoding/json"
+func (t *Tristate) UnmarshalJSON(data []byte) error {
+	val, err := strconv.ParseBool(string(data))
+	switch {
+	case err != nil:
+		*t = TristateAuto
+	case val == true:
+		*t = TristateOn
+	default:
+		*t = TristateOff
+	}
+	return nil
+}
+
+// String returns the value of Tristate as a string
+func (t *Tristate) String() string {
+	switch *t {
+	case TristateOff:
+		return "off"
+	case TristateOn:
+		return "on"
+	}
+	return "auto"
 }
 
 // Policy options with their defaults.
-var opt = options{}
+var opt = options{
+	Rdt: TristateAuto,
+}
 
 // parseConfData parses options from a YAML data.
 func parseConfData(raw []byte) (*options, error) {
-	conf := &options{}
+	conf := &options{
+		Rdt: TristateAuto, // Rdt defaults to 'auto'
+	}
 
 	if len(raw) != 0 {
 		if err := yaml.Unmarshal(raw, conf); err != nil {

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -11,6 +11,7 @@ data:
     PreferSharedCPUs: false
   policy.static: |
     RelaxedIsolation: true
+    Rdt: auto
   policy.stp: |+
     # This is an example configuration file for the builtin cmk policy
     # The imaginary example system here consists of 4 sockets, 4 cores (8


### PR DESCRIPTION
Add a policy-level configuration setting for controlling RDT support.
The setting is tri-state:
- "off" disables RDT control from the policy
- "on" requires RDT support (error is returned if RDT is not
   enabled/available on lower layers)
- any other value means autodiscovery, i.e. RDT control is enabled if
  it's available
The setting defaults to 'auto'.