### PR TITLE
[WIP][RFC] Add k8s-native deployment as an alternative for cri-resmgr

### DIFF
--- a/cmd/cri-resmgr/Dockerfile
+++ b/cmd/cri-resmgr/Dockerfile
@@ -1,0 +1,45 @@
+# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
+# reproducible by choosing an image by its hash and installing an OS version
+# with --version=:
+# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
+# CLEAR_LINUX_VERSION="--version=29970"
+#
+# This is used on release branches before tagging a stable version.
+# The master branch defaults to using the latest Clear Linux.
+ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+
+FROM ${CLEAR_LINUX_BASE} as builder
+
+ARG CLEAR_LINUX_VERSION=
+
+RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+RUN swupd bundle-add make ${CLEAR_LINUX_VERSION}
+RUN mkdir /install_root \
+    && swupd os-install \
+    ${CLEAR_LINUX_VERSION} \
+    --path /install_root \
+    --statedir /swupd-state \
+    --bundles=os-core \
+    --no-boot-update \
+    && rm -rf /install_root/var/lib/swupd/*
+
+ARG DIR=/go/src/build
+WORKDIR $DIR
+ADD . $DIR
+
+ENV GO111MODULE=on GOFLAGS=-mod=vendor
+RUN make BUILD_DIRS=cri-resmgr
+
+FROM centos/systemd as final
+ARG DIR=/go/src/build
+COPY --from=builder /install_root /
+
+COPY --from=builder /go/src/build/bin/cri-resmgr /bin/cri-resmgr
+
+ADD cmd/cri-resmgr/cri-resource-manager.sysconf /config/cri-resource-manager.sysconf
+ADD cmd/cri-resmgr/cri-resource-manager.service /config/cri-resource-manager.service
+ADD cmd/cri-resmgr/bootstrap.sh /bin/bootstrap.sh
+ADD cmd/cri-resmgr/cleanup.sh /bin/cleanup.sh
+
+ENTRYPOINT ["/bin/bash", "-c", "/bin/bootstrap.sh"]
+

--- a/cmd/cri-resmgr/bootstrap.sh
+++ b/cmd/cri-resmgr/bootstrap.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+
+RUNNER=${RUNNER:-"containerd"}
+CRI_RESMGR_POLICY=${CRI_RESMGR_POLICY:-"null"}
+CRI_RESMGR_POLICY_OPTIONS=${CRI_RESMGR_POLICY_OPTIONS:-"-dump='reset,full:.*' -dump-file=/tmp/cri.dump"}
+CRI_RESMGR_DEBUG_OPTIONS=${CRI_RESMGR_DEBUG_OPTIONS:-""}
+
+
+
+runtime_socket=$(find /run/ -iname $RUNNER.sock | head -1)
+CRI_RESMGR_POLICY_OPTIONS+=" -runtime-socket=$runtime_socket -image-socket=$runtime_socket"
+
+
+cp -f /bin/cri-resmgr /host/usr/local/bin/cri-resmgr
+
+cp /config/cri-resource-manager.sysconf /host/etc/sysconfig/cri-resource-manager
+cp /config/cri-resource-manager.service /host/etc/systemd/system/cri-resource-manager.service
+
+sed -i "s|POLICY=.*|POLICY=$CRI_RESMGR_POLICY|" /host/etc/sysconfig/cri-resource-manager
+sed -i "s|POLICY_OPTIONS=.*|POLICY_OPTIONS=$CRI_RESMGR_POLICY_OPTIONS|" /host/etc/sysconfig/cri-resource-manager
+sed -i "s|DEBUG_OPTIONS=.*|DEBUG_OPTIONS=$CRI_RESMGR_DEBUG_OPTIONS|" /host/etc/sysconfig/cri-resource-manager
+
+systemctl daemon-reload
+systemctl restart cri-resource-manager
+
+mkdir -p /host/etc/systemd/system/kubelet.service.d/
+cat > /host/etc/systemd/system/kubelet.service.d/99-cri-resource-manager.conf <<EOF
+[Service]
+Environment=KUBELET_EXTRA_ARGS=
+Environment=KUBELET_EXTRA_ARGS="--container-runtime remote --container-runtime-endpoint unix:///var/run/cri-resmgr/cri-resmgr.sock"
+EOF
+
+mv /var/lib/kubelet/kubeadm-flags.env /var/lib/kubelet/kubeadm-flags.env.bkp
+
+systemctl daemon-reload
+systemctl restart kubelet
+
+#It is assumed this script will be called as a daemonset. As a result, do
+# not return, otherwise the daemon will restart and rexecute the script
+sleep infinity

--- a/cmd/cri-resmgr/cleanup.sh
+++ b/cmd/cri-resmgr/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -f /etc/systemd/system/kubelet.service.d/99-cri-resource-manager.conf
+
+if test -f "/var/lib/kubelet/kubeadm-flags.env.bkp"; then
+    mv /var/lib/kubelet/kubeadm-flags.env.bkp /var/lib/kubelet/kubeadm-flags.env
+fi
+
+systemctl daemon-reload
+systemctl restart kubelet

--- a/cmd/cri-resmgr/cleanup.yaml
+++ b/cmd/cri-resmgr/cleanup.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubelet-cri-resmgr-cleanup
+  namespace: kube-system
+spec:
+  selector:
+      matchLabels:
+        name: kubelet-cri-resmgr-cleanup
+  template:
+    metadata:
+        labels:
+          name: kubelet-cri-resmgr-cleanup
+    spec:
+      serviceAccountName: cri-resmgr-label-node
+      containers:
+      - name: kube-cri-resmgr-cleanup
+        image: obedmr/cri-resmgr
+        imagePullPolicy: Always
+        command: ["bash", "-c", "/bin/cleanup.sh"]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - name: etc
+          mountPath: /etc/systemd
+        - name: kubelet-data
+          mountPath: /var/lib/kubelet
+        - name: dbus
+          mountPath: /var/run/dbus
+        - name: systemd
+          mountPath: /run/systemd
+      volumes:
+        - name: etc
+          hostPath:
+            path: /etc/systemd
+        - name: kubelet-data
+          hostPath:
+            path: /var/lib/kubelet
+        - name: dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: systemd
+          hostPath:
+            path: /run/systemd
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/cmd/cri-resmgr/configmap.yaml
+++ b/cmd/cri-resmgr/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cri-resmgr-config
+  namespace: kube-system
+data:
+  runner: "containerd"
+  cri-resmg.policy: "null"
+  cri-resmg.policy-options: "-dump='reset,full:.*' -dump-file=/tmp/cri.dump"
+  cri-resmg.debub-options: ""

--- a/cmd/cri-resmgr/cri-resmgr-rbac.yaml
+++ b/cmd/cri-resmgr/cri-resmgr-rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cri-resmgr-label-node
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-labeler
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cri-resmgr-label-node-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-labeler
+subjects:
+- kind: ServiceAccount
+  name: cri-resmgr-label-node
+  namespace: kube-system
+

--- a/cmd/cri-resmgr/cri-resource-manager.service
+++ b/cmd/cri-resmgr/cri-resource-manager.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/intel/cri-resource-manager
 [Service]
 Type=simple
 EnvironmentFile=/etc/sysconfig/cri-resource-manager
-ExecStart=/usr/bin/cri-resmgr --policy $POLICY $POLICY_OPTIONS $DEBUG_OPTIONS
+ExecStart=/usr/local/bin/cri-resmgr --policy $POLICY $POLICY_OPTIONS $DEBUG_OPTIONS
 Restart=always
 
 [Install]

--- a/cmd/cri-resmgr/deployment.yaml
+++ b/cmd/cri-resmgr/deployment.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cri-resmgr-deploy
+  namespace: kube-system
+spec:
+  selector:
+      matchLabels:
+        name: cri-resmgr-deploy
+  template:
+    metadata:
+        labels:
+          name: cri-resmgr-deploy
+    spec:
+      serviceAccountName: cri-resmgr-label-node
+      containers:
+      - name: kube-cri-resmgr
+        image: obedmr/cri-resmgr
+        imagePullPolicy: Always
+        command: [ "bash", "-c", "/bin/bootstrap.sh" ]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: RUNNER
+          valueFrom:
+            configMapKeyRef:
+              name: cri-resmgr-config
+              key: runner
+        - name: CRI_RESMGR_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: cri-resmgr-config
+              key: cri-resmg.policy
+        - name: CRI_RESMGR_POLICY_OPTIONS
+          valueFrom:
+            configMapKeyRef:
+              name: cri-resmgr-config
+              key: cri-resmg.policy-options
+        - name: CRI_RESMGR_DEBUG_OPTIONS
+          valueFrom:
+            configMapKeyRef:
+              name: cri-resmgr-config
+              key: cri-resmg.debub-options
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - name: dbus
+          mountPath: /var/run/dbus
+        - name: run-path
+          mountPath: /run/
+        - name: systemd-config
+          mountPath: /host/etc/systemd/system/
+        - name: sysconfig
+          mountPath: /host/etc/sysconfig
+        - name: kubelet-data
+          mountPath: /var/lib/kubelet
+        - name: usr-local-bin
+          mountPath: /host/usr/local/bin
+      volumes:
+        - name: dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: run-path
+          hostPath:
+            path: /run/
+        - name: systemd-config
+          hostPath:
+            path: /etc/systemd/system/
+        - name: sysconfig
+          hostPath:
+            path: /etc/sysconfig
+        - name: kubelet-data
+          hostPath:
+            path: /var/lib/kubelet
+        - name: usr-local-bin
+          hostPath:
+            path: /usr/local/bin
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate


### PR DESCRIPTION
This is still in progress PR. The idea is to provide an alternative/experimental deployment mechanism for the `cri-resmgr`, for development and testing it has been really useful and fast to deploy/use.

**TODO**

- [x] Add rbac-based config
- [x] Add initial `deployment.yaml`
- [x] Add `configmap.yaml` for custom environment variables
- [ ] Add `README.md` file for documentation
- [ ] Add jaeger's enabled deployment for tracing hosting 



Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>