### PR TITLE
topologyaware: cover pod-preferences.go with unit tests

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
@@ -16,6 +16,7 @@ package topologyaware
 
 import (
 	"fmt"
+
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
@@ -117,7 +118,12 @@ type cpuRequest struct {
 	full      int             // number of full CPUs requested
 	fraction  int             // amount of fractional CPU requested
 	isolate   bool            // prefer isolated exclusive CPUs
-	elevate   int             // displace allocation up in the tree
+
+	// elevate indicates how much to elevate the actual allocation of the
+	// container in the tree of pools. Or in other words how many levels to
+	// go up in the tree starting at the best fitting pool, before assigning
+	// the container to an actual pool. Currently ignored.
+	elevate int
 }
 
 var _ CPURequest = &cpuRequest{}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -1,0 +1,287 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	v1 "k8s.io/api/core/v1"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+type mockContainer struct {
+	name                                  string
+	namespace                             string
+	returnValueForGetResourceRequirements v1.ResourceRequirements
+}
+
+func (m *mockContainer) PrettyName() string {
+	return m.name
+}
+func (m *mockContainer) GetPod() (cache.Pod, bool) {
+	return &mockPod{}, false
+}
+func (m *mockContainer) GetID() string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetPodID() string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetCacheID() string {
+	return "0"
+}
+func (m *mockContainer) GetName() string {
+	return m.name
+}
+func (m *mockContainer) GetNamespace() string {
+	return m.namespace
+}
+func (m *mockContainer) UpdateState(cache.ContainerState) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetState() cache.ContainerState {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetQOSClass() v1.PodQOSClass {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetImage() string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetCommand() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetArgs() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetLabelKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetLabel(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetResmgrLabelKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetResmgrLabel(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetAnnotationKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetAnnotation(string, interface{}) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetResmgrAnnotationKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetResmgrAnnotation(string, interface{}) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetEnvKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetEnv(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetMounts() []cache.Mount {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetMountByHost(string) *cache.Mount {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetMountByContainer(string) *cache.Mount {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetDevices() []cache.Device {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetDeviceByHost(string) *cache.Device {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetDeviceByContainer(string) *cache.Device {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetResourceRequirements() v1.ResourceRequirements {
+	return m.returnValueForGetResourceRequirements
+}
+func (m *mockContainer) GetLinuxResources() *cri.LinuxContainerResources {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetCommand([]string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetArgs([]string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetLabel(string, string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteLabel(string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetAnnotation(string, string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteAnnotation(string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetEnv(string, string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) UnsetEnv(string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) InsertMount(*cache.Mount) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteMount(string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) InsertDevice(*cache.Device) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteDevice(string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetTopologyHints() sysfs.TopologyHints {
+	return sysfs.TopologyHints{}
+}
+func (m *mockContainer) GetCPUPeriod() int64 {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetCPUQuota() int64 {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetCPUShares() int64 {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetMemoryLimit() int64 {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetOomScoreAdj() int64 {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetCpusetCpus() string {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetCpusetMems() string {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetLinuxResources(*cri.LinuxContainerResources) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetCPUPeriod(int64) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetCPUQuota(int64) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetCPUShares(int64) {
+}
+func (m *mockContainer) SetMemoryLimit(int64) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetOomScoreAdj(int64) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetCpusetCpus(string) {
+}
+func (m *mockContainer) SetCpusetMems(string) {
+	panic("unimplemented")
+}
+func (m *mockContainer) UpdateCriCreateRequest(*cri.CreateContainerRequest) error {
+	panic("unimplemented")
+}
+func (m *mockContainer) CriUpdateRequest() (*cri.UpdateContainerResourcesRequest, error) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetAffinity() []*cache.Affinity {
+	return nil
+}
+
+type mockPod struct {
+	name                               string
+	returnValueFotGetQOSClass          v1.PodQOSClass
+	returnValue1FotGetResmgrAnnotation string
+	returnValue2FotGetResmgrAnnotation bool
+}
+
+func (m *mockPod) GetInitContainers() []cache.Container {
+	panic("unimplemented")
+}
+func (m *mockPod) GetContainers() []cache.Container {
+	panic("unimplemented")
+}
+func (m *mockPod) GetID() string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetUID() string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetName() string {
+	return m.name
+}
+func (m *mockPod) GetNamespace() string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetState() cache.PodState {
+	panic("unimplemented")
+}
+func (m *mockPod) GetQOSClass() v1.PodQOSClass {
+	return m.returnValueFotGetQOSClass
+}
+func (m *mockPod) GetLabelKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetLabel(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetResmgrLabelKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetResmgrLabel(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetAnnotationKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetAnnotation(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetAnnotationObject(string, interface{}, func([]byte, interface{}) error) (bool, error) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetResmgrAnnotationKeys() []string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetResmgrAnnotation(key string) (string, bool) {
+	return m.returnValue1FotGetResmgrAnnotation, m.returnValue2FotGetResmgrAnnotation
+}
+func (m *mockPod) GetResmgrAnnotationObject(string, interface{}, func([]byte, interface{}) error) (bool, error) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetCgroupParentDir() string {
+	panic("unimplemented")
+}
+func (m *mockPod) GetPodResourceRequirements() cache.PodResourceRequirements {
+	panic("unimplemented")
+}
+func (m *mockPod) GetContainerAffinity(string) []*cache.Affinity {
+	panic("unimplemented")
+}
+func (m *mockPod) ScopeExpression() *cache.Expression {
+	panic("unimplemented")
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences.go
@@ -15,8 +15,9 @@
 package topologyaware
 
 import (
-	"github.com/ghodss/yaml"
 	"strconv"
+
+	"github.com/ghodss/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,8 @@ const (
 )
 
 // podIsolationPreference checks if containers explicitly prefers to run on multiple isolated CPUs.
+// The first return value indicates whether the container is isolated or not.
+// The second return value indicates whether that decision was explicit (true) or implicit (false).
 func podIsolationPreference(pod cache.Pod, container cache.Container) (bool, bool) {
 	value, ok := pod.GetResmgrAnnotation(keyIsolationPreference)
 	if !ok {
@@ -59,6 +62,13 @@ func podIsolationPreference(pod cache.Pod, container cache.Container) (bool, boo
 }
 
 // podSharedCPUPreference checks if a container wants to opt-out from exclusive allocation.
+// The first return value indicates if the container prefers to opt-out from
+// exclusive (sliced-off or isolated) CPU allocation even if it was otherwise
+// eligible for it.
+// The second return value, elevate, indicates how much to elevate the actual
+// allocation of the container in the tree of pools. Or in other words how many
+// levels to go up in the tree starting at the best fitting pool, before
+// assigning the container to an actual pool.
 func podSharedCPUPreference(pod cache.Pod, container cache.Container) (bool, int) {
 	value, ok := pod.GetResmgrAnnotation(keySharedCPUPreference)
 	if !ok {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pod-preferences_test.go
@@ -1,0 +1,360 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyaware
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	resapi "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodIsolationPreference(t *testing.T) {
+	tcases := []struct {
+		name             string
+		pod              *mockPod
+		container        *mockContainer
+		expectedIsolate  bool
+		expectedExplicit bool
+		disabled         bool
+	}{
+		{
+			name:     "podIsolationPreference() should handle nil pod arg gracefully",
+			disabled: true,
+		},
+		{
+			name:            "return defaults",
+			pod:             &mockPod{},
+			expectedIsolate: opt.PreferIsolated,
+		},
+		{
+			name: "prefer resmgr's annotation value",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "true",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			expectedIsolate:  true,
+			expectedExplicit: true,
+		},
+		{
+			name: "return defaults for unparsable",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "UNPARSABLE",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			expectedIsolate: opt.PreferIsolated,
+		},
+		{
+			name: "podIsolationPreference() should handle nil container arg gracefully",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "key: true",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			disabled: true,
+		},
+		{
+			name: "return defaults for missing preferences",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "key: true",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container:       &mockContainer{},
+			expectedIsolate: opt.PreferIsolated,
+		},
+		{
+			name: "return defined preferences",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "testcontainer: false",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container: &mockContainer{
+				name: "testcontainer",
+			},
+			expectedExplicit: true,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.disabled {
+				t.Skipf("The case '%s' is skipped", tc.name)
+			}
+			isolate, explicit := podIsolationPreference(tc.pod, tc.container)
+			if isolate != tc.expectedIsolate || explicit != tc.expectedExplicit {
+				t.Errorf("Expected (%v, %v), but got (%v, %v)", tc.expectedIsolate, tc.expectedExplicit, isolate, explicit)
+			}
+		})
+	}
+}
+
+func TestPodSharedCPUPreference(t *testing.T) {
+	tcases := []struct {
+		name            string
+		pod             *mockPod
+		container       *mockContainer
+		expectedShared  bool
+		expectedElevate int
+		disabled        bool
+	}{
+		{
+			name:     "podSharedCPUPreference() should handle nil pod arg gracefully",
+			disabled: true,
+		},
+		{
+			name:           "return defaults",
+			pod:            &mockPod{},
+			expectedShared: opt.PreferShared,
+		},
+		{
+			name: "prefer resmgr's annotation value",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "true",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			expectedShared: true,
+		},
+		{
+			name: "return defaults for unparsable",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "UNPARSABLE",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			expectedShared: opt.PreferShared,
+		},
+		{
+			name: "podSharedCPUPreference() should handle nil container arg gracefully",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "key: true",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			disabled: true,
+		},
+		{
+			name: "return defaults for missing preferences",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "key: true",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container:      &mockContainer{},
+			expectedShared: opt.PreferShared,
+		},
+		{
+			name: "return defined preferences",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "testcontainer: false",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container: &mockContainer{
+				name: "testcontainer",
+			},
+		},
+		{
+			name: "return defaults for unparsable annotation value",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "testcontainer: UNPARSABLE",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container: &mockContainer{
+				name: "testcontainer",
+			},
+			expectedShared: opt.PreferShared,
+		},
+		{
+			name: "return defaults for elevate gt 0", // FIXME(rojkov): what ever that means... This looks strange the value can be of either bool or int type
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "testcontainer: 12",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container: &mockContainer{
+				name: "testcontainer",
+			},
+			expectedShared: opt.PreferShared,
+		},
+		{
+			name: "return negative annotation value",
+			pod: &mockPod{
+				returnValue1FotGetResmgrAnnotation: "testcontainer: -9",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			container: &mockContainer{
+				name: "testcontainer",
+			},
+			expectedShared:  true,
+			expectedElevate: -9,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.disabled {
+				t.Skipf("The case '%s' is skipped", tc.name)
+			}
+			shared, elevate := podSharedCPUPreference(tc.pod, tc.container)
+			if shared != tc.expectedShared || elevate != tc.expectedElevate {
+				t.Errorf("Expected (%v, %v), but got (%v, %v)", tc.expectedShared, tc.expectedElevate, shared, elevate)
+			}
+		})
+	}
+}
+
+func TestCpuAllocationPreferences(t *testing.T) {
+	tcases := []struct {
+		name             string
+		pod              *mockPod
+		container        *mockContainer
+		expectedFull     int
+		expectedFraction int
+		expectedIsolate  bool
+		expectedElevate  int
+		disabled         bool
+	}{
+		{
+			name:     "cpuAllocationPreferences() should handle nil container arg gracefully",
+			disabled: true,
+		},
+		{
+			name:      "no resource requirements",
+			container: &mockContainer{},
+		},
+		{
+			name: "cpuAllocationPreferences() should handle nil pod arg gracefully",
+			container: &mockContainer{
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("1"),
+					},
+				},
+			},
+			disabled: true,
+		},
+		{
+			name: "return defaults",
+			container: &mockContainer{
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("1"),
+					},
+				},
+			},
+			pod: &mockPod{},
+		},
+		{
+			name: "return request's value for system container",
+			container: &mockContainer{
+				namespace: metav1.NamespaceSystem,
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("2"),
+					},
+				},
+			},
+			pod:              &mockPod{},
+			expectedFraction: 2000,
+		},
+		{
+			name: "return request's value for burstable QoS",
+			container: &mockContainer{
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("2"),
+					},
+				},
+			},
+			pod: &mockPod{
+				returnValueFotGetQOSClass: corev1.PodQOSBurstable,
+			},
+			expectedFraction: 2000,
+		},
+		{
+			name: "return request's value for guaranteed QoS",
+			container: &mockContainer{
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("2"),
+					},
+				},
+			},
+			pod: &mockPod{
+				returnValueFotGetQOSClass: corev1.PodQOSGuaranteed,
+			},
+			expectedFull: 2,
+		},
+		{
+			name: "return request's value for guaranteed QoS and isolate",
+			container: &mockContainer{
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("1"),
+					},
+				},
+			},
+			pod: &mockPod{
+				returnValueFotGetQOSClass: corev1.PodQOSGuaranteed,
+			},
+			expectedFull:    1,
+			expectedIsolate: true,
+		},
+		{
+			name: "return request's value for guaranteed QoS and no isolate",
+			container: &mockContainer{
+				name: "testcontainer",
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("1"),
+					},
+				},
+			},
+			pod: &mockPod{
+				returnValueFotGetQOSClass:          corev1.PodQOSGuaranteed,
+				returnValue1FotGetResmgrAnnotation: "testcontainer: false",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			expectedFull: 1,
+		},
+		{
+			name: "prefer shared",
+			container: &mockContainer{
+				name: "testcontainer",
+				returnValueForGetResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						corev1.ResourceCPU: resapi.MustParse("2"),
+					},
+				},
+			},
+			pod: &mockPod{
+				returnValueFotGetQOSClass:          corev1.PodQOSGuaranteed,
+				returnValue1FotGetResmgrAnnotation: "testcontainer: -9",
+				returnValue2FotGetResmgrAnnotation: true,
+			},
+			expectedFull:     0,
+			expectedFraction: 2000,
+			expectedElevate:  9,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.disabled {
+				t.Skipf("The case '%s' is skipped", tc.name)
+			}
+			full, fraction, isolate, elevate := cpuAllocationPreferences(tc.pod, tc.container)
+			if full != tc.expectedFull || fraction != tc.expectedFraction ||
+				isolate != tc.expectedIsolate || elevate != tc.expectedElevate {
+				t.Errorf("Expected (%v, %v, %v, %v), but got (%v, %v, %v, %v)",
+					tc.expectedFull, tc.expectedFraction, tc.expectedIsolate, tc.expectedElevate,
+					full, fraction, isolate, elevate)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The tests cover 100% of pod-preferences.go. Hopefully the input and expected output make sense as I didn't fully understand the code's purpose. E.g. what is `elevate` in function results?

Also please check if the names of the test cases reflect their meaning.