### PR TITLE
config: return errors related to applying updates in the reply message

### DIFF
--- a/pkg/agent/flags.go
+++ b/pkg/agent/flags.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"flag"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
 )
 
@@ -27,6 +28,7 @@ type options struct {
 	resmgrSocket  string
 	configNs      string
 	configMapName string
+	labelName     string
 }
 
 var opts = options{}
@@ -37,4 +39,5 @@ func init() {
 	flag.StringVar(&opts.kubeconfig, "kubeconfig", "", "Kubeconfig to use, empty string implies in-cluster config (i.e. running inside a Pod)")
 	flag.StringVar(&opts.configNs, "config-ns", "kube-system", "Kubernetes namespace where to look for config")
 	flag.StringVar(&opts.configMapName, "configmap-name", "cri-resmgr-config", "Name of the K8s ConfigMap to watch")
+	flag.StringVar(&opts.labelName, "label-name", kubernetes.ResmgrKey("group"), "Name of the label used to assign a node to a configuration group.")
 }

--- a/pkg/agent/kubernetes.go
+++ b/pkg/agent/kubernetes.go
@@ -20,17 +20,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	agent_v1 "github.com/intel/cri-resource-manager/pkg/agent/api/v1"
 )
+
+type namespace string
 
 // nodeName contains the name of the k8s we're running on
 var nodeName string
@@ -94,17 +97,169 @@ func patchNodeStatus(cli *k8sclient.Clientset, fields map[string]string) error {
 	return err
 }
 
-// watchConfigMap watches changes in a ConfigMap object
-func watchConfigMap(cli *k8sclient.Clientset, ns string, name string) (watch.Interface, error) {
-	listOpts := meta_v1.ListOptions{
-		FieldSelector: "metadata.name=" + name,
+// watch is a wrapper around the k8s watch.Interface
+type watch struct {
+	parent  *watcher
+	kind    string
+	ns      namespace
+	name    string
+	openfn  func(namespace, string) (k8swatch.Interface, error)
+	queryfn func(namespace, string) (interface{}, error)
+	stop    chan struct{}
+	events  chan k8swatch.Event
+}
+
+// openFn is the type for functions creating k8s watcher of a particular kind.
+type openFn func(ns namespace, name string) (k8swatch.Interface, error)
+
+// queryFn is the type for functions querying k8s objects being watched.
+type queryFn func(ns namespace, name string) (interface{}, error)
+
+const (
+	// SyntheticMissing is a synthetic initial event for currently non-existent object.
+	SyntheticMissing = k8swatch.EventType("SyntheticMissing")
+)
+
+func newWatch(parent *watcher, kind string, ns namespace, open openFn, query queryFn) *watch {
+	return &watch{
+		parent:  parent,
+		kind:    kind,
+		ns:      ns,
+		stop:    make(chan struct{}),
+		events:  make(chan k8swatch.Event),
+		openfn:  open,
+		queryfn: query,
 	}
-	watch, err := cli.CoreV1().ConfigMaps(ns).Watch(listOpts)
-	if err != nil {
-		return nil, agentError("failed to create a watch for configmaps in ns %q: %v", ns, err)
+}
+
+// newNodeWatch creates a watch for k8s Node
+func newNodeWatch(parent *watcher) *watch {
+	w := newWatch(parent, "Node", namespace(""),
+		func(ns namespace, name string) (k8swatch.Interface, error) {
+			selector := meta_v1.ListOptions{FieldSelector: "metadata.name=" + name}
+			k8w, err := parent.k8sCli.CoreV1().Nodes().Watch(selector)
+			if err != nil {
+				return nil, err
+			}
+			return k8w, nil
+		},
+		func(ns namespace, name string) (interface{}, error) {
+			noopts := meta_v1.GetOptions{}
+			node, err := parent.k8sCli.CoreV1().Nodes().Get(name, noopts)
+			if err != nil {
+				return nil, err
+			}
+			return node, nil
+		})
+	w.Start(nodeName)
+	return w
+}
+
+// newConfigMapWatch creates a watch for k8s ConfigMap
+func newConfigMapWatch(parent *watcher, name string, ns namespace) *watch {
+	w := newWatch(parent, "ConfigMap", ns,
+		func(ns namespace, name string) (k8swatch.Interface, error) {
+			selector := meta_v1.ListOptions{FieldSelector: "metadata.name=" + name}
+			k8w, err := parent.k8sCli.CoreV1().ConfigMaps(string(ns)).Watch(selector)
+			if err != nil {
+				return nil, err
+			}
+			return k8w, nil
+		},
+		func(ns namespace, name string) (interface{}, error) {
+			noopts := meta_v1.GetOptions{}
+			cm, err := parent.k8sCli.CoreV1().ConfigMaps(string(ns)).Get(name, noopts)
+			if err != nil {
+				return nil, err
+			}
+			return cm, nil
+		})
+	w.Start(name)
+	return w
+}
+
+func (w *watch) Name() string {
+	ns, name := w.ns, w.name
+	if ns != "" {
+		ns += "/"
+	}
+	if name == "" {
+		name = "<none>"
+	}
+	return w.kind + ":" + string(ns) + name
+}
+
+// Query queries the object being watched.
+func (w *watch) Query() (interface{}, error) {
+	if w.name == "" {
+		return nil, nil
+	}
+	return w.queryfn(w.ns, w.name)
+}
+
+// Start watching an object.
+func (w *watch) Start(name string) {
+	w.Stop()
+	w.name = name
+
+	if w.name == "" {
+		return
 	}
 
-	return watch, nil
+	// proxy events from a go-routing until we're told to stop.
+	go func() {
+		var k8w k8swatch.Interface
+		var events <-chan k8swatch.Event
+		var ratelimit <-chan time.Time
+		var err error
+
+		// let the watcher know not to expect initial event
+		if _, err = w.queryfn(w.ns, w.name); err != nil {
+			w.events <- k8swatch.Event{Type: SyntheticMissing}
+		}
+
+		for {
+			if events == nil {
+				w.parent.Info("creating %s watch", w.Name())
+				if k8w, err = w.openfn(w.ns, w.name); err != nil {
+					w.parent.Warn("failed to create %s watch: %v", w.Name(), err)
+					ratelimit = time.After(1 * time.Second)
+				} else {
+					events = k8w.ResultChan()
+					ratelimit = nil
+				}
+			}
+
+			select {
+			case _ = <-w.stop:
+				if events != nil {
+					k8w.Stop()
+				}
+				return
+			case e, ok := <-events:
+				if ok {
+					w.events <- e
+				} else {
+					k8w.Stop()
+					events = nil
+				}
+			case _ = <-ratelimit:
+			}
+		}
+	}()
+}
+
+// Close closes a watch.
+func (w *watch) Stop() {
+	select {
+	case w.stop <- struct{}{}:
+	default:
+	}
+}
+
+// ResultChan returns the event channel of the watch.
+func (w *watch) ResultChan() <-chan k8swatch.Event {
+	return w.events
 }
 
 func init() {

--- a/pkg/cri/resource-manager/config/api/v1/api.pb.go
+++ b/pkg/cri/resource-manager/config/api/v1/api.pb.go
@@ -3,13 +3,14 @@
 
 package v1
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
-	context "golang.org/x/net/context"
+	context "context"
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,13 +22,13 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type SetConfigRequest struct {
 	// Name
-	NodeName string `protobuf:"bytes,1,opt,name=node_name,json=nodeName" json:"node_name,omitempty"`
+	NodeName string `protobuf:"bytes,1,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
 	// Key-value map of ConfigMap data
-	Config               map[string]string `protobuf:"bytes,2,rep,name=config" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Config               map[string]string `protobuf:"bytes,2,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -37,16 +38,17 @@ func (m *SetConfigRequest) Reset()         { *m = SetConfigRequest{} }
 func (m *SetConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*SetConfigRequest) ProtoMessage()    {}
 func (*SetConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_5e05445820305fb8, []int{0}
+	return fileDescriptor_2d9bc9cf5b527561, []int{0}
 }
+
 func (m *SetConfigRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetConfigRequest.Unmarshal(m, b)
 }
 func (m *SetConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetConfigRequest.Marshal(b, m, deterministic)
 }
-func (dst *SetConfigRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetConfigRequest.Merge(dst, src)
+func (m *SetConfigRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetConfigRequest.Merge(m, src)
 }
 func (m *SetConfigRequest) XXX_Size() int {
 	return xxx_messageInfo_SetConfigRequest.Size(m)
@@ -72,6 +74,8 @@ func (m *SetConfigRequest) GetConfig() map[string]string {
 }
 
 type SetConfigReply struct {
+	// If not empty, indicate an error that happened while trying to apply new configuration.
+	Error                string   `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -81,16 +85,17 @@ func (m *SetConfigReply) Reset()         { *m = SetConfigReply{} }
 func (m *SetConfigReply) String() string { return proto.CompactTextString(m) }
 func (*SetConfigReply) ProtoMessage()    {}
 func (*SetConfigReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_5e05445820305fb8, []int{1}
+	return fileDescriptor_2d9bc9cf5b527561, []int{1}
 }
+
 func (m *SetConfigReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetConfigReply.Unmarshal(m, b)
 }
 func (m *SetConfigReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetConfigReply.Marshal(b, m, deterministic)
 }
-func (dst *SetConfigReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetConfigReply.Merge(dst, src)
+func (m *SetConfigReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetConfigReply.Merge(m, src)
 }
 func (m *SetConfigReply) XXX_Size() int {
 	return xxx_messageInfo_SetConfigReply.Size(m)
@@ -101,10 +106,41 @@ func (m *SetConfigReply) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SetConfigReply proto.InternalMessageInfo
 
+func (m *SetConfigReply) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*SetConfigRequest)(nil), "v1.SetConfigRequest")
 	proto.RegisterMapType((map[string]string)(nil), "v1.SetConfigRequest.ConfigEntry")
 	proto.RegisterType((*SetConfigReply)(nil), "v1.SetConfigReply")
+}
+
+func init() {
+	proto.RegisterFile("pkg/cri/resource-manager/config/api/v1/api.proto", fileDescriptor_2d9bc9cf5b527561)
+}
+
+var fileDescriptor_2d9bc9cf5b527561 = []byte{
+	// 243 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x32, 0x28, 0xc8, 0x4e, 0xd7,
+	0x4f, 0x2e, 0xca, 0xd4, 0x2f, 0x4a, 0x2d, 0xce, 0x2f, 0x2d, 0x4a, 0x4e, 0xd5, 0xcd, 0x4d, 0xcc,
+	0x4b, 0x4c, 0x4f, 0x2d, 0xd2, 0x4f, 0xce, 0xcf, 0x4b, 0xcb, 0x4c, 0xd7, 0x4f, 0x2c, 0xc8, 0xd4,
+	0x2f, 0x33, 0x04, 0x51, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x4c, 0x65, 0x86, 0x4a, 0x4b,
+	0x18, 0xb9, 0x04, 0x82, 0x53, 0x4b, 0x9c, 0xc1, 0x4a, 0x82, 0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b,
+	0x84, 0xa4, 0xb9, 0x38, 0xf3, 0xf2, 0x53, 0x52, 0xe3, 0xf3, 0x12, 0x73, 0x53, 0x25, 0x18, 0x15,
+	0x18, 0x35, 0x38, 0x83, 0x38, 0x40, 0x02, 0x7e, 0x89, 0xb9, 0xa9, 0x42, 0x16, 0x5c, 0x6c, 0x10,
+	0x03, 0x25, 0x98, 0x14, 0x98, 0x35, 0xb8, 0x8d, 0x14, 0xf4, 0xca, 0x0c, 0xf5, 0xd0, 0x8d, 0xd0,
+	0x83, 0xf0, 0x5c, 0xf3, 0x4a, 0x8a, 0x2a, 0x83, 0xa0, 0xea, 0xa5, 0x2c, 0xb9, 0xb8, 0x91, 0x84,
+	0x85, 0x04, 0xb8, 0x98, 0xb3, 0x53, 0x2b, 0xa1, 0xe6, 0x83, 0x98, 0x42, 0x22, 0x5c, 0xac, 0x65,
+	0x89, 0x39, 0xa5, 0xa9, 0x12, 0x4c, 0x60, 0x31, 0x08, 0xc7, 0x8a, 0xc9, 0x82, 0x51, 0x49, 0x8d,
+	0x8b, 0x0f, 0xc9, 0x8a, 0x82, 0x1c, 0xb0, 0xda, 0xd4, 0xa2, 0xa2, 0xfc, 0x22, 0xa8, 0x7e, 0x08,
+	0xc7, 0xc8, 0x91, 0x8b, 0x0d, 0xa2, 0x48, 0xc8, 0x9c, 0x8b, 0x13, 0xae, 0x43, 0x48, 0x04, 0x9b,
+	0x1b, 0xa5, 0x84, 0xd0, 0x44, 0x0b, 0x72, 0x2a, 0x95, 0x18, 0x9c, 0x58, 0xa2, 0x98, 0xca, 0x0c,
+	0x93, 0xd8, 0xc0, 0x41, 0x64, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xb6, 0x6e, 0xc6, 0x28, 0x56,
+	0x01, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -115,8 +151,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// Client API for Config service
-
+// ConfigClient is the client API for Config service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ConfigClient interface {
 	SetConfig(ctx context.Context, in *SetConfigRequest, opts ...grpc.CallOption) (*SetConfigReply, error)
 }
@@ -131,17 +168,24 @@ func NewConfigClient(cc *grpc.ClientConn) ConfigClient {
 
 func (c *configClient) SetConfig(ctx context.Context, in *SetConfigRequest, opts ...grpc.CallOption) (*SetConfigReply, error) {
 	out := new(SetConfigReply)
-	err := grpc.Invoke(ctx, "/v1.Config/SetConfig", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/v1.Config/SetConfig", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for Config service
-
+// ConfigServer is the server API for Config service.
 type ConfigServer interface {
 	SetConfig(context.Context, *SetConfigRequest) (*SetConfigReply, error)
+}
+
+// UnimplementedConfigServer can be embedded to have forward compatible implementations.
+type UnimplementedConfigServer struct {
+}
+
+func (*UnimplementedConfigServer) SetConfig(ctx context.Context, req *SetConfigRequest) (*SetConfigReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetConfig not implemented")
 }
 
 func RegisterConfigServer(s *grpc.Server, srv ConfigServer) {
@@ -177,27 +221,4 @@ var _Config_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "pkg/cri/resource-manager/config/api/v1/api.proto",
-}
-
-func init() {
-	proto.RegisterFile("pkg/cri/resource-manager/config/api/v1/api.proto", fileDescriptor_api_5e05445820305fb8)
-}
-
-var fileDescriptor_api_5e05445820305fb8 = []byte{
-	// 233 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x32, 0x28, 0xc8, 0x4e, 0xd7,
-	0x4f, 0x2e, 0xca, 0xd4, 0x2f, 0x4a, 0x2d, 0xce, 0x2f, 0x2d, 0x4a, 0x4e, 0xd5, 0xcd, 0x4d, 0xcc,
-	0x4b, 0x4c, 0x4f, 0x2d, 0xd2, 0x4f, 0xce, 0xcf, 0x4b, 0xcb, 0x4c, 0xd7, 0x4f, 0x2c, 0xc8, 0xd4,
-	0x2f, 0x33, 0x04, 0x51, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x4c, 0x65, 0x86, 0x4a, 0x4b,
-	0x18, 0xb9, 0x04, 0x82, 0x53, 0x4b, 0x9c, 0xc1, 0x4a, 0x82, 0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b,
-	0x84, 0xa4, 0xb9, 0x38, 0xf3, 0xf2, 0x53, 0x52, 0xe3, 0xf3, 0x12, 0x73, 0x53, 0x25, 0x18, 0x15,
-	0x18, 0x35, 0x38, 0x83, 0x38, 0x40, 0x02, 0x7e, 0x89, 0xb9, 0xa9, 0x42, 0x16, 0x5c, 0x6c, 0x10,
-	0x03, 0x25, 0x98, 0x14, 0x98, 0x35, 0xb8, 0x8d, 0x14, 0xf4, 0xca, 0x0c, 0xf5, 0xd0, 0x8d, 0xd0,
-	0x83, 0xf0, 0x5c, 0xf3, 0x4a, 0x8a, 0x2a, 0x83, 0xa0, 0xea, 0xa5, 0x2c, 0xb9, 0xb8, 0x91, 0x84,
-	0x85, 0x04, 0xb8, 0x98, 0xb3, 0x53, 0x2b, 0xa1, 0xe6, 0x83, 0x98, 0x42, 0x22, 0x5c, 0xac, 0x65,
-	0x89, 0x39, 0xa5, 0xa9, 0x12, 0x4c, 0x60, 0x31, 0x08, 0xc7, 0x8a, 0xc9, 0x82, 0x51, 0x49, 0x80,
-	0x8b, 0x0f, 0xc9, 0x8a, 0x82, 0x9c, 0x4a, 0x23, 0x47, 0x2e, 0x36, 0x08, 0x57, 0xc8, 0x9c, 0x8b,
-	0x13, 0x2e, 0x27, 0x24, 0x82, 0xcd, 0x35, 0x52, 0x42, 0x68, 0xa2, 0x05, 0x39, 0x95, 0x4a, 0x0c,
-	0x4e, 0x2c, 0x51, 0x4c, 0x65, 0x86, 0x49, 0x6c, 0xe0, 0xc0, 0x30, 0x06, 0x04, 0x00, 0x00, 0xff,
-	0xff, 0x51, 0x03, 0x1c, 0x7b, 0x40, 0x01, 0x00, 0x00,
 }

--- a/pkg/cri/resource-manager/config/api/v1/api.proto
+++ b/pkg/cri/resource-manager/config/api/v1/api.proto
@@ -31,4 +31,6 @@ message SetConfigRequest {
 }
 
 message SetConfigReply {
+     // If not empty, indicate an error that happened while trying to apply new configuration.
+    string error = 1;
 }

--- a/pkg/cri/resource-manager/config/server.go
+++ b/pkg/cri/resource-manager/config/server.go
@@ -93,8 +93,16 @@ func (s *server) Stop() {
 func (s *server) SetConfig(ctx context.Context, req *v1.SetConfigRequest) (*v1.SetConfigReply, error) {
 	s.Lock()
 	defer s.Unlock()
+
 	s.Debug("REQUEST: %s", req)
-	return &v1.SetConfigReply{}, s.setConfigCb(&RawConfig{NodeName: req.NodeName, Data: req.Config})
+
+	reply := &v1.SetConfigReply{}
+	err := s.setConfigCb(&RawConfig{NodeName: req.NodeName, Data: req.Config})
+	if err != nil {
+		reply.Error = fmt.Sprintf("failed to apply configuration: %v", err)
+	}
+
+	return reply, nil
 }
 
 func serverError(format string, args ...interface{}) error {


### PR DESCRIPTION
This PR is stacked on (includes) PR #54 .

    Return configuration update errors as a field in the reply message.
    This allows the agent to differentiate between errors in delivery
    vs. errors in applying an update.
    
    For delivery errors the agent will keep retrying indefinitely, sending
    an update request at periodic intervals. For errors in applying an
    update the agent will give up immediately and only try sending a new
    update when the configration is updated the next time.
