### PR TITLE
rdt: support MBps mode of memory bandwidth allocation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -80,7 +80,7 @@ data:
         l3Allocation:
           all: 100%
         mbAllocation:
-          all: 100%
+          all: [100%]
         classes:
           Guaranteed:
             l3schema:
@@ -93,8 +93,8 @@ data:
           #    1: "80%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 100
-          #    1-3: 80
+          #    all: [100%]
+          #    1-3: [80%, 10000MBps]
           Burstable:
             l3schema:
               all:
@@ -104,14 +104,14 @@ data:
                 data: "50%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 66
+          #    all: [66%, 5000MBps]
           BestEffort:
             l3schema:
               all:
                 unified: "33%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 33
+          #    all: [33%, 3000MBps]
   dump: |+
     Config: full:.*,debug
     File: /tmp/cri-full-debug.dump
@@ -187,7 +187,7 @@ data:
         l3Allocation:
           all: 100%
         mbAllocation:
-          all: 100%
+          all: [100%]
         classes:
           Guaranteed:
             l3schema:
@@ -200,8 +200,8 @@ data:
           #    1: "80%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 100
-          #    1-3: 80
+          #    all: [100%]
+          #    1-3: [80%, 10000MBps]
           Burstable:
             l3schema:
               all:
@@ -211,14 +211,14 @@ data:
                 data: "50%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 66
+          #    all: [66%, 5000MBps]
           BestEffort:
             l3schema:
               all:
                 unified: "33%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 33
+          #    all: [33%, 3000MBps]
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -289,7 +289,7 @@ data:
         l3Allocation:
           all: 100%
         mbAllocation:
-          all: 100%
+          all: [100%]
         classes:
           Guaranteed:
             l3schema:
@@ -302,8 +302,8 @@ data:
           #    1: "80%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 100
-          #    1-3: 80
+          #    all: [100%]
+          #    1-3: [80%, 10000MBps]
           Burstable:
             l3schema:
               all:
@@ -313,14 +313,14 @@ data:
                 data: "50%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 66
+          #    all: [66%, 5000MBps]
           BestEffort:
             l3schema:
               all:
                 unified: "33%"
           # MBA (Memory Bandwidth Allocation)
           #  mbschema:
-          #    all: 33
+          #    all: [33%, 3000MBps]
   dump: |+
     Config: full:.*,short:.*Stop.*,off:.*List.*
     File: /tmp/cri-selective-debug.dump


### PR DESCRIPTION
Changes the configuration so that the MB allocation (rdt partitions) and
MB schema (rdt classes) values are now a specified as a list instead of
a single value. Also, a unit is now required in order to determine what
the user intended (100% is quite different than 100MBps in modern
systems). The value to use is picked depending on the mode active on the
os level (whether -o mba_MBps mount option was used or not).

A missing value (of the correct unit) is treated as a configuration
error. This means that normally all mb schemas must have a percentage
value, and, if 'o -mba_MBps' mount option of the resctrl fileystem, all
mb schemas must have a MBps value.

A configuration example:
```
  rdt:
    partitions:
      default:
        mbAllocation:
          all: [90% 9000MBps]
        classes:
          Burstable:
            mbSchema:
              all: [66%, 5000MBps]
```