### PR TITLE
[rebalancing] cache: add cache functions for tagging containers.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -323,6 +323,13 @@ type Container interface {
 	HasPending(string) bool
 	// ClearPending clears the pending change marker for the given controller.
 	ClearPending(string)
+
+	// GetTag gets the value of the given tag.
+	GetTag(string) (string, bool)
+	// SetTag sets the value of the given tag and returns its previous value..
+	SetTag(string, string) (string, bool)
+	// DeleteTag deletes the given tag, returning its deleted value.
+	DeleteTag(string) (string, bool)
 }
 
 // A cached container.
@@ -344,6 +351,7 @@ type container struct {
 	Mounts        map[string]*Mount   // mounts
 	Devices       map[string]*Device  // devices
 	TopologyHints sysfs.TopologyHints // Set of topology hints for all containers within Pod
+	Tags          map[string]string   // container tags (local dynamic labels)
 
 	Resources v1.ResourceRequirements      // container resources (from webhook annotation)
 	LinuxReq  *cri.LinuxContainerResources // used to estimate Resources if we lack annotations

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -88,6 +88,8 @@ func (c *container) fromCreateRequest(req *cri.CreateContainerRequest) error {
 		}
 	}
 
+	c.Tags = make(map[string]string)
+
 	// if we get more than one hint, check that there are no duplicates
 	// if len(c.TopologyHints) > 1 {
 	// 	c.TopologyHints = sysfs.DeDuplicateTopologyHints(c.TopologyHints)
@@ -133,6 +135,7 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 	c.Image = lrc.GetImage().GetImage()
 	c.Labels = lrc.Labels
 	c.Annotations = lrc.Annotations
+	c.Tags = make(map[string]string)
 
 	if p.Resources != nil {
 		if r, ok := p.Resources.InitContainers[c.Name]; ok {
@@ -789,4 +792,21 @@ func (c *container) HasPending(controller string) bool {
 	}
 	_, pending := c.pending[controller]
 	return pending
+}
+
+func (c *container) GetTag(key string) (string, bool) {
+	value, ok := c.Tags[key]
+	return value, ok
+}
+
+func (c *container) SetTag(key string, value string) (string, bool) {
+	prev, ok := c.Tags[key]
+	c.Tags[key] = value
+	return prev, ok
+}
+
+func (c *container) DeleteTag(key string) (string, bool) {
+	value, ok := c.Tags[key]
+	delete(c.Tags, key)
+	return value, ok
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -302,6 +302,15 @@ func (m *mockContainer) HasPending(string) bool {
 func (m *mockContainer) ClearPending(string) {
 	panic("unimplemented")
 }
+func (m *mockContainer) GetTag(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetTag(string, string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteTag(string) (string, bool) {
+	panic("unimplemented")
+}
 
 type mockPod struct {
 	name                               string


### PR DESCRIPTION
Add functions for manipulating container tags, which are basically dynamic labels which exist only in the scope of the resource manager itself. We'll use tags to attach dynamically changing attributes to running containers based on the collected metrics data.
