### PR TITLE
packaging fixes: cri-resmgr systemd service doesn't require 'agent', shouldn't expect recursive substitutions from systemd.

### DIFF
--- a/cmd/cri-resmgr/cri-resource-manager.service
+++ b/cmd/cri-resmgr/cri-resource-manager.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=A CRI proxy with (hardware) resource aware container placement policies.
 Documentation=https://github.com/intel/cri-resource-manager
-Requires=cri-resource-manager-agent.service
 
 [Service]
 Type=simple

--- a/cmd/cri-resmgr/cri-resource-manager.sysconf
+++ b/cmd/cri-resmgr/cri-resource-manager.sysconf
@@ -3,6 +3,4 @@ POLICY=topology-aware
 # Any extra options for the active policy.
 POLICY_OPTIONS="--reserved-resources=cpu=750m"
 # Debug flags to enable.
-DEBUG_OPTIONS="--logger-debug resource-manager,policy,cache,$POLICY"
-# Config file for accessing the cluster through the API server.
-KUBE_CONFIG="--kubeconfig /root/.kube/config"
+DEBUG_OPTIONS="--logger-debug resource-manager,policy,cache"


### PR DESCRIPTION
This patchset fixes two problems mostly related to packaging:
1. cri-resmgr systemd service does not agent (we don't even provide a service for it).
2. Don't expect in the environment file that systemd would do recursive substitutions.