### PR TITLE
agent: rate-limit configuration update storms with a small lowpass filtering timeout.

### DIFF
--- a/pkg/agent/flags.go
+++ b/pkg/agent/flags.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"flag"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
 )
 
@@ -27,6 +28,7 @@ type options struct {
 	resmgrSocket  string
 	configNs      string
 	configMapName string
+	labelName     string
 }
 
 var opts = options{}
@@ -37,4 +39,5 @@ func init() {
 	flag.StringVar(&opts.kubeconfig, "kubeconfig", "", "Kubeconfig to use, empty string implies in-cluster config (i.e. running inside a Pod)")
 	flag.StringVar(&opts.configNs, "config-ns", "kube-system", "Kubernetes namespace where to look for config")
 	flag.StringVar(&opts.configMapName, "configmap-name", "cri-resmgr-config", "Name of the K8s ConfigMap to watch")
+	flag.StringVar(&opts.labelName, "label-name", kubernetes.ResmgrKey("group"), "Name of the label used to assign a node to a configuration group.")
 }

--- a/pkg/agent/kubernetes.go
+++ b/pkg/agent/kubernetes.go
@@ -20,17 +20,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	agent_v1 "github.com/intel/cri-resource-manager/pkg/agent/api/v1"
 )
+
+type namespace string
 
 // nodeName contains the name of the k8s we're running on
 var nodeName string
@@ -94,17 +97,169 @@ func patchNodeStatus(cli *k8sclient.Clientset, fields map[string]string) error {
 	return err
 }
 
-// watchConfigMap watches changes in a ConfigMap object
-func watchConfigMap(cli *k8sclient.Clientset, ns string, name string) (watch.Interface, error) {
-	listOpts := meta_v1.ListOptions{
-		FieldSelector: "metadata.name=" + name,
+// watch is a wrapper around the k8s watch.Interface
+type watch struct {
+	parent  *watcher
+	kind    string
+	ns      namespace
+	name    string
+	openfn  func(namespace, string) (k8swatch.Interface, error)
+	queryfn func(namespace, string) (interface{}, error)
+	stop    chan struct{}
+	events  chan k8swatch.Event
+}
+
+// openFn is the type for functions creating k8s watcher of a particular kind.
+type openFn func(ns namespace, name string) (k8swatch.Interface, error)
+
+// queryFn is the type for functions querying k8s objects being watched.
+type queryFn func(ns namespace, name string) (interface{}, error)
+
+const (
+	// SyntheticMissing is a synthetic initial event for currently non-existent object.
+	SyntheticMissing = k8swatch.EventType("SyntheticMissing")
+)
+
+func newWatch(parent *watcher, kind string, ns namespace, open openFn, query queryFn) *watch {
+	return &watch{
+		parent:  parent,
+		kind:    kind,
+		ns:      ns,
+		stop:    make(chan struct{}),
+		events:  make(chan k8swatch.Event),
+		openfn:  open,
+		queryfn: query,
 	}
-	watch, err := cli.CoreV1().ConfigMaps(ns).Watch(listOpts)
-	if err != nil {
-		return nil, agentError("failed to create a watch for configmaps in ns %q: %v", ns, err)
+}
+
+// newNodeWatch creates a watch for k8s Node
+func newNodeWatch(parent *watcher) *watch {
+	w := newWatch(parent, "Node", namespace(""),
+		func(ns namespace, name string) (k8swatch.Interface, error) {
+			selector := meta_v1.ListOptions{FieldSelector: "metadata.name=" + name}
+			k8w, err := parent.k8sCli.CoreV1().Nodes().Watch(selector)
+			if err != nil {
+				return nil, err
+			}
+			return k8w, nil
+		},
+		func(ns namespace, name string) (interface{}, error) {
+			noopts := meta_v1.GetOptions{}
+			node, err := parent.k8sCli.CoreV1().Nodes().Get(name, noopts)
+			if err != nil {
+				return nil, err
+			}
+			return node, nil
+		})
+	w.Start(nodeName)
+	return w
+}
+
+// newConfigMapWatch creates a watch for k8s ConfigMap
+func newConfigMapWatch(parent *watcher, name string, ns namespace) *watch {
+	w := newWatch(parent, "ConfigMap", ns,
+		func(ns namespace, name string) (k8swatch.Interface, error) {
+			selector := meta_v1.ListOptions{FieldSelector: "metadata.name=" + name}
+			k8w, err := parent.k8sCli.CoreV1().ConfigMaps(string(ns)).Watch(selector)
+			if err != nil {
+				return nil, err
+			}
+			return k8w, nil
+		},
+		func(ns namespace, name string) (interface{}, error) {
+			noopts := meta_v1.GetOptions{}
+			cm, err := parent.k8sCli.CoreV1().ConfigMaps(string(ns)).Get(name, noopts)
+			if err != nil {
+				return nil, err
+			}
+			return cm, nil
+		})
+	w.Start(name)
+	return w
+}
+
+func (w *watch) Name() string {
+	ns, name := w.ns, w.name
+	if ns != "" {
+		ns += "/"
+	}
+	if name == "" {
+		name = "<none>"
+	}
+	return w.kind + ":" + string(ns) + name
+}
+
+// Query queries the object being watched.
+func (w *watch) Query() (interface{}, error) {
+	if w.name == "" {
+		return nil, nil
+	}
+	return w.queryfn(w.ns, w.name)
+}
+
+// Start watching an object.
+func (w *watch) Start(name string) {
+	w.Stop()
+	w.name = name
+
+	if w.name == "" {
+		return
 	}
 
-	return watch, nil
+	// proxy events from a go-routing until we're told to stop.
+	go func() {
+		var k8w k8swatch.Interface
+		var events <-chan k8swatch.Event
+		var ratelimit <-chan time.Time
+		var err error
+
+		// let the watcher know not to expect initial event
+		if _, err = w.queryfn(w.ns, w.name); err != nil {
+			w.events <- k8swatch.Event{Type: SyntheticMissing}
+		}
+
+		for {
+			if events == nil {
+				w.parent.Info("creating %s watch", w.Name())
+				if k8w, err = w.openfn(w.ns, w.name); err != nil {
+					w.parent.Warn("failed to create %s watch: %v", w.Name(), err)
+					ratelimit = time.After(1 * time.Second)
+				} else {
+					events = k8w.ResultChan()
+					ratelimit = nil
+				}
+			}
+
+			select {
+			case _ = <-w.stop:
+				if events != nil {
+					k8w.Stop()
+				}
+				return
+			case e, ok := <-events:
+				if ok {
+					w.events <- e
+				} else {
+					k8w.Stop()
+					events = nil
+				}
+			case _ = <-ratelimit:
+			}
+		}
+	}()
+}
+
+// Close closes a watch.
+func (w *watch) Stop() {
+	select {
+	case w.stop <- struct{}{}:
+	default:
+	}
+}
+
+// ResultChan returns the event channel of the watch.
+func (w *watch) ResultChan() <-chan k8swatch.Event {
+	return w.events
 }
 
 func init() {


### PR DESCRIPTION
This PR is stacked on (includes) PR #52 .

Filter update storms by queuing them internally and passing forward after a short timeout.
Also always reply with success for configuration updates. The old behavior of replying with an error and then indefinitely trying to resubmit the exact same already rejected data does not make sense. We can start reporting configuration failures asynchronously once we figure out how and where to propagate the error back. In the stock agent case, it could be propagated back to the offending ConfigMap.