### PR TITLE
sysfs: fix topology unit tests for mockRoot vs. symlinks.

### DIFF
--- a/pkg/sysfs/topology_test.go
+++ b/pkg/sysfs/topology_test.go
@@ -28,6 +28,9 @@ func setupTestEnv(t *testing.T) func() {
 	if err != nil {
 		t.Fatal("unable to get current directory")
 	}
+	if path, err := filepath.EvalSymlinks(pwd); err == nil {
+		pwd = path
+	}
 	mockRoot = pwd + "/testdata"
 	teardown := func() {
 		mockRoot = ""


### PR DESCRIPTION
Without this patch topology tests fail if the repository happens to be cloned to/from s directory where $(pwd) contains any symlinks. Resolve symlinks in mockRoot to avoid this.