### PR TITLE
[RFC] resource manager: add event and metrics processing skeleton.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,8 @@ bin/webhook: $(wildcard cmd/webhook/*.go) \
                 find $$dir -name \*.go; \
             done | sort | uniq)
 
+bin/avx512-load: $(wildcard cmd/avx512-load/*.go)
+
 # phony targets
 .PHONY: all build install clean test images \
 	format vet cyclomatic-check lint golangci-lint \

--- a/cmd/avx512-load/main.go
+++ b/cmd/avx512-load/main.go
@@ -1,0 +1,114 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/minio/sha256-simd"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+const (
+	bufSize    = 4 * 1024
+	iterations = 32 * 1024
+)
+
+type config struct {
+	count int
+	fork  bool
+	id    string
+}
+
+var cfg = &config{}
+
+type avx512 struct {
+	id   string
+	fork bool
+	buf  [bufSize]byte
+}
+
+func newAvx512(id string, fork bool) *avx512 {
+	return &avx512{id: id, fork: fork}
+}
+
+func (a *avx512) log(format string, args ...interface{}) {
+	fmt.Printf("["+a.id+"] "+format+"\n", args...)
+}
+
+func (a *avx512) start() error {
+	if a.fork {
+		cmd := exec.Command(os.Args[0], "--id", a.id)
+		err := cmd.Start()
+		return err
+	}
+
+	go func() { runtime.LockOSThread(); a.load() }()
+	return nil
+}
+
+func (a *avx512) load() {
+	a.log("preparing test input...")
+	for i := 0; i < len(a.buf); i++ {
+		a.buf[i] = byte(i & 0xff)
+		if (i % (len(a.buf) / 100)) == 0 {
+			a.log("%.2f %%", 100*float64(i)/float64(len(a.buf)))
+		}
+	}
+	a.log("done")
+
+	server := sha256.NewAvx512Server()
+	h512 := sha256.NewAvx512(server)
+	rounds := 0
+	for {
+		for i := 0; i < iterations; i++ {
+			h512.Write(a.buf[:])
+		}
+		h512.Sum([]byte{})
+		h512.Reset()
+		rounds++
+		a.log("done with %d test rounds", rounds)
+	}
+}
+
+func main() {
+	flag.IntVar(&cfg.count, "count", 1, "how many AVX512 load generator to run in parallel")
+	flag.BoolVar(&cfg.fork, "fork", false, "fork subprocesses instead of using goroutines")
+	flag.StringVar(&cfg.id, "id", "", "AVX512 load generator id")
+	flag.Parse()
+
+	for i := 0; i < cfg.count; i++ {
+		id := fmt.Sprintf("AVX512#%d", i)
+		avx := newAvx512(id, cfg.fork)
+		err := avx.start()
+		if err != nil {
+			fmt.Printf("error: failed to start %s: %v\n", id, err)
+			os.Exit(1)
+		}
+	}
+
+	if !cfg.fork {
+		n := runtime.NumGoroutine()
+		runtime.GOMAXPROCS(n)
+		fmt.Printf("GOMAXPROCS set to %d\n", n)
+	}
+
+	for {
+		time.Sleep(3600 * time.Second)
+	}
+}

--- a/cmd/cri-resmgr/main.go
+++ b/cmd/cri-resmgr/main.go
@@ -73,5 +73,6 @@ func main() {
 
 	for {
 		time.Sleep(15 * time.Second)
+		m.SendEvent("this is a timeout event from main...")
 	}
 }

--- a/cmd/ptugen/Dockerfile
+++ b/cmd/ptugen/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine as builder
+
+RUN apk update && apk add bash && rm -fr /var/cache/apk/*
+COPY cmd/ptugen/ptugen /bin/ptugen

--- a/pkg/avx/collector.go
+++ b/pkg/avx/collector.go
@@ -53,7 +53,6 @@ var (
 
 	bpfBinaryName  = "avx512.o"
 	bpfInstallpath = "/usr/libexec/bpf"
-	cgroupV2path   = "/sys/fs/cgroup/unified"
 
 	// our logger instance
 	log = logger.NewLogger("avx")
@@ -152,7 +151,7 @@ func NewCollector() (prometheus.Collector, error) {
 	}
 
 	return &collector{
-		root:                     cgroupV2path,
+		root:                     cgroups.V2path,
 		bpfModule:                bpfModule,
 		avxContextSwitchCounters: avxSwitchCounters,
 		allContextSwitchCounters: allSwitchCounters,
@@ -273,8 +272,6 @@ func (c collector) collectLastCPUStats(ch chan<- prometheus.Metric) {
 }
 
 func init() {
-	flag.StringVar(&cgroupV2path, "cgroupv2-path", cgroupV2path,
-		"Path to cgroup-v2 mountpoint")
 	flag.StringVar(&bpfInstallpath, "bpf-install-path", bpfInstallpath,
 		"Path to eBPF install directory")
 }

--- a/pkg/cgroups/cgroupstats.go
+++ b/pkg/cgroups/cgroupstats.go
@@ -1,0 +1,527 @@
+package cgroups
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// BlkioDeviceBytes contains a single operations line of blkio.throttle.io_service_bytes_recursive file
+type BlkioDeviceBytes struct {
+	Major      int
+	Minor      int
+	Operations map[string]int64
+}
+
+// BlkioThrottleBytes has parsed contents of blkio.throttle.io_service_bytes_recursive file
+type BlkioThrottleBytes struct {
+	DeviceBytes []BlkioDeviceBytes
+	TotalBytes  int64
+}
+
+// CPUAcctUsage has a parsed line of cpuacct.usage_all file
+type CPUAcctUsage struct {
+	CPU    int
+	User   int64
+	System int64
+}
+
+// HugetlbUsage has parsed contents of huge pages usage in bytes.
+type HugetlbUsage struct {
+	Size     string
+	Bytes    int64
+	MaxBytes int64
+}
+
+// MemoryUsage has parsed contents of memory usage in bytes.
+type MemoryUsage struct {
+	Bytes    int64
+	MaxBytes int64
+}
+
+// NumaLine represents one line in the NUMA statistics file.
+type NumaLine struct {
+	Total int64
+	Nodes map[string]int64
+}
+
+// NumaStat has parsed contets of a NUMA statistics file.
+type NumaStat struct {
+	Total       NumaLine
+	File        NumaLine
+	Anon        NumaLine
+	Unevictable NumaLine
+
+	HierarchicalTotal       NumaLine
+	HierarchicalFile        NumaLine
+	HierarchicalAnon        NumaLine
+	HierarchicalUnevictable NumaLine
+}
+
+// GlobalNumaStats has the statistics from one global NUMA nodestats file.
+type GlobalNumaStats struct {
+	NumaHit       int64
+	NumaMiss      int64
+	NumaForeign   int64
+	InterleaveHit int64
+	LocalNode     int64
+	OtherNode     int64
+}
+
+func readCgroupFileLines(filePath string) ([]string, error) {
+
+	f, err := ioutil.ReadFile(filePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	data := string(f)
+
+	rawLines := strings.Split(data, "\n")
+
+	lines := make([]string, 0)
+
+	// Sanitize the lines and remove empty ones.
+	for _, rawLine := range rawLines {
+		if len(strings.TrimSpace(rawLine)) > 0 {
+			lines = append(lines, rawLine)
+		}
+	}
+
+	return lines, nil
+}
+
+func readCgroupSingleNumber(filePath string) (int64, error) {
+
+	// File looks like this:
+	//
+	// 4
+
+	lines, err := readCgroupFileLines(filePath)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if len(lines) != 1 {
+		return 0, fmt.Errorf("error parsing file")
+	}
+
+	number, err := strconv.ParseInt(lines[0], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return number, nil
+}
+
+var blkLineRe = regexp.MustCompile(`^(\d+):(\d+) (\w+) (\d+)$`)
+
+// GetBlkioThrottleBytes returns amount of bytes transferred to/from the disk.
+func GetBlkioThrottleBytes(cgroupPath string) (BlkioThrottleBytes, error) {
+
+	// File looks like this:
+	//
+	// 8:16 Read 4223325184
+	// 8:16 Write 3207528448
+	// 8:16 Sync 5387592704
+	// 8:16 Async 2043260928
+	// 8:16 Discard 0
+	// 8:16 Total 7430853632
+	// 8:0 Read 5246572032
+	// 8:0 Write 2361737216
+	// 8:0 Sync 5575892480
+	// 8:0 Async 2032416768
+	// 8:0 Discard 0
+	// 8:0 Total 7608309248
+	// Total 15039162880
+
+	lines, err := readCgroupFileLines(path.Join(cgroupPath, "blkio.throttle.io_service_bytes_recursive"))
+
+	if err != nil {
+		return BlkioThrottleBytes{}, err
+	}
+
+	if len(lines) == 1 && lines[0] == "Total 0" {
+		return BlkioThrottleBytes{TotalBytes: 0}, nil
+	}
+
+	result := BlkioThrottleBytes{}
+	result.DeviceBytes = make([]BlkioDeviceBytes, 0)
+
+	for _, line := range lines {
+		if line[:5] == "Total" {
+			tokens := strings.Split(line, " ")
+			if len(tokens) == 2 {
+				totalBytes, err := strconv.ParseInt(tokens[1], 10, 64)
+				if err != nil {
+					return BlkioThrottleBytes{}, err
+				}
+				result.TotalBytes = totalBytes
+			}
+		} else {
+			tokens := blkLineRe.FindStringSubmatch(line)
+			if tokens == nil || len(tokens) != 5 {
+				return BlkioThrottleBytes{}, fmt.Errorf("error parsing file")
+			}
+			major64, err := strconv.ParseInt(string(tokens[1]), 10, 32)
+			if err != nil {
+				return BlkioThrottleBytes{}, err
+			}
+			minor64, err := strconv.ParseInt(string(tokens[2]), 10, 32)
+			if err != nil {
+				return BlkioThrottleBytes{}, err
+			}
+			major := int(major64)
+			minor := int(minor64)
+
+			var device *BlkioDeviceBytes
+			// Find if we already have the device. There should only be a few so this isn't too costly.
+			for _, dev := range result.DeviceBytes {
+				if dev.Major == major && dev.Minor == minor {
+					device = &dev
+				}
+			}
+
+			if device == nil {
+				device = &BlkioDeviceBytes{Major: major, Minor: minor, Operations: make(map[string]int64)}
+				result.DeviceBytes = append(result.DeviceBytes, *device)
+			}
+			bytes, err := strconv.ParseInt(string(tokens[4]), 10, 64)
+			if err != nil {
+				return BlkioThrottleBytes{}, err
+			}
+
+			device.Operations[string(tokens[3])] = bytes
+		}
+	}
+
+	return result, nil
+}
+
+// GetCPUAcctStats retrieves CPU account statistics for a given cgroup.
+func GetCPUAcctStats(cgroupPath string) ([]CPUAcctUsage, error) {
+
+	// File looks like this:
+	//
+	// cpu user system
+	// 0 3723082232186 2456599218
+	// 1 3748398003001 1149546796
+
+	lines, err := readCgroupFileLines(path.Join(cgroupPath, "cpuacct.usage_all"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]CPUAcctUsage, len(lines)-1)
+
+	for i, line := range lines {
+		// skip first line
+		if i > 0 && len(line) > 0 {
+			tokens := strings.Split(line, " ")
+			if len(tokens) == 3 {
+				cpu, err := strconv.ParseInt(tokens[0], 10, 32)
+				if err != nil {
+					return nil, err
+				}
+				user, err := strconv.ParseInt(tokens[1], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				system, err := strconv.ParseInt(tokens[2], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				result[i-1] = CPUAcctUsage{CPU: int(cpu), User: user, System: system}
+			}
+		}
+	}
+	return result, nil
+}
+
+// GetCPUSetMemoryMigrate returns boolean indicating whether memory migration is enabled.
+func GetCPUSetMemoryMigrate(cgroupPath string) (bool, error) {
+
+	// File looks like this:
+	//
+	// 0
+
+	number, err := readCgroupSingleNumber(path.Join(cgroupPath, "cpuset.memory_migrate"))
+
+	if err != nil {
+		return false, err
+	}
+
+	if number == 0 {
+		return false, nil
+	} else if number == 1 {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("error parsing file")
+}
+
+var hugetlbUsageInBytesRe = regexp.MustCompile(`^\S*/hugetlb\.(.*)\.usage_in_bytes$`)
+var hugetlbMaxUsageInBytesRe = regexp.MustCompile(`^\S*/hugetlb\.(.*)\.max_usage_in_bytes$`)
+
+// GetHugetlbUsage retrieves huge pages statistics for a given cgroup.
+func GetHugetlbUsage(cgroupPath string) ([]HugetlbUsage, error) {
+
+	// Files look like this:
+	//
+	// 124
+
+	usageFiles, err := filepath.Glob(path.Join(cgroupPath, "/hugetlb.*.usage_in_bytes"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	maxUsageFiles, err := filepath.Glob(path.Join(cgroupPath, "/hugetlb.*.max_usage_in_bytes"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(usageFiles) != len(maxUsageFiles) {
+		return nil, fmt.Errorf("error finding files")
+	}
+
+	result := make([]HugetlbUsage, len(usageFiles))
+
+	for i, file := range usageFiles {
+		tokens := hugetlbUsageInBytesRe.FindStringSubmatch(file)
+		if tokens == nil || len(tokens) != 2 {
+			return nil, fmt.Errorf("error finding files")
+		}
+		size := string(tokens[1])
+
+		result[i].Size = size
+
+		number, err := readCgroupSingleNumber(file)
+
+		if err != nil {
+			return nil, err
+		}
+
+		result[i].Bytes = number
+	}
+
+	for _, file := range maxUsageFiles {
+		tokens := hugetlbMaxUsageInBytesRe.FindStringSubmatch(file)
+		if tokens == nil || len(tokens) != 2 {
+			return nil, fmt.Errorf("error finding files")
+		}
+		size := string(tokens[1])
+
+		// Find the already existing result.
+
+		var res *HugetlbUsage
+
+		for j, tmp := range result {
+			if tmp.Size == size {
+				res = &result[j]
+			}
+		}
+		if res == nil {
+			return nil, fmt.Errorf("error finding files")
+		}
+
+		number, err := readCgroupSingleNumber(file)
+
+		if err != nil {
+			return nil, err
+		}
+
+		res.MaxBytes = number
+	}
+
+	return result, nil
+}
+
+// GetMemoryUsage retrieves cgroup memory usage.
+func GetMemoryUsage(cgroupPath string) (MemoryUsage, error) {
+
+	// Files look like this:
+	//
+	// 142
+
+	usage, err := readCgroupSingleNumber(path.Join(cgroupPath, "memory.usage_in_bytes"))
+	if err != nil {
+		return MemoryUsage{}, err
+	}
+
+	maxUsage, err := readCgroupSingleNumber(path.Join(cgroupPath, "memory.max_usage_in_bytes"))
+	if err != nil {
+		return MemoryUsage{}, err
+	}
+
+	result := MemoryUsage{
+		Bytes:    usage,
+		MaxBytes: maxUsage,
+	}
+
+	return result, nil
+}
+
+var numaLineRe = regexp.MustCompile(`^(\S+)=(\d+)([ N\d+=\d+]+)$`)
+var numaNodesRe = regexp.MustCompile(`(N\d+)=(\d+)`)
+
+// GetNumaStats returns parsed cgroup NUMA statistics.
+func GetNumaStats(cgroupPath string) (NumaStat, error) {
+
+	// File looks like this:
+	//
+	// total=44611 N0=32631 N1=7501 N2=1982 N3=2497
+	// file=44428 N0=32614 N1=7335 N2=1982 N3=2497
+	// anon=183 N0=17 N1=166 N2=0 N3=0
+	// unevictable=0 N0=0 N1=0 N2=0 N3=0
+	// hierarchical_total=768133 N0=509113 N1=138887 N2=20464 N3=99669
+	// hierarchical_file=722017 N0=496516 N1=119997 N2=20181 N3=85323
+	// hierarchical_anon=46096 N0=12597 N1=18890 N2=283 N3=14326
+	// hierarchical_unevictable=20 N0=0 N1=0 N2=0 N3=20
+
+	lines, err := readCgroupFileLines(path.Join(cgroupPath, "memory.numa_stat"))
+
+	if err != nil {
+		return NumaStat{}, err
+	}
+
+	result := NumaStat{}
+	for _, line := range lines {
+		tokens := numaLineRe.FindStringSubmatch(line)
+		if tokens == nil || len(tokens) != 4 {
+			return NumaStat{}, fmt.Errorf("error parsing file")
+		}
+		number, err := strconv.ParseInt(tokens[2], 10, 64)
+		if err != nil {
+			return NumaStat{}, err
+		}
+
+		// Parse node list separately.
+		nodeMatches := numaNodesRe.FindAllStringSubmatch(tokens[3], -1)
+
+		nodes := make(map[string]int64)
+		for _, nodeMatch := range nodeMatches {
+			number, err := strconv.ParseInt(nodeMatch[2], 10, 64)
+			if err != nil {
+				return NumaStat{}, err
+			}
+			nodes[nodeMatch[1]] = number
+		}
+
+		switch tokens[1] {
+		case "total":
+			result.Total.Total = number
+			result.Total.Nodes = nodes
+		case "file":
+			result.File.Total = number
+			result.File.Nodes = nodes
+		case "anon":
+			result.Anon.Total = number
+			result.Anon.Nodes = nodes
+		case "unevictable":
+			result.Unevictable.Total = number
+			result.Unevictable.Nodes = nodes
+		case "hierarchical_total":
+			result.HierarchicalTotal.Total = number
+			result.HierarchicalTotal.Nodes = nodes
+		case "hierarchical_file":
+			result.HierarchicalFile.Total = number
+			result.HierarchicalFile.Nodes = nodes
+		case "hierarchical_anon":
+			result.HierarchicalAnon.Total = number
+			result.HierarchicalAnon.Nodes = nodes
+		case "hierarchical_unevictable":
+			result.HierarchicalUnevictable.Total = number
+			result.HierarchicalUnevictable.Nodes = nodes
+		default:
+			return NumaStat{}, fmt.Errorf("error parsing file")
+		}
+	}
+
+	return result, nil
+}
+
+var globalNumaNodeRe = regexp.MustCompile(`^\S*(\d+)$`)
+
+// GetGlobalNumaStats returns the global (non-cgroup) NUMA statistics per node.
+func GetGlobalNumaStats() (map[int]GlobalNumaStats, error) {
+
+	// Files look like this:
+	//
+	// numa_hit 1851614569
+	// numa_miss 0
+	// numa_foreign 0
+	// interleave_hit 49101
+	// local_node 1851614569
+	// other_node 0
+
+	result := make(map[int]GlobalNumaStats)
+
+	nodeDirs, err := filepath.Glob("/sys/devices/system/node/node*")
+
+	if err != nil {
+		return map[int]GlobalNumaStats{}, err
+	}
+
+	if len(nodeDirs) <= 0 {
+		return map[int]GlobalNumaStats{}, fmt.Errorf("error finding files")
+	}
+
+	for _, dir := range nodeDirs {
+		nameTokens := globalNumaNodeRe.FindStringSubmatch(dir)
+		if nameTokens == nil || len(nameTokens) != 2 {
+			return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing directory name")
+		}
+		nodeNumber, err := strconv.ParseInt(nameTokens[1], 10, 64)
+		if err != nil {
+			return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing directory name")
+		}
+
+		nodeStat := GlobalNumaStats{}
+
+		numastat := path.Join(dir, "numastat")
+		lines, err := readCgroupFileLines(numastat)
+		if err != nil {
+			return map[int]GlobalNumaStats{}, fmt.Errorf("error reading %s", numastat)
+		}
+
+		for _, line := range lines {
+			tokens := strings.Split(line, " ")
+			if len(tokens) != 2 {
+				return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing numastat file")
+			}
+			number, err := strconv.ParseInt(tokens[1], 10, 64)
+			if err != nil {
+				return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing numastat file")
+			}
+			switch tokens[0] {
+			case "numa_hit":
+				nodeStat.NumaHit = number
+			case "numa_miss":
+				nodeStat.NumaMiss = number
+			case "numa_foreign":
+				nodeStat.NumaForeign = number
+			case "interleave_hit":
+				nodeStat.InterleaveHit = number
+			case "local_node":
+				nodeStat.LocalNode = number
+			case "other_node":
+				nodeStat.OtherNode = number
+			default:
+				return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing numastat file")
+			}
+		}
+
+		result[int(nodeNumber)] = nodeStat
+	}
+
+	return result, nil
+}

--- a/pkg/cgroups/v2path.go
+++ b/pkg/cgroups/v2path.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"flag"
+)
+
+var (
+	// V2path is the mount point for the cgroup V2 pseudofilesystem.
+	V2path string
+)
+
+func init() {
+	flag.StringVar(&V2path, "cgroupv2-path", "/sys/fs/cgroup/unified",
+		"Path to cgroup-v2 mountpoint")
+}

--- a/pkg/cgroupstats/collector.go
+++ b/pkg/cgroupstats/collector.go
@@ -1,0 +1,386 @@
+package cgroupstats
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/intel/cri-resource-manager/pkg/cgroups"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	numaStatsDesc = prometheus.NewDesc(
+		"cgroup_numa_stats",
+		"NUMA statistics for a given container and pod.",
+		[]string{
+			// cgroup path
+			"cgroup_path",
+			// NUMA node ID
+			"numa_node_id",
+			// NUMA memory type
+			"type",
+		}, nil,
+	)
+
+	memoryUsageDesc = prometheus.NewDesc(
+		"cgroup_memory_usage",
+		"Memory usage statistics for a given container and pod.",
+		[]string{
+			"cgroup_path",
+			"type",
+		}, nil,
+	)
+
+	memoryMigrateDesc = prometheus.NewDesc(
+		"cgroup_memory_migrate",
+		"Memory migrate status for a given container and pod.",
+		[]string{
+			"cgroup_path",
+		}, nil,
+	)
+
+	cpuAcctUsageDesc = prometheus.NewDesc(
+		"cgroup_cpu_acct",
+		"CPU accounting for a given container and pod.",
+		[]string{
+			"cgroup_path",
+			// CPU ID
+			"cpu",
+			"type",
+		}, nil,
+	)
+
+	hugeTlbUsageDesc = prometheus.NewDesc(
+		"cgroup_hugetlb_usage",
+		"Hugepages usage for a given container and pod.",
+		[]string{
+			"cgroup_path",
+			"size",
+			"type",
+		}, nil,
+	)
+
+	blkioDeviceUsageDesc = prometheus.NewDesc(
+		"cgroup_blkio_device_usage",
+		"Blkio Device bytes usage for a given container and pod.",
+		[]string{
+			"cgroup_path",
+			"major",
+			"minor",
+			"operation",
+		}, nil,
+	)
+)
+
+var (
+	// cgroupRoot is the mount point for the cgroup (v1) filesystem
+	cgroupRoot = "/sys/fs/cgroup"
+	// our logger instance
+	log = logger.NewLogger("cgroupstats")
+)
+
+const (
+	kubepodsDir = "kubepods.slice"
+)
+
+type collector struct {
+}
+
+// NewCollector creates new Prometheus collector
+func NewCollector() (prometheus.Collector, error) {
+	return &collector{}, nil
+}
+
+// Describe implements prometheus.Collector interface
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func updateCPUAcctUsageMetric(ch chan<- prometheus.Metric, path string, metric []cgroups.CPUAcctUsage) {
+	for i, acct := range metric {
+		ch <- prometheus.MustNewConstMetric(
+			cpuAcctUsageDesc,
+			prometheus.CounterValue,
+			float64(acct.CPU),
+			path, strconv.FormatInt(int64(i), 10), "CPU",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			cpuAcctUsageDesc,
+			prometheus.CounterValue,
+			float64(acct.User),
+			path, strconv.FormatInt(int64(i), 10), "User",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			cpuAcctUsageDesc,
+			prometheus.CounterValue,
+			float64(acct.System),
+			path, strconv.FormatInt(int64(i), 10), "System",
+		)
+	}
+}
+
+func updateMemoryMigrateMetric(ch chan<- prometheus.Metric, path string, migrate bool) {
+	migrateValue := 0
+	if migrate {
+		migrateValue = 1
+	}
+	ch <- prometheus.MustNewConstMetric(
+		memoryMigrateDesc,
+		prometheus.GaugeValue,
+		float64(migrateValue),
+		path,
+	)
+}
+
+func updateMemoryUsageMetric(ch chan<- prometheus.Metric, path string, metric cgroups.MemoryUsage) {
+	ch <- prometheus.MustNewConstMetric(
+		memoryUsageDesc,
+		prometheus.GaugeValue,
+		float64(metric.Bytes),
+		path, "Bytes",
+	)
+	ch <- prometheus.MustNewConstMetric(
+		memoryUsageDesc,
+		prometheus.GaugeValue,
+		float64(metric.MaxBytes),
+		path, "MaxBytes",
+	)
+}
+
+func updateNumaStatMetric(ch chan<- prometheus.Metric, path string, metric cgroups.NumaStat) {
+	// TODO: use "reflect" to iterate through the struct fields of NumaStat?
+
+	for key, value := range metric.Total.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "Total",
+		)
+	}
+	for key, value := range metric.File.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "File",
+		)
+	}
+	for key, value := range metric.Anon.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "Anon",
+		)
+	}
+	for key, value := range metric.Unevictable.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "Unevictable",
+		)
+	}
+	for key, value := range metric.HierarchicalTotal.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "HierarchicalTotal",
+		)
+	}
+	for key, value := range metric.HierarchicalFile.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "HierarchicalFile",
+		)
+	}
+	for key, value := range metric.HierarchicalAnon.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "HierarchicalAnon",
+		)
+	}
+	for key, value := range metric.HierarchicalUnevictable.Nodes {
+		ch <- prometheus.MustNewConstMetric(
+			numaStatsDesc,
+			prometheus.GaugeValue,
+			float64(value),
+			path, key, "HierarchicalUnevictable",
+		)
+	}
+}
+
+func updateHugeTlbUsageMetric(ch chan<- prometheus.Metric, path string, metric []cgroups.HugetlbUsage) {
+	// One HugeTlbUsage for each size.
+	for _, hugeTlbUsage := range metric {
+		ch <- prometheus.MustNewConstMetric(
+			hugeTlbUsageDesc,
+			prometheus.GaugeValue,
+			float64(hugeTlbUsage.Bytes),
+			path, hugeTlbUsage.Size, "Bytes",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			hugeTlbUsageDesc,
+			prometheus.GaugeValue,
+			float64(hugeTlbUsage.MaxBytes),
+			path, hugeTlbUsage.Size, "MaxBytes",
+		)
+	}
+}
+
+func updateBlkioDeviceUsageMetric(ch chan<- prometheus.Metric, path string, metric cgroups.BlkioThrottleBytes) {
+	for _, deviceBytes := range metric.DeviceBytes {
+		for operation, val := range deviceBytes.Operations {
+			ch <- prometheus.MustNewConstMetric(
+				blkioDeviceUsageDesc,
+				prometheus.CounterValue,
+				float64(val),
+				path, strconv.FormatInt(int64(deviceBytes.Major), 10),
+				strconv.FormatInt(int64(deviceBytes.Minor), 10), operation,
+			)
+		}
+	}
+}
+
+func walkCgroups() []string {
+	containerDirs := []string{}
+
+	cpuset := filepath.Join(cgroupRoot, "cpuset")
+	filepath.Walk(filepath.Join(cpuset, kubepodsDir),
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			if !info.IsDir() {
+				return nil
+			}
+
+			dir := info.Name()
+			if !strings.HasSuffix(dir, ".scope") {
+				return nil
+			}
+
+			switch {
+			case strings.HasPrefix(dir, "cri-containerd-"):
+				break
+			case strings.HasPrefix(dir, "crio-"):
+				break
+			case strings.HasPrefix(dir, "docker-"):
+				break
+			default:
+				return filepath.SkipDir
+			}
+
+			path = strings.TrimPrefix(path, cpuset+"/")
+			containerDirs = append(containerDirs, path)
+
+			return nil
+		})
+
+	return containerDirs
+}
+
+func cgroupPath(controller, path string) string {
+	return filepath.Join(cgroupRoot, controller, path)
+}
+
+// Collect implements prometheus.Collector interface
+func (c collector) Collect(ch chan<- prometheus.Metric) {
+	var wg sync.WaitGroup
+
+	// We don't bail out on errors because those can happen if there is a race condition between
+	// the destruction of a container and us getting to read the cgroup data. We just don't report
+	// the values we don't get.
+
+	collectors := []func(string){
+		func(path string) {
+			defer wg.Done()
+			numa, err := cgroups.GetNumaStats(cgroupPath("memory", path))
+			if err == nil {
+				updateNumaStatMetric(ch, path, numa)
+			} else {
+				log.Error("failed to collect NUMA stats for %s: %v", path, err)
+			}
+		},
+		func(path string) {
+			defer wg.Done()
+			memory, err := cgroups.GetMemoryUsage(cgroupPath("memory", path))
+			if err == nil {
+				updateMemoryUsageMetric(ch, path, memory)
+			} else {
+				log.Error("failed to collect memory usage stats for %s: %v", path, err)
+			}
+		},
+		func(path string) {
+			defer wg.Done()
+			migrate, err := cgroups.GetCPUSetMemoryMigrate(cgroupPath("cpuset", path))
+			if err == nil {
+				updateMemoryMigrateMetric(ch, path, migrate)
+			} else {
+				log.Error("failed to collect memory migration stats for %s: %v", path, err)
+			}
+		},
+		func(path string) {
+			defer wg.Done()
+			cpuAcctUsage, err := cgroups.GetCPUAcctStats(cgroupPath("cpuacct", path))
+			if err == nil {
+				updateCPUAcctUsageMetric(ch, path, cpuAcctUsage)
+			} else {
+				log.Error("failed to collect CPU accounting stats for %s: %v", path, err)
+			}
+		},
+		func(path string) {
+			defer wg.Done()
+			hugeTlbUsage, err := cgroups.GetHugetlbUsage(cgroupPath("hugetlb", path))
+			if err == nil {
+				updateHugeTlbUsageMetric(ch, path, hugeTlbUsage)
+			} else {
+				log.Error("failed to collect hugetlb stats for %s: %v", path, err)
+			}
+		},
+		func(path string) {
+			defer wg.Done()
+			blkioDeviceUsage, err := cgroups.GetBlkioThrottleBytes(cgroupPath("blkio", path))
+			if err == nil {
+				updateBlkioDeviceUsageMetric(ch, path, blkioDeviceUsage)
+			} else {
+				log.Error("failed to collect blkio stats for %s: %v", path, err)
+			}
+		},
+	}
+
+	for _, path := range walkCgroups() {
+		wg.Add(len(collectors))
+		for _, fn := range collectors {
+			go fn(path)
+		}
+	}
+
+	// We need to wait so that the response channel doesn't get closed.
+	wg.Wait()
+}
+
+func init() {
+	flag.StringVar(&cgroupRoot, "cgroup-path", cgroupRoot,
+		"Path to cgroup filesystem mountpoint")
+
+	err := metrics.RegisterCollector("cgroupstats", NewCollector)
+	if err != nil {
+		log.Error("failed register cgroupstats collector: %v", err)
+	}
+}

--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -370,3 +370,22 @@ func (pca *podContainerAffinity) parseFull(pod *pod, value string, weight int32)
 
 	return nil
 }
+
+// globalAffinity creates a general affinity (all containers in scope).
+func globalAffinity(key string, weight int32) *Affinity {
+	return &Affinity{
+		Scope: &Expression{
+			Op: AlwaysTrue, // evaluate against all containers
+		},
+		Match: &Expression{
+			Key: key,
+			Op:  Exists,
+		},
+		Weight: weight,
+	}
+}
+
+// globalAntiAffinity creates a general anti-affinity (all containers in scope).
+func globalAntiAffinity(key string, weight int32) *Affinity {
+	return globalAffinity(key, -weight)
+}

--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// SelfReference indicates a container self-referencing value.
-	//SelfReference = "@self:"
+	SelfReference = "@self:"
 
 	// annotation key for specifying container affinity rules
 	keyAffinity = "affinity"
@@ -39,9 +39,12 @@ type podContainerAffinity map[string][]*Affinity
 
 // Affinity specifies a single container affinity.
 type Affinity struct {
-	Scope  *Expression `json:"scope,omitempty"`  // scope for evaluating this affinity
-	Match  *Expression `json:"match"`            // affinity expression
-	Weight int32       `json:"weight,omitempty"` // (optional) weight for this affinity
+	pod       *pod        // owner pod of this affinity
+	name      string      // owner container name of this affinity
+	container *container  // owner container of this affinity
+	Scope     *Expression `json:"scope,omitempty"`  // scope for evaluating this affinity
+	Match     *Expression `json:"match"`            // affinity expression
+	Weight    int32       `json:"weight,omitempty"` // (optional) weight for this affinity
 }
 
 // Expression is used to describe a criteria to select objects within a domain.
@@ -78,7 +81,19 @@ const (
 	Exists Operator = "Exists"
 	// NotExist evalutes to true if the named key does not exist.
 	NotExist Operator = "NotExist"
+	// AlwaysTrue always evaluates to true.
+	AlwaysTrue = "AlwaysTrue"
 )
+
+// Pod returns the owner Pod of the affinity.
+func (a *Affinity) Pod() (Pod, bool) {
+	return a.pod, a.pod != nil
+}
+
+// Container returns the source/container of the affinity.
+func (a *Affinity) Container() (Container, bool) {
+	return a.container, a.container != nil
+}
 
 // Validate checks the affinity for (obvious) invalidity.
 func (a *Affinity) Validate() error {
@@ -172,15 +187,110 @@ func (e *Expression) Evaluate(container Container) bool {
 		result = ok
 	case NotExist:
 		result = !ok
+	case AlwaysTrue:
+		result = true
 	}
 
 	return result
 }
 
 // KeyValue extracts the value of the expresssion key from a container.
-func (e *Expression) KeyValue(container Container) (string, bool) {
-	value, ok := container.GetLabel(e.Key)
+func (e *Expression) KeyValue(c Container) (string, bool) {
+	//value, ok := container.GetLabel(e.Key)
+	value, ok, _ := c.(*container).resolveRef(e.Key)
 	return value, ok
+}
+
+// SelfDereference dereferences a self-reference.
+func (c *container) SelfDereference(path string) (string, error) {
+	// self reference [@self:]pod/labels/foo.bar.foobar/...
+	if strings.HasPrefix(path, SelfReference) {
+		path = strings.TrimPrefix(path, SelfReference)
+	}
+
+	str, _, err := c.resolveRef(path)
+	return str, err
+}
+
+// refolveRef walks an object trying to resolve a reference to a value.
+func (c *container) resolveRef(path string) (string, bool, error) {
+	var obj interface{}
+
+	c.cache.Debug("resolving %s/%s...", c.PrettyName(), path)
+
+	obj = c
+	ref := strings.Split(path, "/")
+	if len(ref) == 1 {
+		ref = []string{"labels", path}
+	}
+	for {
+		key := ref[0]
+		c.cache.Debug("* resolve: walking %s, @%s, obj %T...", path, key, obj)
+		switch obj.(type) {
+		case *container:
+			c := obj.(*container)
+			switch key {
+			case "pod", "Pod":
+				pod, ok := c.GetPod()
+				if !ok {
+					return "", false, cacheError("failed to find pod (%s) for container %s",
+						c.PodID, c.Name)
+				}
+				obj = pod
+			case "labels", "Labels":
+				obj = c.Labels
+			case "annotations", "Annotations":
+				obj = c.Annotations
+			case "tags", "Tags":
+				obj = c.Tags
+			case "name", "Name":
+				obj = c.Name
+			case "namespace", "Namespace":
+				obj = c.Namespace
+			case "qosclass", "QOSClass":
+				obj = string(c.QOSClass)
+			}
+		case *pod:
+			p := obj.(*pod)
+			switch key {
+			case "labels", "Labels":
+				obj = p.Labels
+			case "annotations", "Annotations":
+				obj = p.Annotations
+			case "name", "Name":
+				obj = p.Name
+			case "namespace", "Namespace":
+				obj = p.Namespace
+			case "qosclass", "QOSClass":
+				obj = string(p.QOSClass)
+			}
+		case map[string]string:
+			value, ok := obj.(map[string]string)[key]
+			if !ok {
+				return "", false, nil
+			}
+			obj = value
+
+		default:
+			return "", false, cacheError("can't handle object of type %T in reference %s",
+				obj, path)
+
+		}
+
+		ref = ref[1:]
+		if len(ref) == 0 {
+			break
+		}
+	}
+
+	str, ok := obj.(string)
+	if !ok {
+		return "", false, cacheError("reference %s resolved to non-string: %T", path, obj)
+	}
+
+	c.cache.Debug("%s/%s => %s", c.PrettyName(), path, str)
+
+	return str, true, nil
 }
 
 // String returns the affinity as a string.
@@ -199,7 +309,7 @@ func (e *Expression) String() string {
 }
 
 // Try to parse affinities in simplified notation from the given annotation value.
-func (pca *podContainerAffinity) parseSimple(pod Pod, value string, weight int32) bool {
+func (pca *podContainerAffinity) parseSimple(pod *pod, value string, weight int32) bool {
 	parsed := simpleAffinity{}
 	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
 		return false
@@ -209,7 +319,10 @@ func (pca *podContainerAffinity) parseSimple(pod Pod, value string, weight int32
 	for name, values := range parsed {
 		(*pca)[name] = append((*pca)[name],
 			&Affinity{
-				Scope: podScope,
+				pod:       pod,
+				name:      name,
+				container: pod.getContainer(name),
+				Scope:     podScope,
 				Match: &Expression{
 					Key:    kubernetes.ContainerNameLabel,
 					Op:     In,
@@ -223,7 +336,7 @@ func (pca *podContainerAffinity) parseSimple(pod Pod, value string, weight int32
 }
 
 // Try to parse affinities in full notation from the given annotation value.
-func (pca *podContainerAffinity) parseFull(pod Pod, value string, weight int32) error {
+func (pca *podContainerAffinity) parseFull(pod *pod, value string, weight int32) error {
 	parsed := podContainerAffinity{}
 	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
 		return cacheError("failed to parse affinity annotation '%s': %v", value, err)
@@ -235,20 +348,23 @@ func (pca *podContainerAffinity) parseFull(pod Pod, value string, weight int32) 
 		if !ok {
 			ca = make([]*Affinity, 0, len(pa))
 		}
+
 		for _, a := range pa {
+			a.pod, a.name, a.container = pod, name, pod.getContainer(name)
+
 			if a.Scope == nil {
 				a.Scope = podScope
 			}
 			if a.Weight == 0 {
 				a.Weight = weight
 			}
-
 			if err := a.Validate(); err != nil {
 				return err
 			}
 
 			ca = append(ca, a)
 		}
+
 		(*pca)[name] = ca
 	}
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -324,6 +324,13 @@ type Container interface {
 	HasPending(string) bool
 	// ClearPending clears the pending change marker for the given controller.
 	ClearPending(string)
+
+	// GetTag gets the value of the given tag.
+	GetTag(string) (string, bool)
+	// SetTag sets the value of the given tag and returns its previous value..
+	SetTag(string, string) (string, bool)
+	// DeleteTag deletes the given tag, returning its deleted value.
+	DeleteTag(string) (string, bool)
 }
 
 // A cached container.
@@ -345,6 +352,7 @@ type container struct {
 	Mounts        map[string]*Mount   // mounts
 	Devices       map[string]*Device  // devices
 	TopologyHints sysfs.TopologyHints // Set of topology hints for all containers within Pod
+	Tags          map[string]string   // container tags (local dyanmic labels)
 
 	Resources v1.ResourceRequirements      // container resources (from webhook annotation)
 	LinuxReq  *cri.LinuxContainerResources // used to estimate Resources if we lack annotations

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -68,6 +68,8 @@ type Pod interface {
 	GetInitContainers() []Container
 	// GetContainers returns the (non-init) containers of the pod.
 	GetContainers() []Container
+	// GetContainer returns the named container of the pod.
+	GetContainer(string) (Container, bool)
 	// GetId returns the pod id of the pod.
 	GetID() string
 	// GetUID returns the (kubernetes) unique id of the pod.
@@ -90,8 +92,6 @@ type Pod interface {
 	// GetResmgrLabel returns the value of a pod label from the
 	// cri-resource-manager namespace.
 	GetResmgrLabel(string) (string, bool)
-	// GetAnnotationKeys returns the keys of all annotations of the container.
-
 	// GetAnnotationKeys returns the keys of all pod annotations as a string slice.
 	GetAnnotationKeys() []string
 	// GetAnnotation returns the value of the given annotation and whether it was found.
@@ -133,6 +133,7 @@ type pod struct {
 	Labels       map[string]string // pod labels
 	Annotations  map[string]string // pod annotations
 	CgroupParent string            // cgroup parent directory
+	containers   map[string]string // container name to ID map
 
 	Resources *PodResourceRequirements // annotated resource requirements
 	Affinity  *podContainerAffinity    // annotated container affinity

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -430,6 +430,8 @@ type Cache interface {
 	DeleteContainer(id string) Container
 	// LookupContainer looks up a container in the cache.
 	LookupContainer(id string) (Container, bool)
+	// LookupContainerByCgroup looks up a container for the given cgroup path.
+	LookupContainerByCgroup(path string) (Container, bool)
 
 	// GetPendingContainers returs all containers with pending changes.
 	GetPendingContainers() []Container
@@ -701,6 +703,35 @@ func (cch *cache) DeleteContainer(id string) Container {
 func (cch *cache) LookupContainer(id string) (Container, bool) {
 	c, ok := cch.Containers[id]
 	return c, ok
+}
+
+// LookupContainerByCgroup looks up the container for the given cgroup path.
+func (cch *cache) LookupContainerByCgroup(path string) (Container, bool) {
+	cch.Debug("resolving %s to a container...", path)
+
+	for id, c := range cch.Containers {
+		if id != c.CacheID {
+			continue
+		}
+
+		parent := ""
+		if pod, ok := c.GetPod(); ok {
+			parent = pod.GetCgroupParentDir()
+		}
+		if parent == "" {
+			continue
+		}
+
+		if !strings.HasPrefix(path, parent) {
+			continue
+		}
+
+		if strings.Index(path, c.GetID()) != -1 {
+			return c, true
+		}
+	}
+
+	return nil, false
 }
 
 // Refresh the cache from an (assumed to be unfiltered) pod or container list response.

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -40,6 +40,9 @@ const (
 	RDT = "rdt"
 	// BlockIO marks changes that can be applied by the BlockIO controller.
 	BlockIO = "blockio"
+
+	// TagAVX512 tags containers that use AVX512 instructions.
+	TagAVX512 = "AVX512"
 )
 
 // PodState is the pod state in the runtime.

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -88,6 +88,8 @@ func (c *container) fromCreateRequest(req *cri.CreateContainerRequest) error {
 		}
 	}
 
+	c.Tags = make(map[string]string)
+
 	// if we get more than one hint, check that there are no duplicates
 	// if len(c.TopologyHints) > 1 {
 	// 	c.TopologyHints = sysfs.DeDuplicateTopologyHints(c.TopologyHints)
@@ -133,6 +135,7 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 	c.Image = lrc.GetImage().GetImage()
 	c.Labels = lrc.Labels
 	c.Annotations = lrc.Annotations
+	c.Tags = make(map[string]string)
 
 	if p.Resources != nil {
 		if r, ok := p.Resources.InitContainers[c.Name]; ok {
@@ -789,4 +792,21 @@ func (c *container) HasPending(controller string) bool {
 	}
 	_, pending := c.pending[controller]
 	return pending
+}
+
+func (c *container) GetTag(key string) (string, bool) {
+	value, ok := c.Tags[key]
+	return value, ok
+}
+
+func (c *container) SetTag(key string, value string) (string, bool) {
+	prev, ok := c.Tags[key]
+	c.Tags[key] = value
+	return prev, ok
+}
+
+func (c *container) DeleteTag(key string) (string, bool) {
+	prev, ok := c.Tags[key]
+	delete(c.Tags, key)
+	return prev, ok
 }

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -41,6 +41,7 @@ func (p *pod) fromRunRequest(req *cri.RunPodSandboxRequest) error {
 		return cacheError("pod %s has no request metadata", p.ID)
 	}
 
+	p.containers = make(map[string]string)
 	p.Name = meta.Name
 	p.Namespace = meta.Namespace
 	p.State = PodState(int32(PodStateReady))
@@ -61,6 +62,7 @@ func (p *pod) fromListResponse(pod *cri.PodSandbox) error {
 		return cacheError("pod %s has no reply metadata", p.ID)
 	}
 
+	p.containers = make(map[string]string)
 	p.Name = meta.Name
 	p.Namespace = meta.Namespace
 	p.State = PodState(int32(pod.State))
@@ -107,6 +109,32 @@ func (p *pod) GetContainers() []Container {
 	}
 
 	return containers
+}
+
+// Get container pointer by its name.
+func (p *pod) getContainer(name string) *container {
+	var found *container
+
+	if p.containers == nil {
+		p.containers = make(map[string]string)
+	}
+
+	for _, c := range p.GetContainers() {
+		cptr := c.(*container)
+		p.containers[cptr.Name] = cptr.ID
+		if cptr.Name == name {
+			found = cptr
+		}
+	}
+
+	return found
+}
+
+// Get container by its name.
+func (p *pod) GetContainer(name string) (Container, bool) {
+	c := p.getContainer(name)
+
+	return c, c != nil
 }
 
 // Get the id of a pod.

--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -74,8 +74,9 @@ func (m *resmgr) pollMetrics() {
 			timer.Stop()
 			return
 		case _ = <-timer.C:
-			m.gatherMetrics()
-			m.processMetrics()
+			gathered := m.gatherMetrics()
+			m.processMetrics(gathered)
+			m.gathered = gathered
 		}
 	}
 }

--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -1,0 +1,147 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resmgr
+
+import (
+	"time"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+// stopEvent is the event used to shut down event processing.
+type stopEvent struct{}
+
+// Our event logging instance
+var elog = logger.NewLogger("event")
+
+// SendEvent injects the given event to the resource managers event processing loop.
+func (m *resmgr) SendEvent(event interface{}) error {
+	if m.events == nil {
+		return resmgrError("can't send event, no event channel")
+	}
+	select {
+	case m.events <- event:
+		return nil
+	default:
+		return resmgrError("can't send event, event channel full")
+	}
+}
+
+// startEventProcessing starts the resource manager event processing goroutine.
+func (m *resmgr) startEventProcessing() error {
+	if err := m.setupMetricsCollection(); err != nil {
+		return err
+	}
+
+	m.shutdown = make(chan interface{})
+	m.events = make(chan interface{}, 8)
+
+	go m.pollMetrics()
+	go m.pollRebalance()
+	go m.processEvents()
+
+	return nil
+}
+
+// stopEventProcessing stops the resource manager event processing loop.
+func (m *resmgr) stopEventProcessing() {
+	if m.shutdown != nil {
+		close(m.shutdown)
+	}
+}
+
+// pollMetrics periodically polls our metrics gatherer.
+func (m *resmgr) pollMetrics() {
+	elog.Info("starting metrics polling")
+	timer := time.NewTicker(opt.PollMetrics)
+	for {
+		select {
+		case _ = <-m.shutdown:
+			elog.Info("stopping metrics polling")
+			timer.Stop()
+			return
+		case _ = <-timer.C:
+			m.gatherMetrics()
+			m.processMetrics()
+		}
+	}
+}
+
+// pollRebalance periodically checks and triggers rebalancing of containers if necessary.
+func (m *resmgr) pollRebalance() {
+	elog.Info("starting rebalance polling")
+	timer := time.NewTicker(opt.Rebalance)
+	for {
+		select {
+		case _ = <-m.shutdown:
+			elog.Info("stopping rebalance polling")
+			timer.Stop()
+			return
+		case _ = <-timer.C:
+			if m.rebalance {
+				if err := m.Rebalance(); err != nil {
+					elog.Error("rebalancing failed: %v", err)
+				} else {
+					m.rebalance = false
+				}
+			}
+		}
+	}
+}
+
+// processEvents pulls events from our event channel and processes them.
+func (m *resmgr) processEvents() {
+	elog.Info("starting event processing")
+	for {
+		select {
+		case _ = <-m.shutdown:
+			elog.Info("stopping event processing")
+			close(m.events)
+			m.events = nil
+			return
+		case event := <-m.events:
+			m.processOneEvent(event)
+		}
+	}
+}
+
+// processOneEvent processes a single resource manager event.
+func (m *resmgr) processOneEvent(event interface{}) {
+	m.Lock()
+	defer m.Unlock()
+
+	switch event.(type) {
+	case string:
+		elog.Debug("received string event '%s'...", event.(string))
+
+	case *avx512Event:
+		e := event.(*avx512Event)
+		if e.active {
+			if _, wasTagged := e.container.SetTag(cache.TagAVX512, "true"); !wasTagged {
+				m.rebalance = true
+			}
+		} else {
+			if _, wasTagged := e.container.DeleteTag(cache.TagAVX512); wasTagged {
+				m.rebalance = true
+			}
+		}
+
+	default:
+		elog.Warn("received unknown event %T (%v)", event, event)
+	}
+
+	m.cache.Save()
+}

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -16,21 +16,24 @@ package resmgr
 
 import (
 	"flag"
+	"time"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
 )
 
-// Options captures our command line or runtime configurable parameters.
+// Options captures our command line parameters.
 type options struct {
-	ImageSocket    string `json:",omitempty"`
-	RuntimeSocket  string `json:",omitempty"`
-	RelaySocket    string `json:",omitempty"`
-	RelayDir       string `json:",omitempty"`
-	AgentSocket    string `json:",omitempty"`
-	ConfigSocket   string `json:",omitempty"`
-	ResctrlPath    string `json:",omitempty"`
-	FallbackConfig string `json:",omitempty"`
-	ForceConfig    string `json:",omitempty"`
+	ImageSocket    string
+	RuntimeSocket  string
+	RelaySocket    string
+	RelayDir       string
+	AgentSocket    string
+	ConfigSocket   string
+	ResctrlPath    string
+	FallbackConfig string
+	ForceConfig    string
+	PollMetrics    time.Duration
+	Rebalance      time.Duration
 }
 
 // Relay command line options and runtime configuration with their defaults.
@@ -55,4 +58,9 @@ func init() {
 		"Fallback configuration to use unless/until one is available from the cache or agent.")
 	flag.StringVar(&opt.ForceConfig, "force-config", "",
 		"Configuration used to override the one stored in the cache. Does not override the agent.")
+
+	flag.DurationVar(&opt.PollMetrics, "metrics-interval", 30*time.Second,
+		"Interval for polling/gathering metrics collection.")
+	flag.DurationVar(&opt.Rebalance, "rebalance-interval", 5*time.Minute,
+		"Minimum interval between triggering container rebalancing.")
 }

--- a/pkg/cri/resource-manager/metrics.go
+++ b/pkg/cri/resource-manager/metrics.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resmgr
+
+import (
+	"bytes"
+	"strings"
+
+	model "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/intel/cri-resource-manager/pkg/avx"
+	"github.com/intel/cri-resource-manager/pkg/cgroups"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/instrumentation"
+	"github.com/intel/cri-resource-manager/pkg/metrics"
+	// pull in all metrics
+	_ "github.com/intel/cri-resource-manager/pkg/metrics/register"
+)
+
+// avx512Event indicates a change in a containers usage of AVX512 instructions.
+type avx512Event struct {
+	container cache.Container
+	active    bool
+}
+
+// setupMetricsCollection activates metrics data collection and processing.
+func (m *resmgr) setupMetricsCollection() error {
+	g, err := metrics.NewMetricGatherer()
+	if err != nil {
+		return err
+	}
+	m.gatherer = g
+	return nil
+}
+
+// gatherMetrics polls metrics and caches them for proxying to prometheus
+func (m *resmgr) gatherMetrics() {
+	families, err := m.gatherer.Gather()
+	if err != nil {
+		elog.Error("failed to gather metrics: %v", err)
+	}
+	m.gathered = families
+}
+
+// processMetrics processes the pending/gathered metrics data
+func (m *resmgr) processMetrics() {
+	for _, f := range m.gathered {
+		m.processMetricFamily(f)
+	}
+	m.gathered = nil
+}
+
+// processMetricFamily processes the given metrics event.
+func (m *resmgr) processMetricFamily(mf *model.MetricFamily) {
+	elog.Debug("got metrics event %s...", *mf.Name)
+
+	if elog.DebugEnabled() {
+		buf := &bytes.Buffer{}
+		if _, err := expfmt.MetricFamilyToText(buf, mf); err == nil {
+			elog.DebugBlock("  <metric event> ", "%s", strings.TrimSpace(buf.String()))
+		}
+	}
+
+	switch *mf.Name {
+	case avx.AVXSwitchCountName:
+		if *mf.Type != model.MetricType_GAUGE {
+			elog.Warn("unexpected %s type: %v, expected %v",
+				avx.AVXSwitchCountName, *mf.Type, model.MetricType_GAUGE)
+			return
+		}
+		for _, metric := range mf.Metric {
+			if len(metric.Label) < 1 {
+				continue
+			}
+			if metric.Label[0].GetName() != "cgroup" {
+				elog.Warn("expected cgroup gauge label not found")
+				continue
+			}
+			cgroup := strings.TrimPrefix(metric.Label[0].GetValue(), cgroups.V2path)
+			value := metric.Gauge.GetValue()
+
+			elog.Info("%s %s: %f", *mf.Name, cgroup, value)
+			if c, ok := m.resolveCgroupPath(cgroup); ok {
+				elog.Info("  => container %s...", c.PrettyName())
+				m.SendEvent(&avx512Event{container: c, active: true})
+			}
+		}
+
+	case avx.AllSwitchCountName:
+		elog.Debug("got metric event %s", *mf.Name)
+
+	case avx.LastCPUName:
+		elog.Debug("got metric event %s", *mf.Name)
+
+	default:
+		elog.Warn("ignoring metric event %s...", *mf.Name)
+	}
+}
+
+// resolveCgroupPath resolves a cgroup path to a container.
+func (m *resmgr) resolveCgroupPath(path string) (cache.Container, bool) {
+	m.Lock()
+	defer m.Unlock()
+	return m.cache.LookupContainerByCgroup(path)
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -416,16 +416,7 @@ func (m *mockCache) DeleteContainer(string) cache.Container {
 func (m *mockCache) LookupContainer(string) (cache.Container, bool) {
 	return m.returnValue1ForLookupContainer, m.returnValue2ForLookupContainer
 }
-func (m *mockCache) StartTransaction() error {
-	panic("unimplemented")
-}
-func (m *mockCache) CommitTransaction() []cache.Container {
-	panic("unimplemented")
-}
-func (m *mockCache) QueryTransaction() []cache.Container {
-	panic("unimplemented")
-}
-func (m *mockCache) AbortTransaction() {
+func (m *mockCache) LookupContainerByCgroup(path string) (cache.Container, bool) {
 	panic("unimplemented")
 }
 func (m *mockCache) GetPendingContainers() []cache.Container {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -302,6 +302,15 @@ func (m *mockContainer) HasPending(string) bool {
 func (m *mockContainer) ClearPending(string) {
 	panic("unimplemented")
 }
+func (m *mockContainer) GetTag(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetTag(string, string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteTag(string) (string, bool) {
+	panic("unimplemented")
+}
 
 type mockPod struct {
 	name                               string

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -316,6 +316,9 @@ func (m *mockPod) GetInitContainers() []cache.Container {
 func (m *mockPod) GetContainers() []cache.Container {
 	panic("unimplemented")
 }
+func (m *mockPod) GetContainer(string) (cache.Container, bool) {
+	panic("unimplemented")
+}
 func (m *mockPod) GetID() string {
 	panic("unimplemented")
 }

--- a/pkg/cri/resource-manager/rebalance.go
+++ b/pkg/cri/resource-manager/rebalance.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resmgr
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+)
+
+// Rebalance rebalances containers.
+func (m *resmgr) Rebalance() error {
+	m.Lock()
+	defer m.Unlock()
+
+	disruptible := []cache.Container{}
+	for _, c := range m.cache.GetContainers() {
+		if c.GetQOSClass() != corev1.PodQOSGuaranteed {
+			disruptible = append(disruptible, c)
+		}
+	}
+	if len(disruptible) == 0 {
+		return nil
+	}
+
+	m.Info("rebalancing (reallocating) containers...")
+
+	method := "rebalance"
+	if err := m.policy.ReallocateResources(disruptible); err != nil {
+		m.Error("%s: failed to rebalance containers: %v", method, err)
+		return resmgrError("%s: failed to rebalance containers: %v", method, err)
+	}
+
+	if err := m.runPostUpdateHooks(context.Background(), method); err != nil {
+		m.Error("%s: failed to run post-update hooks: %v", method, err)
+		return resmgrError("%s: failed to run post-update hooks: %v", method, err)
+	}
+
+	m.cache.Save()
+	return nil
+}
+
+// runPostUpdateHooks runs the necessary hooks after reconcilation.
+func (m *resmgr) runPostUpdateHooks(ctx context.Context, method string) error {
+	for _, c := range m.cache.GetPendingContainers() {
+		switch c.GetState() {
+		case cache.ContainerStateRunning, cache.ContainerStateCreated:
+			if err := m.control.RunPostUpdateHooks(c); err != nil {
+				return err
+			}
+			if req, ok := c.GetCRIRequest(); ok {
+				if _, err := m.sendCRIRequest(ctx, req); err != nil {
+					m.Warn("%s update of container %s failed: %v",
+						method, c.PrettyName(), err)
+				} else {
+					c.ClearCRIRequest()
+				}
+			}
+			m.policy.ExportResourceData(c)
+		default:
+			m.Warn("%s: skipping container %s (in state %v)", method,
+				c.PrettyName(), c.GetState())
+		}
+	}
+	return nil
+}

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -50,8 +50,8 @@ func (m *resmgr) setupRequestProcessing() error {
 	return nil
 }
 
-// activateRequestProcessing starts activates request processing by starting the active policy.
-func (m *resmgr) activateRequestProcessing() error {
+// startRequestProcessing starts request processing by starting the active policy.
+func (m *resmgr) startRequestProcessing() error {
 	ctx := context.Background()
 	add, del, err := m.syncWithCRI(ctx)
 

--- a/pkg/instrumentation/instrumentation.go
+++ b/pkg/instrumentation/instrumentation.go
@@ -175,7 +175,7 @@ func registerPrometheusExporter() error {
 	log := logger.NewLogger("metrics/" + ServiceName)
 	cfg := prometheus.Options{
 		Namespace: prometheusNamespace(ServiceName),
-		Gatherer:  prom.Gatherers{dynamicGatherers, prom.NewRegistry()},
+		Gatherer:  prom.Gatherers{dynamicGatherers},
 		OnError:   func(err error) { log.Error("%v", err) },
 	}
 	pexport, err = prometheus.NewExporter(cfg)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -141,20 +141,6 @@ func (l *logger) passthrough(level Level) bool {
 }
 
 func (l *logger) formatMessage(format string, args ...interface{}) string {
-	if len(l.source) > logging.srcalign {
-		logging.srcalign = len(l.source)
-		l.prefix = ""
-		for _, l := range logging.loggers {
-			l.prefix = ""
-		}
-
-	}
-	if l.prefix == "" {
-		suf := (logging.srcalign - len(l.source)) / 2
-		pre := logging.srcalign - (len(l.source) + suf)
-		l.prefix = "[" + fmt.Sprintf("%-*s", pre, "") + l.source + fmt.Sprintf("%*s", suf, "") + "] "
-	}
-
 	prefix := ""
 	if l.shouldPrefix() {
 		prefix = l.prefix
@@ -352,10 +338,20 @@ func activateBackend(name string) {
 
 // Update loggers when debug flags or sources change.
 func (o *options) updateLoggers() {
+	logging.srcalign = 0
 	for s, l := range logging.loggers {
 		l.enabled = opt.sourceEnabled(s)
 		l.debug = opt.debugEnabled(s)
 		l.level = opt.Level
+		l.prefix = ""
+		if (l.enabled || l.debug) && len(l.source) > logging.srcalign {
+			logging.srcalign = len(l.source)
+		}
+	}
+	for _, l := range logging.loggers {
+		suf := (logging.srcalign - len(l.source)) / 2
+		pre := logging.srcalign - (len(l.source) + suf)
+		l.prefix = "[" + fmt.Sprintf("%-*s", pre, "") + l.source + fmt.Sprintf("%*s", suf, "") + "] "
 	}
 }
 

--- a/pkg/metrics/register/register_metrics.go
+++ b/pkg/metrics/register/register_metrics.go
@@ -1,5 +1,8 @@
 package register
 
 import (
-	_ "github.com/intel/cri-resource-manager/pkg/avx" // To call init()
+	// Pull in avx collector.
+	_ "github.com/intel/cri-resource-manager/pkg/avx"
+	// Pull in cgroup-based metric collector.
+	_ "github.com/intel/cri-resource-manager/pkg/cgroupstats"
 )


### PR DESCRIPTION
This PR is based on/requires #84 and #85 .

This patch series adds skeletal support for making resource manager policy decisions based on unsolicited *events*, in addition to the current, *request*-based decisions. The various patches here
  - splits out and makes externally accessible the HTTP server in pkg/instrumentation
  - adds support for dynamically registered prometheus.Gatherer's to instrumentation (for proxying)
  - add a NUMA- block I/O, etc. metrics collector
  - add policy support for reallocating resources of a subset of the running containers
  - add support for event-triggered decision making
  - periodically trigger metrics collection
  - proxies the collected raw metrics to prometheus
  - generate events and related decisions based on the metrics
  - adds support for AVX512-related container affinity

Currently the only metric we generate events for is AVX512 instructions.