### PR TITLE
rdt: add JSON marshaller for l3AbsoluteAllocation

### DIFF
--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -175,6 +175,11 @@ func (a l3AbsoluteAllocation) Overlay(baseMask Bitmask) (Bitmask, error) {
 	return Bitmask(a), nil
 }
 
+// MarshalJSON implements the Marshaler interface of "encoding/json"
+func (a l3AbsoluteAllocation) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%#x\"", a)), nil
+}
+
 // Overlay function of the cacheAllocation interface
 func (a l3RelativeAllocation) Overlay(baseMask Bitmask) (Bitmask, error) {
 	baseMaskMsb := uint64(baseMask.msbOne())


### PR DESCRIPTION
Makes debug prints more readable.