### PR TITLE
fix: assume containers are *not* InitContainers.

### DIFF
--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -99,7 +99,7 @@ func (p *pod) GetContainers() []Container {
 			continue
 		}
 		if p.Resources != nil {
-			if _, ok := p.Resources.Containers[c.ID]; !ok {
+			if _, ok := p.Resources.InitContainers[c.ID]; ok {
 				continue
 			}
 		}


### PR DESCRIPTION
Fix pod.GetContainers() to never assume a container is an
InitContainer unless we know it for sure (IOW our webhook
has explicitly annotated it so).