### PR TITLE
dump: don't be so chatty about verbosity evaluation when debugging.

### DIFF
--- a/pkg/dump/flags.go
+++ b/pkg/dump/flags.go
@@ -224,13 +224,14 @@ func (f *dumpFile) String() string {
 }
 
 func (o *options) verbosityOf(method string) verbosity {
+	if v, ok := o.matches[method]; ok {
+		return v
+	}
+
 	log.Debug("%s: match checking verbosity...", method)
 	if v, ok := o.methods[method]; ok {
 		log.Debug("  => exact match: %v", v)
-		return v
-	}
-	if v, ok := o.matches[method]; ok {
-		log.Debug("  => regexp match: %v", v)
+		o.matches[method] = v
 		return v
 	}
 	if v, ok := o.methods["*"]; ok {


### PR DESCRIPTION
Log the details of evaluating dumping verbosity only once per encountered method name.
This should make '--logger-debug all' much more usable again regardless if message dumping is enabled.