### PR TITLE
scripts: accept unannotated tags for versioning.

### DIFF
--- a/scripts/build/git-id
+++ b/scripts/build/git-id
@@ -21,7 +21,7 @@ unknown_version() {
 
 get_gitids () {
     if [ -d .git ]; then
-        version=$(git describe --long --dirty 2>/dev/null || unknown_version)
+        version=$(git describe --tags --long --dirty 2>/dev/null || unknown_version)
         buildid=$(git rev-parse --short HEAD || echo unknown)
         if [ -n "$DIR" ]; then
             if [ "$version" != "$(cat $DIR/git-version 2>/dev/null)" ]; then


### PR DESCRIPTION
Github uses lightweight tags for releases, so start accepting
those as well when git-describing HEAD for generating version
ids.