### PR TITLE
rdt: implement "partitions"

### DIFF
--- a/docs/rdt.md
+++ b/docs/rdt.md
@@ -7,12 +7,13 @@ monitoring. In Linux system the functionality is exposed to the user space via
 the [resctrl](https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt)
 filesystem. Cache and memory allocation in RDT is handled by using resource
 control groups. Resource allocation is specified on the group level and each
-task (process/thread) is assigned to one group.
+task (process/thread) is assigned to one group. In the context of CRI Resource
+we use the term 'RDT class' instead of 'resource control group'.
 
 Out of the RDT technologies, CRI Resource Manager currently supports L3 cache
-allocation and memory bandwidth allocation. Based on the configuration, it
-creates a set of resource control groups which the policies can assign
-containers to.
+allocation and memory bandwidth allocation. The configuration contains a set of
+RDT classes which the policies can assign containers to. In the underlying
+system (on OS level) one resctrl group per RDT class) is created.
 
 ## Configuration
 
@@ -27,12 +28,21 @@ containers to.
 CRI utilizes configuration received from
 [`cri-resmgr-agent`](../README.md#cri-resource-manager-node-agent), under the
 key `rdt` in the ConfigMap containing `cri-resmgr` configuration data. The
-configuration specifies a set of RDT classes (or resource control groups) that
-the policies assign containers to. The configuration can be dynamically updated
-by editing the ConfigMap. The set of RDT classes can be freely specified, but,
-one must ensure that classes required by the active policy are specified, and,
-that the maxmimum number of classes (CLOSes) supported by the underlying system
-is not exceeded.
+configuration specifies a set of 'partitions' each further containing a set of
+'classes'. The configuration can be dynamically updated by editing the
+ConfigMap.
+
+Partitions represent a logical grouping of the underlying classes, each
+partition specifying a portion of the available resources (L3/MB) which will be
+shared by the classes under it. L3 allocations between partitions are exclusive,
+i.e. no overlap on the cache ways between partitions is allowed. MB
+allocations do not have this property, i.e. all partitions may have 100% of
+bandwidth, for example.
+
+Classes represent the actual RDT classes that the policies assign containers
+to. The set of RDT classes can be freely specified, but, one must ensure that
+classes required by the active policy are specified, and, that the maxmimum
+number of classes (CLOSes) supported by the underlying system is not exceeded.
 
 CRI-RM has a built-in default configuration containing three classes
 corresponding to the Pod QOS classes of Kubernetes. These are utilized by the

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -153,12 +153,6 @@ func (m *resmgr) Start() error {
 		return resmgrError("failed to start relay: %v", err)
 	}
 
-	// Temporary hack to get pkg/rdt properly configured.
-	// TODO: remove after pkg/rdt config management is fixed
-	if err := m.loadInitialConfig(); err != nil {
-		return resmgrError("failed to load initial configuration: %v", err)
-	}
-
 	if m.conf != nil {
 		m.cache.SetConfig(m.conf)
 	}

--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -18,256 +18,241 @@ package rdt
 
 import (
 	"fmt"
+	"math/bits"
 	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/utils"
 )
 
-// ResctrlGroupConfig represents configuration of one CTRL group in the Linux
-// resctrl interface
-type ResctrlGroupConfig struct {
-	L3Schema L3Schema `json:"l3Schema,omitempty"`
-	MBSchema MBSchema `json:"mbSchema,omitempty"`
+// options represents the raw RDT configuration data from the configmap
+type options struct {
+	Options    schemaOptions `json:"options"`
+	Partitions map[string]struct {
+		L3Allocation rawAllocations `json:"l3Allocation"`
+		MBAllocation rawAllocations `json:"mbAllocation"`
+		Classes      map[string]struct {
+			L3Schema rawAllocations `json:"l3Schema"`
+			MBSchema rawAllocations `json:"mbSchema"`
+		} `json:"classes"`
+	} `json:"partitions"`
 }
 
-// SchemaOptions contains the common settings for all resctrl groups
-type SchemaOptions struct {
-	L3 L3Options `json:"l3"`
-	MB MBOptions `json:"mb"`
+// rawAllocations is an intermediate helper type for JSON parsing of
+// per-cache-id allocations
+type rawAllocations map[string]interface{}
+
+// config represents the final (parsed and resolved) runtime configuration of
+// RDT Control
+type config struct {
+	Options    schemaOptions
+	Partitions map[string]partitionConfig
+	Classes    map[string]classConfig
 }
 
-// L3Options contains the common settings for L3 cache allocation
-type L3Options struct {
+// partitionConfig is the final configuration of one partition
+type partitionConfig struct {
+	L3 map[uint64]Bitmask
+	MB map[uint64]uint64
+}
+
+// classConfig represents configuration of one class, i.e. one CTRL group in
+// the Linux resctrl interface
+type classConfig struct {
+	Partition string
+	L3Schema  l3Schema
+	MBSchema  mbSchema
+}
+
+// schemaOptions contains the common settings for all classes
+type schemaOptions struct {
+	L3 l3Options `json:"l3"`
+	MB mbOptions `json:"mb"`
+}
+
+// l3Options contains the common settings for L3 cache allocation
+type l3Options struct {
 	Optional bool `json:"optional,omitempty"`
 }
 
-// MBOptions contains the common settings for memory bandwidth allocation
-type MBOptions struct {
+// mbOptions contains the common settings for memory bandwidth allocation
+type mbOptions struct {
 	Optional bool `json:"optional,omitempty"`
 }
 
-// L3Schema represents an L3 part of the schemata of a resctrl group
-type L3Schema struct {
-	Allocations map[uint64]L3Allocation
+// l3Schema represents the L3 part of the schemata of a class (i.e. resctrl group)
+type l3Schema map[uint64]l3Allocation
+
+// mbSchema represents the MB part of the schemata of a class (i.e. resctrl group)
+type mbSchema map[uint64]uint64
+
+// l3Allocation describes the L3 allocation configuration for one cache id
+type l3Allocation struct {
+	Unified cacheAllocation
+	Code    cacheAllocation
+	Data    cacheAllocation
 }
 
-// MBSchema represents an MB part of the schemata of a resctrl group
-type MBSchema struct {
-	Allocations map[uint64]uint64
+// cacheAllocation is the basic interface for handling cache allocations of one
+// type (unified, code, data)
+type cacheAllocation interface {
+	Overlay(Bitmask) (Bitmask, error)
 }
 
-// L3Allocation represents the L3 cache allocation configuration for one cache id
-type L3Allocation struct {
-	Unified CacheBitmask `json:"unified"`
-	Code    CacheBitmask `json:"code"`
-	Data    CacheBitmask `json:"data"`
+// l3AbsoluteAllocation represents an explicitly specified cache allocation
+// bitmask
+type l3AbsoluteAllocation Bitmask
+
+// l3RelativeAllocation represents a percentage range of the available bitmask
+type l3RelativeAllocation struct {
+	lowPct  uint64
+	highPct uint64
 }
 
 // L3SchemaType represents different L3 cache allocation schemes
-type L3SchemaType string
+type l3SchemaType string
 
 const (
-	// L3SchemaTypeUnified is the schema type when CDP is not enabled
-	L3SchemaTypeUnified = ""
-	// L3SchemaTypeCode is the 'code' part of CDP schema
-	L3SchemaTypeCode = "CODE"
-	// L3SchemaTypeData is the 'data' part of CDP schema
-	L3SchemaTypeData = "DATA"
+	// l3SchemaTypeUnified is the schema type when CDP is not enabled
+	l3SchemaTypeUnified = ""
+	// l3SchemaTypeCode is the 'code' part of CDP schema
+	l3SchemaTypeCode = "CODE"
+	// l3SchemaTypeData is the 'data' part of CDP schema
+	l3SchemaTypeData = "DATA"
 )
-
-// IsNil returns true if the schema is empty
-func (s *L3Schema) IsNil() bool {
-	return s.Allocations == nil
-}
 
 // ToStr returns the L3 schema in a format accepted by the Linux kernel
 // resctrl (schemata) interface
-func (s *L3Schema) ToStr(typ L3SchemaType) string {
-	if s.IsNil() {
-		return s.DefaultStr(typ)
-	}
-
+func (s l3Schema) ToStr(typ l3SchemaType, baseSchema map[uint64]Bitmask) (string, error) {
 	schema := "L3" + string(typ) + ":"
 	sep := ""
 
-	// We get cache ids but that doesn't matter
-	for id, masks := range s.Allocations {
-		bitmask := masks.Unified
-		// Use Unified as the default/fallback for Code and Data
-		switch typ {
-		case L3SchemaTypeCode:
-			if masks.Code != 0 {
-				bitmask = masks.Code
+	for id, bitmask := range baseSchema {
+		if s != nil {
+			var err error
+
+			masks := s[id]
+			// Use Unified as the default/fallback for Code and Data
+			overlayMask := masks.Unified
+			switch typ {
+			case l3SchemaTypeCode:
+				if masks.Code != nil {
+					overlayMask = masks.Code
+				}
+			case l3SchemaTypeData:
+				if masks.Data != nil {
+					overlayMask = masks.Data
+				}
 			}
-		case L3SchemaTypeData:
-			if masks.Data != 0 {
-				bitmask = masks.Data
+
+			bitmask, err = overlayMask.Overlay(bitmask)
+			if err != nil {
+				return "", err
 			}
 		}
 		schema += fmt.Sprintf("%s%d=%x", sep, id, bitmask)
 		sep = ";"
 	}
 
-	return schema + "\n"
+	return schema + "\n", nil
 }
 
-// DefaultStr returns the L3 default schema
-func (s *L3Schema) DefaultStr(typ L3SchemaType) string {
-	schema := "L3" + string(typ) + ":"
-	sep := ""
-
-	mask := rdtInfo.l3FullMask()
-
-	for _, id := range rdtInfo.cacheIds {
-		// Set all to full mask (i.e. 100%)
-		schema += fmt.Sprintf("%s%d=%x", sep, id, mask)
-		sep = ";"
+// Overlay function of the cacheAllocation interface
+func (a l3AbsoluteAllocation) Overlay(baseMask Bitmask) (Bitmask, error) {
+	// Just bounds checking that we're "inside" the base mask
+	if Bitmask(a)|baseMask != baseMask {
+		return 0, rdtError("bitmask %#x does not fit basemask %#x", a, baseMask)
 	}
 
-	return schema + "\n"
+	return Bitmask(a), nil
 }
 
-// UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
-func (s *L3Schema) UnmarshalJSON(b []byte) error {
-	var allocations map[string]L3Allocation
+// Overlay function of the cacheAllocation interface
+func (a l3RelativeAllocation) Overlay(baseMask Bitmask) (Bitmask, error) {
+	baseMaskMsb := uint64(baseMask.msbOne())
+	baseMaskLsb := uint64(baseMask.lsbOne())
+	baseMaskNumBits := baseMaskMsb - baseMaskLsb + 1
 
-	err := yaml.Unmarshal(b, &allocations)
-	if err != nil {
-		return err
+	// Check that the basemask contains one (and only one) contiguous block of
+	// (enough) bits set
+	if bits.OnesCount64(uint64(baseMask)) != int(baseMaskNumBits) {
+		return 0, rdtError("invalid basemask %#x: more than one block of bits set", baseMask)
+	}
+	if uint64(bits.OnesCount64(uint64(baseMask))) < rdtInfo.l3MinCbmBits() {
+		return 0, rdtError("invalid basemask %#x: fewer than %d bits set", baseMask, rdtInfo.l3MinCbmBits())
 	}
 
-	s.Allocations = map[uint64]L3Allocation{}
-
-	// Set default allocations
-	fullMask := CacheBitmask(rdtInfo.l3FullMask())
-	defaultAllocation := L3Allocation{Unified: fullMask, Code: fullMask, Data: fullMask}
-	if val, ok := allocations["all"]; ok {
-		defaultAllocation = val
-		delete(allocations, "all")
+	low, high := a.lowPct, a.highPct
+	if low == 0 {
+		low = 1
+	}
+	if low > high || low > 100 || high > 100 {
+		return 0, rdtError("invalid percentage range in %v", a)
 	}
 
-	for _, i := range rdtInfo.cacheIds {
-		s.Allocations[i] = defaultAllocation
-	}
+	// Convert percentage limits to bit numbers
+	// Our effective range is 1%-100%, use substraction (-1) because of
+	// arithmetics, so that we don't overflow on 100%
+	lsb := (low - 1) * baseMaskNumBits / 100
+	msb := (high - 1) * baseMaskNumBits / 100
 
-	// Parse per-cacheId allocations
-	for key, allocation := range allocations {
-		ids, err := listStrToArray(key)
-		if err != nil {
-			return err
+	// Make sure the number of bits set satisfies the minimum requirement
+	numBits := msb - lsb + 1
+	if numBits < rdtInfo.l3MinCbmBits() {
+		gap := rdtInfo.l3MinCbmBits() - numBits
+
+		// First, widen the mask from the "lsb end"
+		lsbAvailable := lsb - baseMaskLsb
+		if gap <= lsbAvailable {
+			lsb -= gap
+		} else {
+			lsb = baseMaskLsb
 		}
-		for _, id := range ids {
-			if _, ok := s.Allocations[uint64(id)]; ok {
-				s.Allocations[uint64(id)] = allocation
-			}
+		// If needed, widen the mask from the "msb end"
+		numBits = msb - lsb + 1
+		gap = rdtInfo.l3MinCbmBits() - numBits
+		msbAvailable := baseMaskMsb - msb
+		if gap <= msbAvailable {
+			msb += gap
+		} else {
+			return 0, rdtError("BUG: not enough bits available for cache bitmask (%s applied on basemask %#x)", a, baseMask)
 		}
 	}
 
-	return nil
+	value := ((1 << (msb - lsb + 1)) - 1) << (lsb + baseMaskLsb)
+
+	return Bitmask(value), nil
 }
 
-// UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
-func (a *L3Allocation) UnmarshalJSON(b []byte) error {
-	type l3Intermediate L3Allocation
-	var tmp l3Intermediate
-
-	err := yaml.Unmarshal(b, &tmp)
-	if err != nil {
-		return err
-	}
-
-	if tmp.Unified == 0 {
-		return fmt.Errorf("'unified' not specified in l3Schema %s", b)
-	}
-	if tmp.Code != 0 && tmp.Data == 0 {
-		return fmt.Errorf("'code' specified but missing 'data' from l3Schema %s", b)
-	}
-	if tmp.Code == 0 && tmp.Data != 0 {
-		return fmt.Errorf("'data' specified but missing 'code' from l3Schema %s", b)
-	}
-
-	*a = L3Allocation(tmp)
-	return nil
-}
-
-// IsNil returns true if the schema is empty
-func (s *MBSchema) IsNil() bool {
-	return s.Allocations == nil
+// MarshalJSON implements the Marshaler interface of "encoding/json"
+func (a l3RelativeAllocation) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%d-%d%%\"", a.lowPct, a.highPct)), nil
 }
 
 // ToStr returns the MB schema in a format accepted by the Linux kernel
 // resctrl (schemata) interface
-func (s *MBSchema) ToStr() string {
-	if s.IsNil() {
-		return s.DefaultStr()
-	}
-
+func (s mbSchema) ToStr(base map[uint64]uint64) string {
 	schema := "MB:"
 	sep := ""
 
-	// We get cache ids but that doesn't matter
-	for id, percentage := range s.Allocations {
+	for id, baseAllocation := range base {
+		allocation := uint64(100)
+		if s != nil {
+			allocation = s[id]
+		}
+		percentage := allocation * baseAllocation / 100
+		// Guarantee minimum bw so that writing out the schemata does not fail
+		if percentage < rdtInfo.mb.minBandwidth {
+			percentage = rdtInfo.mb.minBandwidth
+		}
+
 		schema += fmt.Sprintf("%s%d=%d", sep, id, percentage)
 		sep = ";"
 	}
 
 	return schema + "\n"
-}
-
-// DefaultStr returns the L3 default schema
-func (s *MBSchema) DefaultStr() string {
-	schema := "MB:"
-	sep := ""
-
-	for _, id := range rdtInfo.cacheIds {
-		// Set all to 100 percent
-		schema += fmt.Sprintf("%s%d=100", sep, id)
-		sep = ";"
-	}
-
-	return schema + "\n"
-}
-
-// UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
-func (s *MBSchema) UnmarshalJSON(b []byte) error {
-	var allocations map[string]uint64
-
-	err := yaml.Unmarshal(b, &allocations)
-	if err != nil {
-		return err
-	}
-
-	s.Allocations = map[uint64]uint64{}
-
-	// Set default allocations
-	defaultVal, ok := allocations["all"]
-	if !ok {
-		// Set to 100 if "all" is not specified
-		defaultVal = 100
-	}
-	delete(allocations, "all")
-
-	for _, i := range rdtInfo.cacheIds {
-		s.Allocations[i] = defaultVal
-	}
-
-	// Parse per-cacheId allocations
-	for key, val := range allocations {
-		ids, err := listStrToArray(key)
-		if err != nil {
-			return err
-		}
-		for _, id := range ids {
-			if _, ok := s.Allocations[uint64(id)]; ok {
-				s.Allocations[uint64(id)] = val
-			}
-		}
-	}
-
-	return nil
 }
 
 // listStrToArray parses a string containing a human-readable list of numbers
@@ -309,16 +294,420 @@ func listStrToArray(str string) ([]int, error) {
 	return a, nil
 }
 
-// Options captures our configurable parameters.
-type options struct {
-	// Config is our RDT configuration.
-	Config config `json:"config,omitempty"`
+// resolve tries to resolve the requested configuration into a working
+// configuration
+func (raw options) resolve() (config, error) {
+	var err error
+	conf := config{Options: raw.Options}
+
+	log.Debug("resolving configuration options:\n%s", utils.DumpJSON(raw))
+
+	conf.Partitions, err = raw.resolvePartitions()
+	if err != nil {
+		return conf, err
+	}
+
+	conf.Classes, err = raw.resolveClasses()
+	if err != nil {
+		return conf, err
+	}
+
+	return conf, nil
 }
 
-// Our runtime configuration.
+// resolvePartitions tries to resolve the requested resource allocations of
+// partitions
+func (raw options) resolvePartitions() (map[string]partitionConfig, error) {
+	// Initialize empty partition configuration
+	conf := make(map[string]partitionConfig, len(raw.Partitions))
+	numCacheIds := len(rdtInfo.cacheIds)
+	for name := range raw.Partitions {
+		conf[name] = partitionConfig{L3: make(map[uint64]Bitmask, numCacheIds),
+			MB: make(map[uint64]uint64, numCacheIds)}
+	}
+
+	// Try to resolve L3 partition allocations
+	err := raw.resolveL3Partitions(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to resolve MB partition allocations
+	err = raw.resolveMBPartitions(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return conf, nil
+}
+
+// resolveL3Partitions tries to resolve requested L3 allocations between partitions
+func (raw options) resolveL3Partitions(conf map[string]partitionConfig) error {
+	type partitionAllocation struct {
+		name       string
+		allocation uint64
+	}
+
+	cacheAllocations := map[uint64][]partitionAllocation{}
+	for _, id := range rdtInfo.cacheIds {
+		cacheAllocations[id] = make([]partitionAllocation, 0, len(raw.Partitions))
+	}
+	// Helper structure for printing out human-readable info in the end
+	requests := map[string]map[uint64]uint64{}
+
+	// Parse percentage values from raw config and transfer them to our
+	// per-cache-id structure
+	for name, partition := range raw.Partitions {
+		allocations, err := partition.L3Allocation.parsePercentage()
+		requests[name] = allocations
+		if err != nil {
+			return fmt.Errorf("failed to parse L3 allocation for partition %q: %v", name, err)
+		}
+		for id, val := range allocations {
+			cacheAllocations[id] = append(cacheAllocations[id], partitionAllocation{name: name, allocation: val})
+		}
+	}
+
+	// Next, try to resolve partition allocations, separately for each cache-id
+	fullBitmaskNumBits := uint64(rdtInfo.l3CbmMask().lsbZero())
+	for id, partitions := range cacheAllocations {
+		// Sort partition allocations. We want to resolve smallest allocations
+		// first in order to try to ensure that all allocations can be satisfied
+		// because small percentages might need to be rounded up
+		sort.Slice(partitions, func(i, j int) bool { return partitions[i].allocation < partitions[j].allocation })
+
+		// Sanity check: check that total allocation requested for this cache
+		// id does not exceed 100 percent
+		total := uint64(0)
+		for _, partition := range partitions {
+			total += partition.allocation
+		}
+		if total < 100 {
+			log.Info("requested total L3 partition allocation for cache id %d <100%% (%d%%)", id, total)
+		} else if total > 100 {
+			return fmt.Errorf("accumulated L3 partition allocation requests for cache id %d exceed 100%%", id)
+		}
+
+		bitID := uint64(0)
+		minCbmBits := rdtInfo.l3MinCbmBits()
+		for i, partition := range partitions {
+			bitsAvailable := fullBitmaskNumBits - bitID
+			percentageAvailable := bitsAvailable * 100 / fullBitmaskNumBits
+
+			// This might happen e.g. if number of partitions would be greater
+			// than the total number of bits
+			if bitsAvailable < minCbmBits {
+				return fmt.Errorf("unable to resolve L3 allocation for cache id %d, not enough exlusive bits available", id)
+			}
+
+			// Calculate number of bits allocated for this partition.
+			// Use integer arithmetics, effectively always rounding down
+			// fractional allocations i.e. trying to avoid over-allocation
+			numBits := partition.allocation * bitsAvailable / percentageAvailable
+
+			// Guarantee a non-zero allocation
+			if numBits < minCbmBits {
+				numBits = minCbmBits
+			}
+			// Don't overflow, allocate all remaining bits to the last partition
+			if numBits > bitsAvailable || i == len(partitions)-1 {
+				numBits = bitsAvailable
+			}
+
+			// Compose the actual bitmask
+			conf[partition.name].L3[id] = Bitmask(((1 << numBits) - 1) << bitID)
+
+			bitID += numBits
+		}
+	}
+
+	log.Info("actual (and requested) L3 allocations per partition and cache id:")
+	infoStr := ""
+	for name, partition := range requests {
+		infoStr += name + "\n    "
+		for id, requestedPct := range partition {
+			truePct := float64(bits.OnesCount64(uint64(conf[name].L3[id]))) * 100 / float64(fullBitmaskNumBits)
+			requestedPctStr := fmt.Sprintf("(%d%%)", requestedPct)
+			infoStr += fmt.Sprintf("%2d: %5.1f%% %-6s", id, truePct, requestedPctStr)
+		}
+		infoStr += "\n"
+	}
+	log.InfoBlock("    ", "%s", infoStr)
+
+	return nil
+}
+
+// resolveMBPartitions tries to resolve requested MB allocations between partitions
+func (raw options) resolveMBPartitions(conf map[string]partitionConfig) error {
+	// We use percentage values directly from the raw conf
+	for name, partition := range raw.Partitions {
+		allocations, err := partition.MBAllocation.parsePercentage()
+		if err != nil {
+			return fmt.Errorf("failed to resolve MB allocation for partition %q: %v", name, err)
+		}
+		for id, allocation := range allocations {
+			// Check that we don't go under the minimum allowed bandwidth setting
+			if allocation > rdtInfo.mb.minBandwidth {
+				conf[name].MB[id] = allocation
+			} else {
+				conf[name].MB[id] = rdtInfo.mb.minBandwidth
+			}
+		}
+	}
+
+	return nil
+}
+
+// resolveClasses tries to resolve class allocations of all partitions
+func (raw options) resolveClasses() (map[string]classConfig, error) {
+	classes := make(map[string]classConfig)
+
+	for bname, partition := range raw.Partitions {
+		for gname, class := range partition.Classes {
+			if _, ok := classes[gname]; ok {
+				return classes, fmt.Errorf("class names must be unique, %q defined multiple times", gname)
+			}
+
+			var err error
+			gc := classConfig{Partition: bname}
+
+			gc.L3Schema, err = class.L3Schema.parseL3()
+			if err != nil {
+				return classes, fmt.Errorf("failed to resolve L3 allocation for class %q: %v", gname, err)
+			}
+			gc.MBSchema, err = class.MBSchema.parseMB()
+			if err != nil {
+				return classes, fmt.Errorf("failed to resolve MB allocation for class %q: %v", gname, err)
+			}
+
+			classes[gname] = gc
+		}
+	}
+
+	return classes, nil
+}
+
+// parsePercentage parses a percentage value
+func (raw rawAllocations) parsePercentage() (map[uint64]uint64, error) {
+	rawValues, err := raw.rawParse("100%")
+	if err != nil || rawValues == nil {
+		return nil, err
+	}
+
+	allocations := make(map[uint64]uint64, len(rawValues))
+	for id, rawVal := range rawValues {
+		s, ok := rawVal.(string)
+		if !ok {
+			return nil, fmt.Errorf("not a string value %q", rawVal)
+		}
+		allocations[id], err = parsePercentage(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return allocations, nil
+}
+
+// parse parses a raw L3 cache allocation
+func (raw rawAllocations) parseL3() (l3Schema, error) {
+	rawValues, err := raw.rawParse(map[string]interface{}{"unified": "100%"})
+	if err != nil || rawValues == nil {
+		return nil, err
+	}
+
+	allocations := make(l3Schema, len(rawValues))
+	for id, rawVal := range rawValues {
+		strMap, ok := rawVal.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid structure of l3Schema %q", rawVal)
+		}
+		allocations[id], err = parseL3Allocation(strMap)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return allocations, nil
+}
+
+// parseMB parses a raw MB allocation
+func (raw rawAllocations) parseMB() (map[uint64]uint64, error) {
+	rawValues, err := raw.rawParse("100")
+	if err != nil || rawValues == nil {
+		return nil, err
+	}
+
+	allocations := make(map[uint64]uint64, len(rawValues))
+	for id, rawVal := range rawValues {
+		s, ok := rawVal.(string)
+		if !ok {
+			return nil, fmt.Errorf("not a string value %q", rawVal)
+		}
+		allocations[id], err = strconv.ParseUint(s, 10, 7)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return allocations, nil
+}
+
+// rawParse "pre-parses" the rawAllocations per each cache id. I.e. it assigns
+// a raw (string) allocation for each cache id
+func (raw rawAllocations) rawParse(defaultVal interface{}) (map[uint64]interface{}, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	if all, ok := raw["all"]; ok {
+		defaultVal = all
+	} else if defaultVal == nil {
+		return nil, fmt.Errorf("'all' is missing")
+	}
+
+	allocations := make(map[uint64]interface{}, len(rdtInfo.cacheIds))
+	for _, i := range rdtInfo.cacheIds {
+		allocations[i] = defaultVal
+	}
+
+	for key, val := range raw {
+		if key == "all" {
+			continue
+		}
+		ids, err := listStrToArray(key)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			if _, ok := allocations[uint64(id)]; ok {
+				allocations[uint64(id)] = val
+			}
+		}
+	}
+
+	return allocations, nil
+}
+
+// parsePercentage parses a percentage value from a string
+func parsePercentage(s string) (uint64, error) {
+	if s[len(s)-1] != '%' {
+		return 0, fmt.Errorf("%q not a percentage value", s)
+	}
+	val, err := strconv.ParseUint(s[:len(s)-1], 10, 7)
+	if err != nil {
+		return 0, fmt.Errorf("invalid percentage value %q: %v", s, err)
+	}
+	if val < 1 || val > 100 {
+		return 0, fmt.Errorf("percentage value %q out of range (1-100)", s)
+	}
+	return val, nil
+}
+
+// parseL3Allocation parses a generic string map into l3Allocation struct
+func parseL3Allocation(raw map[string]interface{}) (l3Allocation, error) {
+	var err error
+	allocation := l3Allocation{}
+
+	for k, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			return allocation, fmt.Errorf("not a string value %q", v)
+		}
+		switch strings.ToLower(k) {
+		case "unified":
+			allocation.Unified, err = parseCacheAllocation(s)
+		case "code":
+			allocation.Code, err = parseCacheAllocation(s)
+		case "data":
+			allocation.Data, err = parseCacheAllocation(s)
+		}
+		if err != nil {
+			return allocation, err
+		}
+	}
+
+	// Sanity check for the configuration
+	if allocation.Unified == nil {
+		return allocation, fmt.Errorf("'unified' not specified in l3Schema %s", raw)
+	}
+	if allocation.Code != nil && allocation.Data == nil {
+		return allocation, fmt.Errorf("'code' specified but missing 'data' from l3Schema %s", raw)
+	}
+	if allocation.Code == nil && allocation.Data != nil {
+		return allocation, fmt.Errorf("'data' specified but missing 'code' from l3Schema %s", raw)
+	}
+
+	return allocation, nil
+}
+
+// parseCacheAllocation parses a string value into cacheAllocation type
+func parseCacheAllocation(data string) (cacheAllocation, error) {
+	if data[len(data)-1] == '%' {
+		// Percentages of the max number of bits
+		split := strings.SplitN(data[0:len(data)-1], "-", 2)
+		var low, high uint64
+		var err error
+		var allocation l3RelativeAllocation
+
+		if len(split) == 1 {
+			high, err = strconv.ParseUint(split[0], 10, 7)
+			if err != nil {
+				return allocation, err
+			}
+		} else {
+			low, err = strconv.ParseUint(split[0], 10, 7)
+			if err != nil {
+				return allocation, err
+			}
+			high, err = strconv.ParseUint(split[1], 10, 7)
+			if err != nil {
+				return allocation, err
+			}
+		}
+		if low > high || low > 100 || high > 100 {
+			return allocation, fmt.Errorf("invalid percentage range %q", data)
+		}
+		allocation = l3RelativeAllocation{lowPct: low, highPct: high}
+
+		return allocation, nil
+	}
+
+	// Absolute allocation
+	var value uint64
+	var err error
+	if strings.HasPrefix(data, "0x") {
+		// Hex value
+		value, err = strconv.ParseUint(data[2:], 16, 64)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Last, try "list" format (i.e. smthg like 0,2,5-9,...)
+		tmp, err := ListStrToBitmask(data)
+		value = uint64(tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sanity check of absolute allocation: bitmask must (only) contain one
+	// contiguous block of ones wide enough
+	numOnes := bits.OnesCount64(value)
+	if numOnes != 64-bits.LeadingZeros64(value)-bits.TrailingZeros64(value) {
+		return nil, fmt.Errorf("invalid cache bitmask %q: more than one continuous block of ones", data)
+	}
+	if uint64(numOnes) < rdtInfo.l3MinCbmBits() {
+		return nil, fmt.Errorf("invalid cache bitmask %q: number of bits less than %d", data, rdtInfo.l3MinCbmBits())
+	}
+
+	return l3AbsoluteAllocation(value), nil
+}
+
+// Currently active set of "raw" options
 var opt = defaultOptions().(*options)
 
-// defaultOptions returns a new config instance, all initialized to defaults.
+// defaultOptions returns a new instance of "raw" options set to their defaults
 func defaultOptions() interface{} {
 	return &options{}
 }

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -48,16 +48,27 @@ type mbInfo struct {
 	minBandwidth  uint64
 }
 
-func (i Info) l3FullMask() Bitmask {
+// l3Info is a helper method for a "unified API" for getting L3 information
+func (i Info) l3Info() l3Info {
 	switch {
-	case i.l3.Supported():
-		return rdtInfo.l3.cbmMask
 	case i.l3code.Supported():
-		return rdtInfo.l3code.cbmMask
+		return rdtInfo.l3code
 	case i.l3data.Supported():
-		return rdtInfo.l3data.cbmMask
+		return rdtInfo.l3data
+	}
+	return rdtInfo.l3
+}
+
+func (i Info) l3CbmMask() Bitmask {
+	mask := i.l3Info().cbmMask
+	if mask != 0 {
+		return mask
 	}
 	return Bitmask(^uint64(0))
+}
+
+func (i Info) l3MinCbmBits() uint64 {
+	return i.l3Info().minCbmBits
 }
 
 func getRdtInfo(resctrlpath string) (Info, error) {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -70,10 +70,7 @@ func NewControl(resctrlpath string) (Control, error) {
 	}
 
 	if err := r.configureResctrl(r.conf); err != nil {
-		// Temporary hack to get rdt properly configured.
-		// Corresponging hack located in pkg/cri/resource-manager/resource-manager.go
-		// TODO: switch back to returning an error after rdt config management is fixed
-		r.Warn("configuration failed: %v", err)
+		return nil, rdtError("configuration failed: %v", err)
 	}
 
 	pkgcfg.GetModule("rdt").AddNotify(r.configNotify)

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -67,44 +67,52 @@ data:
             Socket: 3
           exclusive: false
   rdt: |+
-    config:
-      # Common options
-      options:
-        l3:
-          optional: true
-        mb:
-          optional: true
-      # This example config specifies three RDT classes (or resctrl groups) with L3
-      # CAT configured
-      resctrlGroups:
-        Guaranteed:
-          l3schema:
-            all:
-              unified: "100%"
-      # Specific settings for L3 CDP (Code and Data Prioritization)
-      #        code: "100%"
-      #        data: "80%"
-      # Specify CacheId (typically correspons CPU socket) specific setting
-      #      1:
-      #        unified: "80%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 100
-      #      1-3: 80
-        Burstable:
-          l3schema:
-            all:
-              unified: "66%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 66
-        BestEffort:
-          l3schema:
-            all:
-              unified: "33%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 33
+    # Common options
+    options:
+      l3:
+        optional: true
+      mb:
+        optional: true
+    # This example config specifies one partition with three classes (resctrl groups in the system)
+    # with L3 CAT configured
+    partitions:
+      default:
+        l3Allocation:
+          all: 100%
+        mbAllocation:
+          all: 100%
+        classes:
+          Guaranteed:
+            l3schema:
+              all:
+                unified: "100%"
+          # Specific settings for L3 CDP (Code and Data Prioritization)
+          #      code: "100%"
+          #      data: "80%"
+          # Specify CacheId (typically corresponds to a CPU socket) specific setting
+          #    1:
+          #      unified: "80%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 100
+          #    1-3: 80
+          Burstable:
+            l3schema:
+              all:
+                unified: "66%"
+                # Separate schema for L3 code and data paths specified
+                code: "100%"
+                data: "50%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 66
+          BestEffort:
+            l3schema:
+              all:
+                unified: "33%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 33
   dump: |+
     Config: full:.*,debug
     File: /tmp/cri-full-debug.dump
@@ -167,44 +175,52 @@ data:
             Socket: 3
           exclusive: false
   rdt: |+
-    config:
-      # Common options
-      options:
-        l3:
-          optional: true
-        mb:
-          optional: true
-      # This example config specifies three RDT classes (or resctrl groups) with L3
-      # CAT configured
-      resctrlGroups:
-        Guaranteed:
-          l3schema:
-            all:
-              unified: "100%"
-      # Specific settings for L3 CDP (Code and Data Prioritization)
-      #        code: "100%"
-      #        data: "80%"
-      # Specify CacheId (typically correspons CPU socket) specific setting
-      #      1:
-      #        unified: "80%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 100
-      #      1-3: 80
-        Burstable:
-          l3schema:
-            all:
-              unified: "66%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 66
-        BestEffort:
-          l3schema:
-            all:
-              unified: "33%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 33
+    # Common options
+    options:
+      l3:
+        optional: true
+      mb:
+        optional: true
+    # This example config specifies one partition with three classes (resctrl groups in the system)
+    # with L3 CAT configured
+    partitions:
+      default:
+        l3Allocation:
+          all: 100%
+        mbAllocation:
+          all: 100%
+        classes:
+          Guaranteed:
+            l3schema:
+              all:
+                unified: "100%"
+          # Specific settings for L3 CDP (Code and Data Prioritization)
+          #      code: "100%"
+          #      data: "80%"
+          # Specify CacheId (typically corresponds to a CPU socket) specific setting
+          #    1:
+          #      unified: "80%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 100
+          #    1-3: 80
+          Burstable:
+            l3schema:
+              all:
+                unified: "66%"
+                # Separate schema for L3 code and data paths specified
+                code: "100%"
+                data: "50%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 66
+          BestEffort:
+            l3schema:
+              all:
+                unified: "33%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 33
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -262,44 +278,52 @@ data:
             Socket: 3
           exclusive: false
   rdt: |+
-    config:
-      # Common options
-      options:
-        l3:
-          optional: true
-        mb:
-          optional: true
-      # This example config specifies three RDT classes (or resctrl groups) with L3
-      # CAT configured
-      resctrlGroups:
-        Guaranteed:
-          l3schema:
-            all:
-              unified: "100%"
-      # Specific settings for L3 CDP (Code and Data Prioritization)
-      #        code: "100%"
-      #        data: "80%"
-      # Specify CacheId (typically correspons CPU socket) specific setting
-      #      1:
-      #        unified: "80%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 100
-      #      1-3: 80
-        Burstable:
-          l3schema:
-            all:
-              unified: "66%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 66
-        BestEffort:
-          l3schema:
-            all:
-              unified: "33%"
-      # MBA (Memory Bandwidth Allocation)
-      #    mbschema:
-      #      all: 33
+    # Common options
+    options:
+      l3:
+        optional: true
+      mb:
+        optional: true
+    # This example config specifies one partition with three classes (resctrl groups in the system)
+    # with L3 CAT configured
+    partitions:
+      default:
+        l3Allocation:
+          all: 100%
+        mbAllocation:
+          all: 100%
+        classes:
+          Guaranteed:
+            l3schema:
+              all:
+                unified: "100%"
+          # Specific settings for L3 CDP (Code and Data Prioritization)
+          #      code: "100%"
+          #      data: "80%"
+          # Specify CacheId (typically corresponds to a CPU socket) specific setting
+          #    1:
+          #      unified: "80%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 100
+          #    1-3: 80
+          Burstable:
+            l3schema:
+              all:
+                unified: "66%"
+                # Separate schema for L3 code and data paths specified
+                code: "100%"
+                data: "50%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 66
+          BestEffort:
+            l3schema:
+              all:
+                unified: "33%"
+          # MBA (Memory Bandwidth Allocation)
+          #  mbschema:
+          #    all: 33
   dump: |+
     Config: full:.*,short:.*Stop.*,off:.*List.*
     File: /tmp/cri-selective-debug.dump


### PR DESCRIPTION
This patch implements a higher-level "partition" hierarchy for RDT
classes that allows easier configuration of exclusive resource
allocation. The partition confiugration specifies a portion of the
resources that will be shared by the classes under it.

One conceptual principle is that the resource allocation between
partitions is exclusive (i.e. there are no shared resources between
partitions) when the resource itself allows/supports exclusive
allocation. In practice, when we now have two resources (cache lines and
memory bandwidth), cache allocations are exclusive (no overlap on the
cache lines between partitions), but memory bandwidth may be overlap
(i.e. all partitions may have 100% of bandwidth).

This patch also changes the previously used terminology a bit: we now
use the term 'class' instead of 'group' or 'resctrl group' in CRI
Resource Manager and it's configuration file.

Aims at implementing #35 