### PR TITLE
[RFC] introspection: provide data for external introspection (for instance, visualization)

### DIFF
--- a/pkg/cri/resource-manager/introspect/introspect.go
+++ b/pkg/cri/resource-manager/introspect/introspect.go
@@ -1,0 +1,201 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package introspect
+
+import (
+	"encoding/json"
+	"fmt"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/topology"
+	"net/http"
+	"sync"
+)
+
+// Pod describes a single pod and its containers.
+type Pod struct {
+	ID         string                // pod CRI ID
+	UID        string                // pod kubernetes ID
+	Name       string                // pod name
+	Containers map[string]*Container // containers of this pod
+}
+
+// Container describes a single container.
+type Container struct {
+	ID            string        // container CRI ID
+	Name          string        // container name
+	Command       []string      // command
+	Args          []string      // and its arguments
+	CPURequest    int64         // CPU requested in milli-CPU (guaranteed amount)
+	CPULimit      int64         // CPU limit in milli-CPU (maximum allowed CPU)
+	MemoryRequest int64         // memory requested in bytes
+	MemoryLimit   int64         // memory limit in bytes (maximum allowed memory)
+	Hints         TopologyHints // topology/allocation hints
+}
+
+// TopologyHints contain a set of allocation hints for a container.
+type TopologyHints topology.Hints
+
+// Assignment describes resource assignments for a single container.
+type Assignment struct {
+	ContainerID   string // ID of container for this assignment
+	SharedCPUs    string // shared CPUs
+	CPUShare      int    // CPU share/weight for SharedCPUs
+	ExclusiveCPUs string // exclusive CPUs
+	Memory        string // memory controllers
+	RDTClass      string // RDT class
+	BlockIOClass  string // block I/O class
+	Pool          string // pool container is assigned to
+}
+
+// Pool describes a single (resource) pool.
+type Pool struct {
+	Name     string   // pool name
+	CPUs     string   // CPUs in this pool
+	Memory   string   // memory controllers (NUMA nodes) for this pool
+	Parent   string   // parent pool
+	Children []string // child pools
+}
+
+// Socket describes a single physical CPU socket in the system.
+type Socket struct {
+	ID   int    // CPU ID
+	CPUs string // CPUs in this socket
+}
+
+// Node describes a single NUMA node in the system.
+type Node struct {
+	ID   int    // node ID
+	CPUs string // CPUs with locality for this NUMA node.
+}
+
+// System describes the underlying HW/system.
+type System struct {
+	Sockets    map[int]*Socket // physical sockets in the system
+	Nodes      map[int]*Node   // NUMA nodes in the system
+	Isolated   string          // kernel-isolated CPUs
+	Offlined   string          // CPUs offline
+	RDTClasses []string        // RDT classes
+	Policy     string          // active policy
+}
+
+// State is the current introspected state of the resource manager.
+type State struct {
+	Pools       map[string]*Pool       // pools
+	Pods        map[string]*Pod        // pods and containers
+	Assignments map[string]*Assignment // resource assignments
+	System      *System                // info about hardware/system
+	Error       string
+}
+
+// Update is a differential update to a previously set state.
+type Update struct {
+	Removed struct {
+		Pods       []string // removed set of pods,
+		Containers []string // containers, and
+		Pools      []string // pools
+	}
+	Updated struct {
+		Containers  []*Container  // updated set of containers,
+		Assignments []*Assignment // assignments, and
+		Pools       []*Pool       // pools
+	}
+	System *System // updated info about hardware/system
+}
+
+// our logger instance
+var log = logger.NewLogger("instrospect")
+
+// Server is our server for external introspection.
+type Server struct {
+	sync.RWMutex                // need to protect against concurrent introspection/update
+	mux          *http.ServeMux // our HTTP request multiplexer
+	state        *State         // introspection data
+	data         string         // state as a JSON string
+	ready        bool
+}
+
+// Setup prepares the given HTTP request multiplexer for serving introspection.
+func Setup(mux *http.ServeMux, state *State) (*Server, error) {
+	s := &Server{mux: mux}
+	if err := s.set(state); err != nil {
+		return nil, err
+	}
+	mux.HandleFunc("/introspect", s.serve)
+	return s, nil
+}
+
+// Set sets the current state for introspection.
+func (s *Server) Set(state *State) error {
+	s.Lock()
+	defer s.Unlock()
+	return s.set(state)
+}
+
+// Update updates the current state for introspection.
+func (s *Server) Update(update *Update) error {
+	s.Lock()
+	defer s.Unlock()
+	return s.update(update)
+}
+
+// Start enables serving HTTP requests.
+func (s *Server) Start() {
+	s.ready = true
+}
+
+// Stop stops serving further HTTP requests.
+func (s *Server) Stop() {
+	s.ready = false
+}
+
+// set sets the given state and encodes it as a JSON string.
+func (s *Server) set(state *State) error {
+	s.state = state
+	data, err := json.Marshal(s.state)
+	if err != nil {
+		err = introspectError("failed to marshal state for introspection: %v", err)
+		s.state = &State{Error: fmt.Sprintf("%v", err)}
+		data, _ = json.Marshal(s.state)
+	}
+
+	s.data = string(data)
+	return err
+}
+
+// update merges the given update to the current state.
+func (s *Server) update(update *Update) error {
+	return s.set(merge(s.state, update))
+}
+
+// serve serves a single HTTP request.
+func (s *Server) serve(w http.ResponseWriter, req *http.Request) {
+	if !s.ready {
+		return
+	}
+	s.RLock()
+	fmt.Fprintf(w, "%s\n\r", s.data)
+	s.RUnlock()
+}
+
+// merge merges the given updates to the state.
+func merge(state *State, update *Update) *State {
+	log.Error("XXX TODO: merge(): State/Update merging not implemented...")
+	return state
+}
+
+// introspectError creates an introspection-specific error.
+func introspectError(format string, args ...interface{}) error {
+	return fmt.Errorf("introspection: "+format, args...)
+}

--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
@@ -134,6 +135,11 @@ func (eda *eda) Rebalance() (bool, error) {
 // ExportResourceData provides resource data to export for the container.
 func (eda *eda) ExportResourceData(c cache.Container) map[string]string {
 	return nil
+}
+
+// Introspect provides data for external introspection.
+func (eda *eda) Introspect(*introspect.State) {
+	return
 }
 
 //

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -16,6 +16,7 @@ package none
 
 import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
@@ -90,6 +91,11 @@ func (n *none) Rebalance() (bool, error) {
 // ExportResourceData provides resource data to export for the container.
 func (n *none) ExportResourceData(c cache.Container) map[string]string {
 	return nil
+}
+
+// Introspect provides data for external introspection.
+func (n *none) Introspect(*introspect.State) {
+	return
 }
 
 // Register us as a policy implementation.

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
 )
@@ -197,6 +198,11 @@ func (p *staticplus) ExportResourceData(c cache.Container) map[string]string {
 	}
 
 	return data
+}
+
+// Introspect provides data for external introspection.
+func (p *staticplus) Introspect(*introspect.State) {
+	return
 }
 
 // policyError creates a formatted policy-specific error.

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/utils"
@@ -246,6 +247,11 @@ func (stp *stp) Rebalance() (bool, error) {
 // ExportResourceData provides resource data to export for the container.
 func (stp *stp) ExportResourceData(c cache.Container) map[string]string {
 	return nil
+}
+
+// Introspect provides data for external introspection.
+func (stp *stp) Introspect(*introspect.State) {
+	return
 }
 
 func (stp *stp) configNotify(event config.Event, source config.Source) error {

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
@@ -185,6 +186,11 @@ func (s *static) ExportResourceData(c cache.Container) map[string]string {
 	}
 
 	return data
+}
+
+// Introspect provides data for external introspection.
+func (s *static) Introspect(*introspect.State) {
+	return
 }
 
 func (s *static) configNotify(event config.Event, source config.Source) error {

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/rdt"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
 )
 
@@ -108,6 +111,8 @@ type Backend interface {
 	Rebalance() (bool, error)
 	// ExportResourceData provides resource data to export for the container.
 	ExportResourceData(cache.Container) map[string]string
+	// Introspect provides data for external introspection.
+	Introspect(*introspect.State)
 }
 
 // Policy is the exposed interface for container resource allocations decision making.
@@ -126,13 +131,16 @@ type Policy interface {
 	Rebalance() (bool, error)
 	// ExportResourceData exports/updates resource data for the container.
 	ExportResourceData(cache.Container)
+	// Introspect provides data for external introspection.
+	Introspect() *introspect.State
 }
 
 // Policy instance/state.
 type policy struct {
-	cache   cache.Cache    // system state cache
-	backend Backend        // our active backend
-	system  *system.System // system/HW/topology info
+	cache   cache.Cache        // system state cache
+	backend Backend            // our active backend
+	system  *system.System     // system/HW/topology info
+	inspsys *introspect.System // ditto for introspection
 }
 
 // backend is a registered Backend.
@@ -258,6 +266,85 @@ func (p *policy) ExportResourceData(c cache.Container) {
 	}
 
 	p.cache.WriteFile(c.GetCacheID(), ExportedResources, 0644, buf.Bytes())
+}
+
+// Introspect provides data for external introspection/visualization.
+func (p *policy) Introspect() *introspect.State {
+	pods := p.cache.GetPods()
+	state := &introspect.State{Pods: make(map[string]*introspect.Pod, len(pods))}
+
+	for _, p := range pods {
+		containers := p.GetContainers()
+		if len(containers) == 0 {
+			continue
+		}
+
+		pod := &introspect.Pod{
+			ID:         p.GetID(),
+			UID:        p.GetUID(),
+			Name:       p.GetName(),
+			Containers: make(map[string]*introspect.Container, len(containers)),
+		}
+
+		for _, c := range containers {
+			container := &introspect.Container{
+				ID:      c.GetID(),
+				Name:    c.GetName(),
+				Command: c.GetCommand(),
+				Args:    c.GetArgs(),
+				Hints:   introspect.TopologyHints(c.GetTopologyHints()),
+			}
+			resources := c.GetResourceRequirements()
+			if req, ok := resources.Requests[corev1.ResourceCPU]; ok {
+				if value := req.MilliValue(); value > 0 {
+					container.CPURequest = value
+				}
+			}
+			if lim, ok := resources.Limits[corev1.ResourceCPU]; ok {
+				if value := lim.MilliValue(); value > 0 {
+					container.CPULimit = value
+				}
+			}
+			if req, ok := resources.Requests[corev1.ResourceMemory]; ok {
+				if value := req.Value(); value > 0 {
+					container.MemoryRequest = value
+				}
+			}
+			if lim, ok := resources.Limits[corev1.ResourceMemory]; ok {
+				if value := lim.Value(); value > 0 {
+					container.MemoryLimit = value
+				}
+			}
+			pod.Containers[container.ID] = container
+		}
+		state.Pods[pod.ID] = pod
+	}
+
+	if p.inspsys == nil {
+		sys := &introspect.System{
+			Sockets: make(map[int]*introspect.Socket, p.system.PackageCount()),
+			Nodes:   make(map[int]*introspect.Node, p.system.NUMANodeCount()),
+		}
+		for _, id := range p.system.PackageIDs() {
+			pkg := p.system.Package(id)
+			sys.Sockets[int(id)] = &introspect.Socket{ID: int(id), CPUs: pkg.CPUSet().String()}
+		}
+		for _, id := range p.system.NodeIDs() {
+			node := p.system.Node(id)
+			sys.Nodes[int(id)] = &introspect.Node{ID: int(id), CPUs: node.CPUSet().String()}
+		}
+		sys.Isolated = p.system.Isolated().String()
+		sys.Offlined = p.system.Offlined().String()
+		p.inspsys = sys
+	}
+
+	p.inspsys.RDTClasses = append([]string{"<root>"}, rdt.GetClasses()...)
+	p.inspsys.Policy = opt.Policy
+
+	state.System = p.inspsys
+	p.backend.Introspect(state)
+
+	return state
 }
 
 // Register registers a policy backend.

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -140,6 +140,7 @@ func (m *resmgr) RunPod(ctx context.Context, method string, request interface{},
 
 	podID := reply.(*criapi.RunPodSandboxResponse).PodSandboxId
 	pod := m.cache.InsertPod(podID, request)
+	m.introspect()
 
 	m.Info("created pod %s (%s)", pod.GetName(), podID)
 
@@ -193,6 +194,7 @@ func (m *resmgr) RemovePod(ctx context.Context, method string, request interface
 	}
 
 	m.cache.DeletePod(podID)
+	m.introspect()
 
 	return reply, rqerr
 }
@@ -250,6 +252,7 @@ func (m *resmgr) CreateContainer(ctx context.Context, method string, request int
 
 	m.cache.UpdateContainerID(container.GetCacheID(), reply)
 	container.UpdateState(cache.ContainerStateCreated)
+	m.introspect()
 
 	return reply, nil
 }
@@ -292,6 +295,8 @@ func (m *resmgr) StartContainer(ctx context.Context, method string, request inte
 		m.Error("%s: failed to run post-start hooks for %s: %v",
 			method, container.PrettyName(), err)
 	}
+
+	m.introspect()
 
 	return reply, rqerr
 }
@@ -338,6 +343,7 @@ func (m *resmgr) StopContainer(ctx context.Context, method string, request inter
 	}
 
 	container.UpdateState(cache.ContainerStateExited)
+	m.introspect()
 
 	return reply, rqerr
 }
@@ -380,6 +386,7 @@ func (m *resmgr) RemoveContainer(ctx context.Context, method string, request int
 	}
 
 	m.cache.DeleteContainer(container.GetCacheID())
+	m.introspect()
 
 	return reply, rqerr
 }
@@ -403,6 +410,8 @@ func (m *resmgr) UpdateContainer(ctx context.Context, method string, request int
 		m.Warn("%s: XXX TODO: we probably should reallocate the container instead...",
 			method)
 	}
+
+	m.introspect()
 
 	return &criapi.UpdateContainerResourcesResponse{}, nil
 }

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -83,16 +83,35 @@ func NewControl(resctrlpath string) (Control, error) {
 	return r, nil
 }
 
-func (r *control) GetClasses() []string {
-	ret := make([]string, len(r.conf.Classes))
-
+// getClasses returns the names of RDT classes from the given configuration.
+func getClasses(conf interface{}) []string {
+	ret := []string{}
 	i := 0
-	for k := range r.conf.Classes {
-		ret[i] = k
-		i++
+	switch conf.(type) {
+	case *options:
+		for _, p := range conf.(*options).Partitions {
+			for k := range p.Classes {
+				ret[i] = k
+				i++
+			}
+		}
+	case *config:
+		for k := range conf.(*config).Classes {
+			ret[i] = k
+			i++
+		}
 	}
 	sort.Strings(ret)
 	return ret
+}
+
+// GetClasses returns the names of RDT classes in the current configuration.
+func GetClasses() []string {
+	return getClasses(opt.Partitions)
+}
+
+func (r *control) GetClasses() []string {
+	return getClasses(r.conf.Partitions)
 }
 
 func (r *control) SetProcessClass(class string, pids ...string) error {


### PR DESCRIPTION
This patch series adds initial support for external introspection of the current state of the resource manager. Introspection data is served over the instrumentation metrics HTTP endpoint using the '/introspect' path. The data is JSON and currently contains:
  - Pods (name, ID, containers)
  - Containers (name, IDs, command/args, resource requests, topology hints)
  - Pools (name, CPUs, memory, parent/children pools)
  - Assignments (container ID, pool, CPU, memory, RDT class, Block I/O class)
  - System info (HW: sockets, NUMA nodes, isolated&offline CPUs, RDT classes, active policy)

In it's current incarnation the patch set fetches pools and assignments from the active policy while other data is provided by the common agnostic policy layer. Consequently, new corresponding Introspect() functions have been added to the policy and backend interfaces as well as to the builtin policy implementations (only the topology-aware one provides real data FTTB).

The reason for this split of duty is that we have not standardized/unified the data structure(s) for resource assignment in the cache. Therefore it is now stored among the policy-specific data. Consequently the agnostic policy layer cannot interpret/map it to the data format provided externally by/for introspection. If/Once we do the unification, we'll probably be able to get rid of the backend-specific Introspect() interface altogether.

The external introspection interface currently only supports fetching a full snapshot of the current state without providing any means to easily track changes. This is true both for the internal interface which provides data for introspection and the external HTTP introspection interface. Some of the existing data structures (introspect.Update) and functions (introspect.Server.Update) are there with differential updates in mind, although they are currently unused or just stubs.

For this patch set I'd like to do/experiment with these additional things:
  - unify representation of container resource assignment
  - move storing resource assignment from the various policies to the generic policy layer
  - differential updates/provide extra data for indicating the changes since the last introspection

The first two we should do regardless of this patch set not because of it...