### PR TITLE
rdt: fix writing multiple pids to tasks file

### DIFF
--- a/pkg/cri/resource-manager/resource-control/control.go
+++ b/pkg/cri/resource-manager/resource-control/control.go
@@ -59,12 +59,11 @@ func (c *criRdt) SetContainerClass(container cache.Container, class string) erro
 		return controlError("failed to get PIDs of container %s: %v", cID, err)
 	}
 
-	for _, pid := range pids {
-		if err = c.SetProcessClass(class, strconv.Itoa(pid)); err != nil {
-			return err
-		}
+	strPids := make([]string, len(pids))
+	for i, pid := range pids {
+		strPids[i] = strconv.Itoa(pid)
 	}
-	return nil
+	return c.SetProcessClass(class, strPids...)
 }
 
 func controlError(format string, args ...interface{}) error {


### PR DESCRIPTION
Fix an error when writing multiple pids to resctrl tasks file.

Ignore non-existent pids when updating tasks file