### PR TITLE
avx: disable AVX collector for tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ GO_CYCLO  := gocyclo
 GO_LINT   := golint
 GO_CILINT := golangci-lint
 
+# TEST_TAGS is the set of extra build tags passed for tests.
+TEST_TAGS :=
+GO_TEST   := $(GO_CMD) test $(TEST_TAGS)
+
 # Disable some golangci_lint checkers for now until we have an more acceptable baseline...
 GO_CILINT_CHECKERS := -D unused,staticcheck,errcheck,deadcode,structcheck,gosimple -E golint,gofmt
 
@@ -201,11 +205,11 @@ golangci-lint:
 
 test:
 ifndef WHAT
-	$(Q)$(GO_CMD) test -race -coverprofile=coverage.txt -covermode=atomic \
+	$(Q)$(GO_TEST) -race -coverprofile=coverage.txt -covermode=atomic \
 	    $(GO_MODULES)
 else
 	$(Q)cd $(WHAT) && \
-            $(GO_CMD) test -v -cover -coverprofile cover.out || rc=1; \
+            $(GO_TEST) -v -cover -coverprofile cover.out || rc=1; \
             $(GO_CMD) tool cover -html=cover.out -o coverage.html; \
             rm cover.out; \
             echo "Coverage report: file://$$(realpath coverage.html)"; \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ GO_LINT   := golint
 GO_CILINT := golangci-lint
 
 # TEST_TAGS is the set of extra build tags passed for tests.
-TEST_TAGS :=
+# We disable AVX collector for tests by default.
+TEST_TAGS := -tags noavx
 GO_TEST   := $(GO_CMD) test $(TEST_TAGS)
 
 # Disable some golangci_lint checkers for now until we have an more acceptable baseline...

--- a/pkg/avx/collector.go
+++ b/pkg/avx/collector.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/cgroups"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
-	"github.com/intel/cri-resource-manager/pkg/metrics"
 	bpf "github.com/iovisor/gobpf/elf"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -270,14 +269,6 @@ func (c collector) collectLastCPUStats(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			float64(binary.LittleEndian.Uint32(counters[idx])),
 			fmt.Sprintf("CPU%d", binary.LittleEndian.Uint32(lastCPU)))
-	}
-}
-
-func init() {
-	err := metrics.RegisterCollector("avx", NewCollector)
-	if err != nil {
-		log.Error("Failed to register AVX collector: %v", err)
-		return
 	}
 }
 

--- a/pkg/avx/register.go
+++ b/pkg/avx/register.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !noavx
+
+package avx
+
+import (
+	"github.com/intel/cri-resource-manager/pkg/metrics"
+)
+
+func init() {
+	err := metrics.RegisterCollector("avx", NewCollector)
+	if err != nil {
+		log.Error("Failed to register AVX collector: %v", err)
+	}
+}


### PR DESCRIPTION
It is normal for a *build system* to *not have* the AVX collector's ELF binary for eBPF filtering installed. Currently,
 - a failure to load the ELF binary causes the AVX collector's constructor to fail,
 - which in turn causes the metrics collector's constructor to bail out with an error,
 - which then causes the resource manager's constructor to fail

This prevents even the trivial end-to-end tests from running.

As a workaround split out the code responsible for automatically registering the AVX collector to a file of its own with a compilation constraint on (the lack of) a tag. When running/building tests, set up the default build tags so that the AVX registration code does not get compiled into the test binaries.
