### PR TITLE
rdt: simplify l3 configuration

### DIFF
--- a/pkg/rdt/bitmask.go
+++ b/pkg/rdt/bitmask.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rdt
 
 import (
+	"fmt"
 	"math/bits"
 	"strconv"
 	"strings"
@@ -30,6 +31,11 @@ import (
 // interface. The "width" i.e. the number of bits available depends on the
 // underlying hardware.
 type CacheBitmask Bitmask
+
+// MarshalJSON is the marshaller function for "encoding/json"
+func (b CacheBitmask) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%#x\"", b)), nil
+}
 
 // UnmarshalJSON is the unmarshaller function for "encoding/json"
 func (b *CacheBitmask) UnmarshalJSON(data []byte) error {

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 )
 
+// Info contains information about the RDT support in the system
 type Info struct {
 	resctrlPath string
 	numClosids  uint64

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -188,35 +188,12 @@ func (r *control) configureResctrlGroup(name string, config ResctrlGroupConfig, 
 	// Handle L3 cache allocation
 	switch {
 	case rdtInfo.l3.Supported():
-		if !config.L3CodeSchema.IsNil() && !options.L3Code.Optional {
-			return rdtError("separate L3 code path schema for %q requested but CDP not enabled", name)
-		}
-		if !config.L3DataSchema.IsNil() && !options.L3Data.Optional {
-			return rdtError("separate L3 data path schema for %q requested but CDP not enabled", name)
-		}
-		r.Debug("configuring L3 schema for %q", name)
 		schemata += config.L3Schema.ToStr(L3SchemaTypeUnified)
 	case rdtInfo.l3data.Supported() || rdtInfo.l3code.Supported():
-		if !config.L3CodeSchema.IsNil() {
-			r.Debug("using specific L3 code schema for %q", name)
-			schemata += config.L3CodeSchema.ToStr(L3SchemaTypeCode)
-		} else {
-			// No L3 code schema was specified -> use the "unified" L3 schema
-			r.Debug("using unified L3 schema in code path for %q", name)
-			schemata += config.L3Schema.ToStr(L3SchemaTypeCode)
-		}
-		if !config.L3DataSchema.IsNil() {
-			r.Debug("using specific L3 data schema for %q", name)
-			schemata += config.L3DataSchema.ToStr(L3SchemaTypeData)
-		} else {
-			// No L3 data schema was specified -> use the "unified" L3 schema
-			r.Debug("using unified L3 schema in data path for %q", name)
-			schemata += config.L3Schema.ToStr(L3SchemaTypeData)
-		}
+		schemata += config.L3Schema.ToStr(L3SchemaTypeCode)
+		schemata += config.L3Schema.ToStr(L3SchemaTypeData)
 	default:
-		if (!config.L3Schema.IsNil() && !options.L3.Optional) ||
-			(!config.L3CodeSchema.IsNil() && !options.L3Code.Optional) ||
-			(!config.L3DataSchema.IsNil() && !options.L3Data.Optional) {
+		if !config.L3Schema.IsNil() && !options.L3.Optional {
 			return rdtError("L3 cache allocation for %q specified in configuration but not supported by system", name)
 		}
 	}

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -79,22 +79,29 @@ data:
       resctrlGroups:
         Guaranteed:
           l3schema:
-            all: "100%"
+            all:
+              unified: "100%"
+      # Specific settings for L3 CDP (Code and Data Prioritization)
+      #        code: "100%"
+      #        data: "80%"
       # Specify CacheId (typically correspons CPU socket) specific setting
-      #      1: "80%"
+      #      1:
+      #        unified: "80%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 100
       #      1-3: 80
         Burstable:
           l3schema:
-            all: "66%"
+            all:
+              unified: "66%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 66
         BestEffort:
           l3schema:
-            all: "33%"
+            all:
+              unified: "33%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 33
@@ -172,22 +179,29 @@ data:
       resctrlGroups:
         Guaranteed:
           l3schema:
-            all: "100%"
+            all:
+              unified: "100%"
+      # Specific settings for L3 CDP (Code and Data Prioritization)
+      #        code: "100%"
+      #        data: "80%"
       # Specify CacheId (typically correspons CPU socket) specific setting
-      #      1: "80%"
+      #      1:
+      #        unified: "80%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 100
       #      1-3: 80
         Burstable:
           l3schema:
-            all: "66%"
+            all:
+              unified: "66%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 66
         BestEffort:
           l3schema:
-            all: "33%"
+            all:
+              unified: "33%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 33
@@ -260,22 +274,29 @@ data:
       resctrlGroups:
         Guaranteed:
           l3schema:
-            all: "100%"
+            all:
+              unified: "100%"
+      # Specific settings for L3 CDP (Code and Data Prioritization)
+      #        code: "100%"
+      #        data: "80%"
       # Specify CacheId (typically correspons CPU socket) specific setting
-      #      1: "80%"
+      #      1:
+      #        unified: "80%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 100
       #      1-3: 80
         Burstable:
           l3schema:
-            all: "66%"
+            all:
+              unified: "66%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 66
         BestEffort:
           l3schema:
-            all: "33%"
+            all:
+              unified: "33%"
       # MBA (Memory Bandwidth Allocation)
       #    mbschema:
       #      all: 33


### PR DESCRIPTION
This patch tries to simplify the configuration of the RDT L3 allocation
and aims to make it slightly more comprehensible and user friendly.
Instead of having independent configuration sections (l3Schema,
l3CodeSchema, l3DataSchema), we now have separate 'unified', 'code' and
'data' settings under the 'l3Schema' key. E.g.
```
    resctrlGroups:
      Guaranteed:
        l3Schema:
          all:
            unified: 90%
            code: 100%
            data: 80%
```
Moreover, 'unified' must always be specified, and, 'code' and 'data' go
together so that none or both of them must be specified (only specifying
one of them creates an error). These requirements were added in order to
reduce the risk of accidental misconfiguration.

Also. the fallback/failure logic has been simplified. Now the
configuration only fails if 'l3Schema' is specified but L3 CAT is not
available and the 'rdt.config.options.l3.optional' is set to false. In
addition the 'l3' setting (which is now mandatory) is used as a
default/fallback value for 'code' and 'data' settings.
