### PR TITLE
fixes: don't blindly assume an annotating webhook is in place.

### DIFF
--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -96,12 +96,14 @@ func (p *pod) GetContainers() []Container {
 	containers := []Container{}
 
 	for _, c := range p.cache.Containers {
+		if c.PodID != p.ID {
+			continue
+		}
 		if p.Resources != nil {
 			if _, ok := p.Resources.Containers[c.ID]; !ok {
 				continue
 			}
 		}
-
 		containers = append(containers, c)
 	}
 


### PR DESCRIPTION
We might not have webhook annotations at all. So filter
containers primarily by PodID and only secondarily by
potentially annotated init- vs. normalness.