### PR TITLE
rdt: support L3 CDP

### DIFF
--- a/pkg/rdt/bitmask.go
+++ b/pkg/rdt/bitmask.go
@@ -34,7 +34,7 @@ type CacheBitmask Bitmask
 // UnmarshalJSON is the unmarshaller function for "encoding/json"
 func (b *CacheBitmask) UnmarshalJSON(data []byte) error {
 	// Number of bits available in CacheBitmask
-	cacheBitmaskNumBits := uint64(rdtInfo.l3.cbmMask.lsbZero())
+	cacheBitmaskNumBits := uint64(rdtInfo.l3FullMask().lsbZero())
 
 	// Drop string quotes
 	str := strings.TrimSpace(string(data[1 : len(data)-1]))

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -53,6 +53,13 @@ data:
     options:
       l3:
         optional: true
+      # If l3code or l3data is NOT set to optional CDP must be enabled in
+      # the system in case 'l3codeschema' and/or 'l3dataschema' are specified
+      # in the groups below
+      l3code:
+        optional: true
+      l3data:
+        optional: true
       mb:
         optional: true
     # This example config specifies three RDT classes (or resctrl groups) with L3
@@ -70,6 +77,11 @@ data:
       Burstable:
         l3schema:
           all: "66%"
+        # Separate schema for L3 code and data paths specified
+        l3codeschema:
+          all: "100%"
+        l3dataschema:
+          all: "50%"
     # MBA (Memory Bandwidth Allocation)
     #    mbschema:
     #      all: 66


### PR DESCRIPTION
Support L3 CDP, that is separate settings for L3 code and data paths.

The logic is such that if the configuration contains separate L3 code
and/or L3 data path setting we require that this is also supported by
the system - unless the corresponding 'optional' option(s) in the RDT
configuration has been set to true. The "unified" L3 schema is used as
a fallback value in case CDP is enabled in the system, but, either one
or both of the separate code/data settings is missing.