### PR TITLE
resource-manager: use initial config received from agent

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -75,31 +75,20 @@ func CreateStpPolicy(opts *policy.BackendOptions) policy.Backend {
 	stp.Info("creating policy...")
 
 	// Read STP configuration
-	if len(opts.Config) > 0 {
-		stp.Info("using policy config from cri-resmgr configuration")
-		stp.conf, err = parseConfData([]byte(opts.Config))
+	if len(opt.confDir) > 0 {
+		stp.conf, err = readConfDir(opt.confDir)
 		if err != nil {
-			stp.Warn("failed to parse config: %v", err)
-		}
-	} else {
-		if len(opt.confDir) > 0 {
-			stp.conf, err = readConfDir(opt.confDir)
-			if err != nil {
-				stp.Warn("failed to read configuration directory: %v", err)
-			}
-		}
-		if len(opt.confFile) > 0 {
-			if stp.conf != nil {
-				stp.Info("Overriding configuration from -static-pools-conf-dir with -static-pools-conf-file")
-			}
-			stp.conf, err = readConfFile(opt.confFile)
-			if err != nil {
-				stp.Warn("failed to read configuration directory: %v", err)
-			}
+			stp.Warn("failed to read configuration directory: %v", err)
 		}
 	}
-	if stp.conf == nil {
-		stp.Fatal("No STP policy configuration loaded")
+	if len(opt.confFile) > 0 {
+		if stp.conf != nil {
+			stp.Info("Overriding configuration from -static-pools-conf-dir with -static-pools-conf-file")
+		}
+		stp.conf, err = readConfFile(opt.confFile)
+		if err != nil {
+			stp.Warn("failed to read configuration directory: %v", err)
+		}
 	}
 
 	config.GetModule(PolicyPath).AddNotify(stp.configNotify)

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -53,8 +53,6 @@ type ConstraintSet map[Domain]Constraint
 
 // Options describes policy options
 type Options struct {
-	// Full configuration data
-	ResmgrConfig *config.RawConfig
 	// Client interface to cri-resmgr agent
 	AgentCli agent.Interface
 	// Rdt control interface
@@ -71,8 +69,6 @@ type BackendOptions struct {
 	AgentCli agent.Interface
 	// Rdt control interface
 	Rdt control.CriRdt
-	// Policy configuration data
-	Config string
 }
 
 // CreateFn is the type for functions used to create a policy instance.
@@ -194,11 +190,6 @@ func NewPolicy(o *Options) (Policy, error) {
 		}
 	}
 
-	conf := extractPolicyConfig(backend.Name(), o.ResmgrConfig)
-	if len(conf) == 0 {
-		p.Warn("received empty policy configuration")
-	}
-
 	if p.DebugEnabled() {
 		p.Debug("*** enabling debugging for %s", opt.Policy)
 		logger.Get(opt.Policy).EnableDebug(true)
@@ -211,7 +202,6 @@ func NewPolicy(o *Options) (Policy, error) {
 		Reserved:  opt.Reserved,
 		AgentCli:  o.AgentCli,
 		Rdt:       o.Rdt,
-		Config:    conf,
 	}
 	p.backend = backend.CreateFn()(backendOpts)
 

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -93,18 +93,9 @@ func NewResourceManager() (ResourceManager, error) {
 		}
 	}
 
-	if conf == nil || len(conf.Data) == 0 {
-		m.Warn("failed to fetch configuration, using last cached data")
-		conf = m.cache.GetConfig()
-	}
-	if conf != nil && len(conf.Data) > 0 {
-		m.SetConfig(conf)
-	}
-
 	policyOpts := &policy.Options{
-		ResmgrConfig: conf,
-		AgentCli:     agent,
-		Rdt:          m.rdt,
+		AgentCli: agent,
+		Rdt:      m.rdt,
 	}
 	if m.policy, err = policy.NewPolicy(policyOpts); err != nil {
 		return nil, resmgrError("failed to create resource manager: %v", err)
@@ -116,6 +107,14 @@ func NewResourceManager() (ResourceManager, error) {
 
 	if err = m.setupPolicyHooks(); err != nil {
 		return nil, resmgrError("failed to create resource manager: %v", err)
+	}
+
+	if conf == nil || len(conf.Data) == 0 {
+		m.Warn("failed to fetch configuration, using last cached data")
+		conf = m.cache.GetConfig()
+	}
+	if conf != nil && len(conf.Data) > 0 {
+		m.SetConfig(conf)
 	}
 
 	if m.configServer, err = config.NewConfigServer(m.SetConfig); err != nil {

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -87,18 +87,18 @@ func NewResourceManager() (ResourceManager, error) {
 		return nil, resmgrError("failed to create resource manager: %v", err)
 	}
 
-	if conf == nil || len(conf.Data) == 0 {
-		m.Warn("failed to fetch configuration, using last cached data")
-		conf = m.cache.GetConfig()
-	}
-	if conf == nil {
-		conf = &config.RawConfig{}
-	}
-
 	if !opt.NoRdt {
 		if err = m.setupRdt(conf.Get("rdt")); err != nil {
 			return nil, resmgrError("failed to create resource manager: %v", err)
 		}
+	}
+
+	if conf == nil || len(conf.Data) == 0 {
+		m.Warn("failed to fetch configuration, using last cached data")
+		conf = m.cache.GetConfig()
+	}
+	if conf != nil && len(conf.Data) > 0 {
+		m.SetConfig(conf)
 	}
 
 	policyOpts := &policy.Options{


### PR DESCRIPTION
Use the initial configuration queried from cri-resmgr-agent. Also,
initialize RDT before parsing this configuration because the config
parsing currently needs RDT information that is made available at RDT
initialization time.