### PR TITLE
policy: pass discovered system/topology to backend.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -47,11 +47,11 @@ var _ policy.Backend = &eda{}
 // Policy backend implementation
 //
 
-// CreateEdaPolicy creates a new policy instance.
-func CreateEdaPolicy(state cache.Cache, opts *policy.BackendOptions) policy.Backend {
+// CreateEdaPolicy creates a new eda policy instance.
+func CreateEdaPolicy(opts *policy.BackendOptions) policy.Backend {
 	eda := &eda{
 		Logger: logger.NewLogger(PolicyName),
-		state:  state,
+		state:  opts.Cache,
 	}
 	eda.Info("creating policy...")
 	// TODO: policy configuration (if any)

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -35,7 +35,7 @@ type none struct {
 var _ policy.Backend = &none{}
 
 // CreateNonePolicy creates a new policy instance.
-func CreateNonePolicy(cache cache.Cache, opts *policy.BackendOptions) policy.Backend {
+func CreateNonePolicy(opts *policy.BackendOptions) policy.Backend {
 	n := &none{Logger: logger.NewLogger(PolicyName)}
 	n.Info("creating policy...")
 	return n

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -67,12 +67,12 @@ var _ policy.Backend = &stp{}
 //
 
 // CreateStpPolicy creates a new policy instance.
-func CreateStpPolicy(state cache.Cache, opts *policy.BackendOptions) policy.Backend {
+func CreateStpPolicy(opts *policy.BackendOptions) policy.Backend {
 	var err error
 	stp := &stp{
 		Logger: logger.NewLogger(PolicyName),
 		agent:  opts.AgentCli,
-		state:  state,
+		state:  opts.Cache,
 	}
 
 	stp.Info("creating policy...")

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -63,23 +63,18 @@ const (
 )
 
 // NewStaticPolicy creates a new policy instance.
-func NewStaticPolicy(state cache.Cache, opts *policy.BackendOptions) policy.Backend {
+func NewStaticPolicy(opts *policy.BackendOptions) policy.Backend {
 	s := &static{
 		Logger:    logger.NewLogger(PolicyName),
-		state:     state,
+		state:     opts.Cache,
+		sys:       opts.System,
 		available: opts.Available,
 		reserved:  opts.Reserved,
 	}
 
 	s.Info("creating policy...")
 
-	sys, err := sysfs.DiscoverSystem()
-	if err != nil {
-		s.Fatal("failed to discover system topology: %v", err)
-	}
-
-	s.sys = sys
-	s.numHT = sys.CPU(sysfs.ID(0)).ThreadCPUSet().Size()
+	s.numHT = s.sys.CPU(sysfs.ID(0)).ThreadCPUSet().Size()
 
 	if err := s.checkConstraints(); err != nil {
 		s.Fatal("cannot start with given constraints: %v", err)


### PR DESCRIPTION
There are several policies interested in system topology. Instead of duplicating code to do system/topology discovery in each, policy discover it once in the agnostic policy layer and pass it to the backend creation function. Also, change the signature of policy.CreateFn to take all arguments as part of policy.BackendOptions.