### PR TITLE
Remove extra space from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.20.1
 	gopkg.in/inf.v0 v0.9.1 // indirect
-
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0


### PR DESCRIPTION
Currently there was an extra space in go.mod file, this patch fixes this.

Signed-off: Syed Ahsan <syed.ahsan.shamim.zaidi@intel.com>

#69 