### PR TITLE
devel: apply initial configuration before startup.

### DIFF
--- a/cmd/cri-resmgr/main.go
+++ b/cmd/cri-resmgr/main.go
@@ -29,12 +29,10 @@ import (
 )
 
 func main() {
-	var configFile string
 	var printConfig bool
 
 	log := logger.Default()
 
-	flag.StringVar(&configFile, "config", "", "Read initial configuration from given file.")
 	flag.BoolVar(&printConfig, "print-config", false, "Print configuration and exit.")
 	flag.Parse()
 
@@ -52,12 +50,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if configFile != "" {
-		if err := config.SetConfigFromFile(configFile); err != nil {
-			log.Error("failed to set configuraton from file '%s': %v", configFile, err)
-			os.Exit(1)
-		}
-	}
 	if printConfig {
 		config.Print(nil)
 		os.Exit(0)

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -16,7 +16,6 @@ package resmgr
 
 import (
 	"flag"
-	"github.com/intel/cri-resource-manager/pkg/config"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/client"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
@@ -31,44 +30,16 @@ type options struct {
 	AgentSocket   string `json:",omitempty"`
 	ConfigSocket  string `json:",omitempty"`
 	ResctrlPath   string `json:",omitempty"`
-	NoRdt         bool
-}
-
-// conf captures our runtime configurable parameters.
-type conf struct {
-	// NoRdt disables RDT resource management.
-	NoRdt bool
 }
 
 // Relay command line options and runtime configuration with their defaults.
-var opt = defaultOptions().(*options)
-var cfg = defaultConfig().(*conf)
-
-// configNotify propagates runtime configurable changes to our options.
-func (o *options) configNotify(event config.Event, source config.Source) error {
-	o.NoRdt = cfg.NoRdt
-	return nil
-}
-
-// defaultOptions returns a new options instance, all initialized to defaults.
-func defaultOptions() interface{} {
-	return &options{
-		ImageSocket:   client.DontConnect,
-		RuntimeSocket: sockets.DockerShim,
-		RelaySocket:   sockets.ResourceManagerRelay,
-		RelayDir:      "/var/libb/cri-resmgr",
-		AgentSocket:   sockets.ResourceManagerAgent,
-		ConfigSocket:  sockets.ResourceManagerConfig,
-		ResctrlPath:   "",
-		NoRdt:         defaultConfig().(*conf).NoRdt,
-	}
-}
-
-// defaultConfig returns a new conf instance, all initialized to defaults.
-func defaultConfig() interface{} {
-	return &conf{
-		NoRdt: false,
-	}
+var opt = options{
+	ImageSocket:   client.DontConnect,
+	RuntimeSocket: sockets.DockerShim,
+	RelaySocket:   sockets.ResourceManagerRelay,
+	RelayDir:      "/var/libb/cri-resmgr",
+	AgentSocket:   sockets.ResourceManagerAgent,
+	ConfigSocket:  sockets.ResourceManagerConfig,
 }
 
 // Register us for command line option processing and configuration handling.
@@ -85,11 +56,4 @@ func init() {
 		"local socket of the cri-resmgr agent to connect")
 	flag.StringVar(&opt.ConfigSocket, "config-socket", sockets.ResourceManagerConfig,
 		"Unix domain socket path where the resource manager listens for cri-resmgr-agent")
-	flag.BoolVar(&opt.NoRdt, "no-rdt", false,
-		"Disable RDT resource management")
-	flag.StringVar(&opt.ResctrlPath, "resctrl-path", "",
-		"Path of the resctrl filesystem mountpoint")
-
-	config.Register("resource-manager", "Resource Management", cfg, defaultConfig,
-		config.WithNotify(opt.configNotify))
 }

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -23,13 +23,15 @@ import (
 
 // Options captures our command line or runtime configurable parameters.
 type options struct {
-	ImageSocket   string `json:",omitempty"`
-	RuntimeSocket string `json:",omitempty"`
-	RelaySocket   string `json:",omitempty"`
-	RelayDir      string `json:",omitempty"`
-	AgentSocket   string `json:",omitempty"`
-	ConfigSocket  string `json:",omitempty"`
-	ResctrlPath   string `json:",omitempty"`
+	ImageSocket    string `json:",omitempty"`
+	RuntimeSocket  string `json:",omitempty"`
+	RelaySocket    string `json:",omitempty"`
+	RelayDir       string `json:",omitempty"`
+	AgentSocket    string `json:",omitempty"`
+	ConfigSocket   string `json:",omitempty"`
+	ResctrlPath    string `json:",omitempty"`
+	FallbackConfig string `json:",omitempty"`
+	ForceConfig    string `json:",omitempty"`
 }
 
 // Relay command line options and runtime configuration with their defaults.
@@ -56,4 +58,9 @@ func init() {
 		"local socket of the cri-resmgr agent to connect")
 	flag.StringVar(&opt.ConfigSocket, "config-socket", sockets.ResourceManagerConfig,
 		"Unix domain socket path where the resource manager listens for cri-resmgr-agent")
+
+	flag.StringVar(&opt.FallbackConfig, "fallback-config", "",
+		"Fallback configuration to use unless/until one is available from the cache or agent.")
+	flag.StringVar(&opt.ForceConfig, "force-config", "",
+		"Configuration used to override the one stored in the cache. Does not override the agent.")
 }

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -35,14 +35,7 @@ type options struct {
 }
 
 // Relay command line options and runtime configuration with their defaults.
-var opt = options{
-	ImageSocket:   client.DontConnect,
-	RuntimeSocket: sockets.DockerShim,
-	RelaySocket:   sockets.ResourceManagerRelay,
-	RelayDir:      "/var/libb/cri-resmgr",
-	AgentSocket:   sockets.ResourceManagerAgent,
-	ConfigSocket:  sockets.ResourceManagerConfig,
-}
+var opt = options{}
 
 // Register us for command line option processing and configuration handling.
 func init() {

--- a/pkg/cri/resource-manager/policy.go
+++ b/pkg/cri/resource-manager/policy.go
@@ -100,7 +100,7 @@ func (m *resmgr) startPolicy() error {
 		add = append(add, c)
 	}
 
-	if err := m.policy.Start(m.cache, add, deleted); err != nil {
+	if err := m.policy.Start(add, deleted); err != nil {
 		return resmgrError("failed to start policy: %v", err)
 	}
 
@@ -271,10 +271,6 @@ func (m *resmgr) processWithPolicy(ctx context.Context, method string, req inter
 			c.UpdateState(cache.ContainerStateRunning)
 		}
 
-		policyErr := m.policy.PostStart(c)
-		if policyErr != nil {
-			m.Warn("failed to update affected container %s: %v", c.GetID(), policyErr)
-		}
 		return rpl, err
 
 	default:

--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -48,8 +48,11 @@ var _ policy.Backend = &eda{}
 //
 
 // CreateEdaPolicy creates a new policy instance.
-func CreateEdaPolicy(opts *policy.BackendOptions) policy.Backend {
-	eda := &eda{Logger: logger.NewLogger(PolicyName)}
+func CreateEdaPolicy(state cache.Cache, opts *policy.BackendOptions) policy.Backend {
+	eda := &eda{
+		Logger: logger.NewLogger(PolicyName),
+		state:  state,
+	}
 	eda.Info("creating policy...")
 	// TODO: policy configuration (if any)
 	return eda
@@ -66,7 +69,7 @@ func (eda *eda) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (eda *eda) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
+func (eda *eda) Start(add []cache.Container, del []cache.Container) error {
 	eda.Debug("preparing for making decisions...")
 	return nil
 }
@@ -127,15 +130,6 @@ func (eda *eda) ExportResourceData(c cache.Container, syntax policy.DataSyntax) 
 	return nil
 }
 
-func (eda *eda) PostStart(cch cache.Container) error {
-	return nil
-}
-
-// SetConfig sets the policy backend configuration
-func (eda *eda) SetConfig(conf string) error {
-	return nil
-}
-
 //
 // Helper functions for STP policy backend
 //
@@ -144,30 +138,7 @@ func edaError(format string, args ...interface{}) error {
 	return fmt.Errorf(PolicyName+": "+format, args...)
 }
 
-//
-// Automatically register us as a policy implementation.
-//
-
-// Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.BackendOptions) policy.Backend
-
-// Name returns the name of this policy implementation.
-func (i Implementation) Name() string {
-	return PolicyName
-}
-
-// Description returns the desccription of this policy implementation.
-func (i Implementation) Description() string {
-	return PolicyDescription
-}
-
-// CreateFn returns the functions used to instantiate this policy.
-func (i Implementation) CreateFn() policy.CreateFn {
-	return policy.CreateFn(i)
-}
-
-var _ policy.Implementation = Implementation(nil)
-
+// Register us as a policy implementation.
 func init() {
-	policy.Register(Implementation(CreateEdaPolicy))
+	policy.Register(PolicyName, PolicyDescription, CreateEdaPolicy)
 }

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -29,12 +29,13 @@ const (
 
 type none struct {
 	logger.Logger
+	cch cache.Cache
 }
 
 var _ policy.Backend = &none{}
 
 // CreateNonePolicy creates a new policy instance.
-func CreateNonePolicy(opts *policy.BackendOptions) policy.Backend {
+func CreateNonePolicy(cache cache.Cache, opts *policy.BackendOptions) policy.Backend {
 	n := &none{Logger: logger.NewLogger(PolicyName)}
 	n.Info("creating policy...")
 	return n
@@ -51,7 +52,7 @@ func (n *none) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (n *none) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
+func (n *none) Start(add []cache.Container, del []cache.Container) error {
 	n.Debug("got started...")
 	return nil
 }
@@ -85,40 +86,7 @@ func (n *none) ExportResourceData(c cache.Container, syntax policy.DataSyntax) [
 	return nil
 }
 
-func (n *none) PostStart(cch cache.Container) error {
-	n.Debug("post start container...")
-	return nil
-}
-
-// SetConfig sets the policy backend configuration
-func (n *none) SetConfig(string) error {
-	return nil
-}
-
-//
-// Automatically register us as a policy implementation.
-//
-
-// Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.BackendOptions) policy.Backend
-
-// Name returns the name of this policy implementation.
-func (n Implementation) Name() string {
-	return PolicyName
-}
-
-// Description returns the desccription of this policy implementation.
-func (n Implementation) Description() string {
-	return PolicyDescription
-}
-
-// CreateFn returns the functions used to instantiate this policy.
-func (n Implementation) CreateFn() policy.CreateFn {
-	return policy.CreateFn(n)
-}
-
-var _ policy.Implementation = Implementation(nil)
-
+// Register us as a policy implementation.
 func init() {
-	policy.Register(Implementation(CreateNonePolicy))
+	policy.Register(PolicyName, PolicyDescription, CreateNonePolicy)
 }

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -71,9 +71,10 @@ type staticplus struct {
 var _ policy.Backend = &staticplus{}
 
 // CreateStaticPlusPolicy creates a new policy instance.
-func CreateStaticPlusPolicy(opts *policy.BackendOptions) policy.Backend {
+func CreateStaticPlusPolicy(cache cache.Cache, opts *policy.BackendOptions) policy.Backend {
 	p := &staticplus{
 		Logger: logger.NewLogger(PolicyName),
+		cache:  cache,
 	}
 
 	p.Info("creating policy...")
@@ -102,9 +103,7 @@ func (p *staticplus) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (p *staticplus) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
-	p.cache = cch
-
+func (p *staticplus) Start(add []cache.Container, del []cache.Container) error {
 	if err := p.restoreCache(); err != nil {
 		return policyError("failed to start: %v", err)
 	}
@@ -194,11 +193,6 @@ func (p *staticplus) ExportResourceData(c cache.Container, syntax policy.DataSyn
 	}
 
 	return []byte(data)
-}
-
-// SetConfig sets the policy backend configuration
-func (p *staticplus) SetConfig(string) error {
-	return nil
 }
 
 // policyError creates a formatted policy-specific error.
@@ -754,30 +748,7 @@ func MilliCPUToShares(milliCPU int) int64 {
 	return int64(shares)
 }
 
-//
-// Automatically register us as a policy implementation.
-//
-
-// Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.BackendOptions) policy.Backend
-
-// Name returns the name of this policy implementation.
-func (n Implementation) Name() string {
-	return PolicyName
-}
-
-// Description returns the desccription of this policy implementation.
-func (n Implementation) Description() string {
-	return PolicyDescription
-}
-
-// CreateFn returns the functions used to instantiate this policy.
-func (n Implementation) CreateFn() policy.CreateFn {
-	return policy.CreateFn(n)
-}
-
-var _ policy.Implementation = Implementation(nil)
-
+// Register us as a policy implementation.
 func init() {
-	policy.Register(Implementation(CreateStaticPlusPolicy))
+	policy.Register(PolicyName, PolicyDescription, CreateStaticPlusPolicy)
 }

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -29,7 +29,6 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
-	control "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/resource-control"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
 )
 
@@ -53,7 +52,6 @@ type static struct {
 	sys           *sysfs.System        // system/topology information
 	numHT         int                  // number of hyperthreads per core
 	state         cache.Cache          // policy/state cache
-	rdt           control.CriRdt       // RDT resource control interface
 }
 
 // Make sure static implements the policy backend interface.
@@ -70,7 +68,6 @@ func NewStaticPolicy(opts *policy.BackendOptions) policy.Backend {
 		Logger:    logger.NewLogger(PolicyName),
 		available: opts.Available,
 		reserved:  opts.Reserved,
-		rdt:       opts.Rdt,
 	}
 
 	s.Info("creating policy...")
@@ -189,33 +186,9 @@ func (s *static) ExportResourceData(c cache.Container, syntax policy.DataSyntax)
 	return []byte(data)
 }
 
-// PostStart allocates resources after container is started
-func (s *static) PostStart(c cache.Container) error {
-	if opt.Rdt == TristateOff {
-		return nil
-	} else if opt.Rdt == TristateOn && s.rdt == nil {
-		return policyError("RDT required but not available")
-	}
-	if s.rdt != nil {
-		pod, ok := c.GetPod()
-		if !ok {
-			return policyError("Pod of container %q not found", c.GetID())
-		}
-		qos := string(pod.GetQOSClass())
-
-		s.Info("setting RDT class of container %q to %q", c.GetID(), qos)
-
-		return s.rdt.SetContainerClass(c, qos)
-	}
-	return nil
-}
-
 func (s *static) configNotify(event config.Event, source config.Source) error {
 	s.Info("configuration %s", event)
 
-	if opt.Rdt == TristateOn && s.rdt == nil {
-		return policyError("RDT requested but not available")
-	}
 	if opt.RelaxedIsolation {
 		s.Info("isolated exclusive CPUs: globally preferred (all pods)")
 	} else {

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -63,9 +63,10 @@ const (
 )
 
 // NewStaticPolicy creates a new policy instance.
-func NewStaticPolicy(opts *policy.BackendOptions) policy.Backend {
+func NewStaticPolicy(state cache.Cache, opts *policy.BackendOptions) policy.Backend {
 	s := &static{
 		Logger:    logger.NewLogger(PolicyName),
+		state:     state,
 		available: opts.Available,
 		reserved:  opts.Reserved,
 	}
@@ -100,7 +101,7 @@ func (s *static) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (s *static) Start(state cache.Cache, add []cache.Container, del []cache.Container) error {
+func (s *static) Start(add []cache.Container, del []cache.Container) error {
 	s.Debug("starting up...")
 
 	if err := s.allocateReserved(); err != nil {
@@ -110,7 +111,7 @@ func (s *static) Start(state cache.Cache, add []cache.Container, del []cache.Con
 	s.Info("using reserved CPUs: %s", s.reservedCpus.String())
 	s.Info("using available CPUs: %s", s.availableCpus.String())
 
-	if err := s.validateState(state); err != nil {
+	if err := s.validateState(s.state); err != nil {
 		return policyError("failed to start with given cache/state: %v", err)
 	}
 
@@ -198,11 +199,6 @@ func (s *static) configNotify(event config.Event, source config.Source) error {
 
 	s.Info("rdt support set to %v", opt.Rdt)
 
-	return nil
-}
-
-// SetConfig sets the policy backend configuration
-func (s *static) SetConfig(conf string) error {
 	return nil
 }
 
@@ -666,30 +662,7 @@ func (s *static) SetCpusetCpus(id, value string) error {
 	return nil
 }
 
-//
-// Automatically register us as a policy implementation.
-//
-
-// Implementation is the implementation we register with the policy module.
-type Implementation func(*policy.BackendOptions) policy.Backend
-
-// Name returns the name of this policy implementation.
-func (i Implementation) Name() string {
-	return PolicyName
-}
-
-// Description returns the desccription of this policy implementation.
-func (i Implementation) Description() string {
-	return PolicyDescription
-}
-
-// CreateFn returns the functions used to instantiate this policy.
-func (i Implementation) CreateFn() policy.CreateFn {
-	return policy.CreateFn(i)
-}
-
-var _ policy.Implementation = Implementation(nil)
-
+// Register us as a policy implementation.
 func init() {
-	policy.Register(Implementation(NewStaticPolicy))
+	policy.Register(PolicyName, PolicyDescription, NewStaticPolicy)
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -391,6 +391,12 @@ func (m *mockCache) EvaluateAffinity(*cache.Affinity) map[string]int32 {
 		"fake key": 1,
 	}
 }
+func (m *mockCache) GetActivePolicy() string {
+	panic("unimplemented")
+}
+func (m *mockCache) SetActivePolicy(string) error {
+	panic("unimplemented")
+}
 func (m *mockCache) SetPolicyEntry(string, interface{}) {
 }
 func (m *mockCache) GetPolicyEntry(string, interface{}) bool {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -75,8 +75,11 @@ type policy struct {
 var _ policyapi.Backend = &policy{}
 
 // CreateTopologyAwarePolicy creates a new policy instance.
-func CreateTopologyAwarePolicy(opts *policyapi.BackendOptions) policyapi.Backend {
-	p := &policy{options: *opts}
+func CreateTopologyAwarePolicy(cache cache.Cache, opts *policyapi.BackendOptions) policyapi.Backend {
+	p := &policy{
+		cache:   cache,
+		options: *opts,
+	}
 
 	p.nodes = make(map[string]Node)
 	p.allocations = allocations{policy: p, CPU: make(map[string]CPUGrant, 32)}
@@ -111,9 +114,7 @@ func (p *policy) Description() string {
 }
 
 // Start prepares this policy for accepting allocation/release requests.
-func (p *policy) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
-	p.cache = cch
-
+func (p *policy) Start(add []cache.Container, del []cache.Container) error {
 	if err := p.restoreCache(); err != nil {
 		return policyError("failed to start: %v", err)
 	}
@@ -216,11 +217,6 @@ func (p *policy) ExportResourceData(c cache.Container, syntax policyapi.DataSynt
 	return []byte(data)
 }
 
-func (p *policy) PostStart(cch cache.Container) error {
-	log.Debug("post start container...")
-	return nil
-}
-
 func (p *policy) configNotify(event config.Event, source config.Source) error {
 	log.Info("configuration %s:", event)
 	log.Info("  - pin containers to CPUs: %v", opt.PinCPU)
@@ -235,11 +231,6 @@ func (p *policy) configNotify(event config.Event, source config.Source) error {
 
 	p.saveConfig()
 
-	return nil
-}
-
-// SetConfig sets the policy backend configuration.
-func (p *policy) SetConfig(rawConf string) error {
 	return nil
 }
 
@@ -310,30 +301,7 @@ func (p *policy) restoreCache() error {
 	return nil
 }
 
-//
-// Automatically register us as a policy implementation.
-//
-
-// Implementation is the implementation we register with the policy module.
-type Implementation func(*policyapi.BackendOptions) policyapi.Backend
-
-// Name returns the name of this policy implementation.
-func (Implementation) Name() string {
-	return PolicyName
-}
-
-// Description returns the desccription of this policy implementation.
-func (Implementation) Description() string {
-	return PolicyDescription
-}
-
-// CreateFn returns the functions used to instantiate this policy.
-func (i Implementation) CreateFn() policyapi.CreateFn {
-	return policyapi.CreateFn(i)
-}
-
-var _ policyapi.Implementation = Implementation(nil)
-
+// Register us as a policy implementation.
 func init() {
-	policyapi.Register(Implementation(CreateTopologyAwarePolicy))
+	policyapi.Register(PolicyName, PolicyDescription, CreateTopologyAwarePolicy)
 }

--- a/pkg/cri/resource-manager/policy/flags.go
+++ b/pkg/cri/resource-manager/policy/flags.go
@@ -38,9 +38,6 @@ type options struct {
 	Reserved ConstraintSet `json:"ReservedResources,omitempty"`
 }
 
-// Registered policy implementations.
-var policies = map[string]Implementation{}
-
 // Our runtime configuration.
 var opt = defaultOptions().(*options)
 

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -17,14 +17,12 @@ package policy
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
-	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/config"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
 
@@ -67,7 +65,7 @@ type BackendOptions struct {
 }
 
 // CreateFn is the type for functions used to create a policy instance.
-type CreateFn func(*BackendOptions) Backend
+type CreateFn func(cache.Cache, *BackendOptions) Backend
 
 // DataSyntax defines the syntax used to export data to a container.
 type DataSyntax string
@@ -78,16 +76,6 @@ const (
 	// ExportedResources is the name of the file container resources are exported to.
 	ExportedResources = "resources.sh"
 )
-
-// Implementation attaches metadata (name, etc.) to a backend creation function.
-type Implementation interface {
-	// Name returns the well-known name for this policy.
-	Name() string
-	// Description returns a verbose description for this policy.
-	Description() string
-	// CreateFn creates an instance of this policy.
-	CreateFn() CreateFn
-}
 
 // Backend is the policy (decision making logic) interface exposed by implementations.
 //
@@ -100,7 +88,7 @@ type Backend interface {
 	// Description gives a verbose description about the policy implementation.
 	Description() string
 	// Start up and sycnhronizes the policy, using the given cache and resource constraints.
-	Start(cache.Cache, []cache.Container, []cache.Container) error
+	Start([]cache.Container, []cache.Container) error
 	// Sync synchronizes the policy, allocating/releasing the given containers.
 	Sync([]cache.Container, []cache.Container) error
 	// AllocateResources allocates resources to/for a container.
@@ -111,16 +99,12 @@ type Backend interface {
 	UpdateResources(cache.Container) error
 	// ExportResourceData provides resource data to export for the container.
 	ExportResourceData(cache.Container, DataSyntax) []byte
-	// PostStart allocates resources after container is started
-	PostStart(cache.Container) error
-	// SetConfig sets the policy backend configuration
-	SetConfig(string) error
 }
 
 // Policy is the exposed interface for container resource allocations decision making.
 type Policy interface {
 	// Start starts up policy, prepare for serving resource management requests.
-	Start(cache.Cache, []cache.Container, []cache.Container) error
+	Start([]cache.Container, []cache.Container) error
 	// PrepareDecisions prepares policy decisions.
 	PrepareDecisions() error
 	// QueryDecisions queries pending policy decisions.
@@ -137,18 +121,26 @@ type Policy interface {
 	ReleaseResources(cache.Container) error
 	// UpdateResources updates resource allocations of a container.
 	UpdateResources(cache.Container) error
-	// PostStart allocates resources after container is started
-	PostStart(cache.Container) error
-	// SetConfig sets the policy configuration
-	SetConfig(*config.RawConfig) error
 }
 
 // Policy instance/state.
 type policy struct {
-	logger.Logger
 	cache   cache.Cache // system state cache
 	backend Backend     // our active backend
 }
+
+// backend is a registered Backend.
+type backend struct {
+	name        string   // unqiue backend name
+	description string   // verbose backend description
+	create      CreateFn // backend creation function
+}
+
+// Out logger instance.
+var log logger.Logger = logger.NewLogger("policy")
+
+// Registered backends.
+var backends = make(map[string]*backend)
 
 // ActivePolicy returns the name of the policy to be activated.
 func ActivePolicy() string {
@@ -156,40 +148,40 @@ func ActivePolicy() string {
 }
 
 // NewPolicy creates a policy instance using the selected backend.
-func NewPolicy(o *Options) (Policy, error) {
+func NewPolicy(cache cache.Cache, o *Options) (Policy, error) {
 	if opt.Policy == NullPolicy {
 		return nil, nil
 	}
 
-	backend, ok := policies[opt.Policy]
+	backend, ok := backends[opt.Policy]
 	if !ok {
 		return nil, policyError("unknown policy '%s'", opt.Policy)
 	}
 
 	p := &policy{
-		Logger: logger.NewLogger("policy"),
+		cache: cache,
 	}
 
-	p.Info("creating new policy '%s'...", backend.Name())
+	log.Info("creating new policy '%s'...", backend.name)
 	if len(opt.Available) != 0 {
-		p.Info("  with resource availability constraints:")
+		log.Info("  with resource availability constraints:")
 		for d := range opt.Available {
-			p.Info("    - %s=%s", d, ConstraintToString(opt.Available[d]))
+			log.Info("    - %s=%s", d, ConstraintToString(opt.Available[d]))
 		}
 	}
 
 	if len(opt.Reserved) != 0 {
-		p.Info("  with resource reservation constraints:")
+		log.Info("  with resource reservation constraints:")
 		for d := range opt.Reserved {
-			p.Info("    - %s=%s", d, ConstraintToString(opt.Reserved[d]))
+			log.Info("    - %s=%s", d, ConstraintToString(opt.Reserved[d]))
 		}
 	}
 
-	if p.DebugEnabled() {
-		p.Debug("*** enabling debugging for %s", opt.Policy)
+	if log.DebugEnabled() {
+		log.Debug("*** enabling debugging for %s", opt.Policy)
 		logger.Get(opt.Policy).EnableDebug(true)
 	} else {
-		p.Debug("*** leaving debugging for %s alone", opt.Policy)
+		log.Debug("*** leaving debugging for %s alone", opt.Policy)
 	}
 
 	backendOpts := &BackendOptions{
@@ -197,23 +189,18 @@ func NewPolicy(o *Options) (Policy, error) {
 		Reserved:  opt.Reserved,
 		AgentCli:  o.AgentCli,
 	}
-	p.backend = backend.CreateFn()(backendOpts)
+	p.backend = backend.create(p.cache, backendOpts)
 
 	return p, nil
 }
 
 // Start starts up policy, preparing it for resving requests.
-func (p *policy) Start(cch cache.Cache, add []cache.Container, del []cache.Container) error {
+func (p *policy) Start(add []cache.Container, del []cache.Container) error {
 	if opt.Policy == NullPolicy {
 		return nil
 	}
 
-	if p.cache != nil {
-		return policyError("policy %s has already been started", p.backend.Name())
-	}
-
-	p.Info("starting policy '%s'...", p.backend.Name())
-	p.cache = cch
+	log.Info("starting policy '%s'...", p.backend.Name())
 
 	// Notes:
 	//   Start() also creates an implicit transaction. This allows the backend
@@ -223,7 +210,7 @@ func (p *policy) Start(cch cache.Cache, add []cache.Container, del []cache.Conta
 
 	p.PrepareDecisions()
 
-	if err := p.backend.Start(p.cache, add, del); err != nil {
+	if err := p.backend.Start(add, del); err != nil {
 		p.AbortDecisions()
 		return err
 	}
@@ -279,44 +266,19 @@ func (p *policy) UpdateResources(c cache.Container) error {
 	return p.backend.UpdateResources(c)
 }
 
-func (p *policy) PostStart(c cache.Container) error {
-	return p.backend.PostStart(c)
-}
-
-// SetConfig updates the configuration of policy backend(s)
-func (p *policy) SetConfig(conf *config.RawConfig) error {
-	p.Info("updating configuration for policy %s...", p.backend.Name())
-
-	c := extractPolicyConfig(p.backend.Name(), conf)
-	err := p.backend.SetConfig(c)
-
-	if err != nil {
-		p.Error("failed to update configuration: %v", err)
-		return policyError("failed to update configuration for policy %s: %v",
-			p.backend.Name(), err)
-	}
-
-	p.Info("configuration update OK")
-
-	return nil
-}
-
-// Register registers a policy implementation.
-func Register(p Implementation) error {
-	log := logger.Get("policy")
-	name := p.Name()
-
-	if p.CreateFn() == nil {
-		return policyError("policy '%s' has a nil instantiation function", name)
-	}
-
+// Register registers a policy backend.
+func Register(name, description string, create CreateFn) error {
 	log.Info("registering policy '%s'...", name)
 
-	if _, ok := policies[name]; ok {
-		return policyError("policy '%s' already registered", name)
+	if o, ok := backends[name]; ok {
+		return policyError("policy %s already registered (%s)", name, o.description)
 	}
 
-	policies[name] = p
+	backends[name] = &backend{
+		name:        name,
+		description: description,
+		create:      create,
+	}
 
 	return nil
 }
@@ -336,34 +298,4 @@ func ConstraintToString(value Constraint) string {
 	default:
 		return fmt.Sprintf("<???(type:%T)>", value)
 	}
-}
-
-// extractPolicyConfig gets the policy/node specific configuration from the
-// full cri-resmgr raw config
-func extractPolicyConfig(policyName string, rawConfig *config.RawConfig) string {
-	config := defaultPolicyConfig(policyName)
-
-	// Go through keys in allconfig (map) and try to find the policy configuration
-	// Scheme for the policy config key is policy.<policy name>[.<node name>]
-	if rawConfig != nil {
-		for k, v := range rawConfig.Data {
-			split := strings.SplitN(k, ".", 3)
-			if split[0] == "policy" && len(split) > 1 && split[1] == policyName {
-				if len(split) == 2 {
-					config = v
-				} else if split[2] == rawConfig.NodeName {
-					config = v
-					break
-				}
-			}
-		}
-	}
-
-	return config
-}
-
-// Return the default configuration for the specified policy.
-func defaultPolicyConfig(policyName string) string {
-	// Just a stub for now, always returning empty.
-	return ""
 }

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -25,7 +25,6 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/config"
-	control "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/resource-control"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
 
@@ -55,8 +54,6 @@ type ConstraintSet map[Domain]Constraint
 type Options struct {
 	// Client interface to cri-resmgr agent
 	AgentCli agent.Interface
-	// Rdt control interface
-	Rdt control.CriRdt
 }
 
 // BackendOptions describes the options for a policy backend instance
@@ -67,8 +64,6 @@ type BackendOptions struct {
 	Reserved ConstraintSet
 	// Client interface to cri-resmgr agent
 	AgentCli agent.Interface
-	// Rdt control interface
-	Rdt control.CriRdt
 }
 
 // CreateFn is the type for functions used to create a policy instance.
@@ -201,7 +196,6 @@ func NewPolicy(o *Options) (Policy, error) {
 		Available: opt.Available,
 		Reserved:  opt.Reserved,
 		AgentCli:  o.AgentCli,
-		Rdt:       o.Rdt,
 	}
 	p.backend = backend.CreateFn()(backendOpts)
 

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -88,7 +88,7 @@ func NewResourceManager() (ResourceManager, error) {
 	policyOpts := &policy.Options{
 		AgentCli: agent,
 	}
-	if m.policy, err = policy.NewPolicy(policyOpts); err != nil {
+	if m.policy, err = policy.NewPolicy(m.cache, policyOpts); err != nil {
 		return nil, resmgrError("failed to create resource manager: %v", err)
 	}
 

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -79,7 +79,6 @@ func NewResourceManager() (ResourceManager, error) {
 
 	copts := cache.Options{
 		CacheDir: opt.RelayDir,
-		Policy:   policy.ActivePolicy(),
 	}
 	if m.cache, err = cache.NewCache(copts); err != nil {
 		return nil, resmgrError("failed to create resource manager: %v", err)


### PR DESCRIPTION
This patch set changes the startup sequence to fetch the latest known configuration and apply it before starting any policy/request processing. This allows, in principle, the active policy to boot
directly into its latest up-to-date configuration.

Moreover, loading this initial configuration is attempted, in decreasing order of preference, from
      - forced configuration (for development, disables updates),
      - the agent,
      - last up-to-date configuration stored in the cache,
      - fallback configuration (also if cached one fails to apply)

The original active/saved policy check recently removed from the cache is
now attempted by the resource manager once the initial configuration is
loaded.

***Notes***: The extra squashme-commits take care of modifying the unit-tests and mocked interfaces according to the changes pending in this patch set. They are split out to help (avoid) re-reviewing and will be squashed before this PR is merged.
