### PR TITLE
fixes: don't bail out if a cgroup directory gets deleted between discovery and processing.

### DIFF
--- a/pkg/cgroups/cgroupid.go
+++ b/pkg/cgroups/cgroupid.go
@@ -35,6 +35,9 @@ func getID(path string) uint64 {
 func (cgid *CgroupID) List() error {
 	return filepath.Walk(cgid.root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			fmt.Printf("WalkFunc called with an error (path %q: %v\n)", path, err)
 			return err
 		}
@@ -59,6 +62,9 @@ func (cgid *CgroupID) Find(id uint64) (string, error) {
 
 	err := filepath.Walk(cgid.root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			fmt.Printf("WalkFunc called with an error (path %q: %v\n)", path, err)
 			return err
 		}

--- a/pkg/utils/cgroups.go
+++ b/pkg/utils/cgroups.go
@@ -34,6 +34,9 @@ func GetContainerCgroupDir(subsystemDir, containerID string) string {
 	var containerDir string
 
 	filepath.Walk(subsystemDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
 		if !info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
Don't bail out from filepath.Walk if a cgroup directory gets deleted between discovery and processing. This happens when a cgroup gets deleted after the entry list of its parent directory has been read but before filepath.Walk gets around to recurse into the directory itself.