### PR TITLE
[rebalancing] cache: allow affinity expressions to reference other metadata than just labels

### DIFF
--- a/docs/container-affinity.md
+++ b/docs/container-affinity.md
@@ -1,0 +1,224 @@
+# Container Affinity and Anti-Affinity
+
+## Introduction
+
+Some policies allow the user to give hints about how particular containers
+should be *co-located* within a node. In particular these hints express whether
+containers should be located *'close'* to each other or *'far away'* from each
+other, in a hardware topology sense.
+
+Since these hints are interpreted always by a particular *policy implementation*,
+the exact definitions of 'close' and 'far' are also somewhat *policy-specific*.
+However as a general rule of thumb containers running
+
+  - on CPUs within the *same NUMA nodes* are considered *'close'* to each other,
+  - on CPUs within *different NUMA nodes* in the *same socket* are *'farther'*, and
+  - on CPUs within *different sockets* are *'far'* from each other
+
+These hints are expressed by `container affinity annotations` on the Pod.
+There are two types of affinities:
+
+  - `affinity` (or `positive affinty`): cause affected containers to *pull* each other closer
+  - `anti-affinity` (or `negative affinity`): cause affected containers to *push* each other further away
+
+Policies try to place a container
+  - close to those the container has affinity towards
+  - far from those the container has anti-affinity towards.
+
+## Affinity Annotation Syntax
+
+*Affinities* are defined as the `cri-resource-manager.intel.com/affinity` annotation.
+*Anti-affinities* are defined as the `cri-resource-manager.intel.com/anti-affinity`
+annotation. They are specified in the `metadata` section of the `Pod YAML`, under
+`annotations` as a dictionary, with each dictionary key being the name of the
+*container* within the Pod to which the annotation belongs to.
+
+```yaml
+metadata:
+  anotations:
+    cri-resource-manager.intel.com/affinity: |
+      container1:
+        - scope:
+            key: [optional-key-domain/]key
+            operator: op
+            values:
+            - value1
+            ...
+            - valueN
+        - match:
+            key: [optional-key-domain/]key
+            operator: op
+            values:
+            - value1
+            ...
+            - valueN
+          weight: w
+```
+
+An anti-affinity is defined similarly but using `cri-resource-manager.intel.com/anti-affinity`
+as the annotation key.
+
+```yaml
+metadata:
+  anotations:
+    cri-resource-manager.intel.com/anti-affinity: |
+      container1:
+        - scope:
+            key: [optional-key-domain/]key
+            operator: op
+            values:
+            - value1
+            ...
+            - valueN
+        - match:
+            key: [optional-key-domain/]key
+            operator: op
+            values:
+            - value1
+            ...
+            - valueN
+          weight: w
+```
+
+## Affinity Semantics
+
+An affinity consists of three parts:
+
+  - `scope expression`: defines which containers this affinity is evaluated against
+  - `match expression`: defines for which containers (within the scope) the affinity applies to
+  - `weight`: defines how *strong* a pull or a push the affinity causes
+
+*Affinities* are also sometimes referred to as *positive affinities* while
+*anti-affinities* are referred to as *negative affinities*. The reason for this is
+that the only difference between these are that affinities have a *positive weight*
+while anti-affinities have a *negative weight*.
+
+The *scope* of an affinity defines the *bounding set of containers* the affinity can
+apply to. The affinity *expression* is evaluated against the containers *in scope* and
+it *selects the containers* the affinity really has an effect on. The *weight* specifies
+whether the effect is a *pull* or a *push*. *Positive* weights cause a *pull* while
+*negative* weights cause a *push*. Additionally, the *weight* specifies *how strong* the
+push or the pull is. This is useful in situations where the policy needs to make some
+compromises because an optimal placement is not possible. The weight then also acts as
+a way to specify preferences of priorities between the various compromises: the heavier
+the weight the stronger the pull or push and the larger the propbability that it will be
+honored, if this is possible at all.
+
+The scope can be omitted from an affinity in which case it implies *Pod scope*, in other
+words the scope of all containers that belong to the same Pod as the container for which
+which the affinity is defined.
+
+The weight can also be omitted in which case it defaults to -1 for anti-affinities
+and +1 for affinities.
+
+Both the affinity scope and the expression select containers, therefore they are identical.
+Both of them are *expressions*. An expression consists of three parts:
+
+  - key: specifies what *metadata* to pick from a container for evaluation
+  - operation (op): specifies what *logical operation* the expression evaluates
+  - values: a set of *strings* to evaluate the the value of the key against
+
+Essentially an expression defines a logical operation of the form (key op values).
+Evaluating this logical expression will take the value of the key in  which
+either evaluates to true or false. 
+a boolean true/false result. Currently the following operations are supported:
+
+  - `Equals`: equality, true if the *value of key* equals the single item in *values*
+  - `NotEqual`: inequality, true if the *value of key* is not equal to the single item in *values*
+  - `In`: membership, true if *value of key* equals to any among *values*
+  - `NotIn`: negated membership, true if the *value of key* is not equal to any among *values*
+  - `Exists`: true if the given *key* exists with any value
+  - `NotExists`: true if the given *key* does not exist
+
+
+The effective affinity between containers C_1 and C_2, A(C_1, C_2) is the sum of the
+weights of all pairwise in-scope matching affinities W(C_1, C_2). To put it another way,
+evaluating an affinity for a container C_1 is done by first using the scope (expression)
+to determine which containers are in the scope of the affinity. Then, for each in-scope
+container C_2 for which the match expression evaluates to true, taking the weight of the
+affinity and adding it to the effective affinity A(C_1, C_2).
+
+Note that currently (for the topology-aware policy) this evaluation is asymmetric:
+A(C_1, C_2) and A(C_2, C_1) can and will be different unless the affinity annotations are
+crafted to prevent this (by making them fully symmetric). Moreover, A(C_1, C_2) is calculated
+and taken into consideration during resource allocation for C_1, while A(C_2, C_1)
+is calculated and taken into account during resource allocation for C_2. This might be
+changed in a future version.
+
+
+## Examples
+
+Put the container `peter` close to the container `sheep` but far away from the
+container `wolf`.
+
+```yaml
+metadata:
+  annotations:
+    cri-resource-manager.intel.com/affinity: |
+      peter:
+      - match:
+          key: name
+          operator: Equals
+          values:
+          - sheep
+        weight: 5
+    cri-resource-manager.intel.com/anti-affinity: |
+      peter:
+      - match:
+          key: name
+          operator: Equals
+          values:
+          - wolf
+        weight: 5
+```
+
+## Shorthand Notation
+
+There is an alternative shorthand syntax for what is considered to be the most common
+case: defining affinities between containers within the same pod. With this notation
+one needs to give just the names of the containers, like in the example below.
+
+```yaml
+  annotations:
+    cri-resource-manager.intel.com/affinity: |
+      container3: [ container1 ]
+    cri-resource-manager.intel.com/anti-affinity: |
+      container3: [ container2 ]
+      container4: [ container2, container3 ]
+```
+
+
+This shorthand notation defines:
+  - `container3` having
+    - affinity (weight 1) to `container1`
+    - `anti-affinity` (weight -1) to `container2`
+  - `container4` having
+    - `anti-affinity` (weight -1) to `container2`, and `container3`
+
+The equivalent annotation in full syntax would be
+
+```yaml
+metadata:
+  annotations:
+    cri-resource-manager.intel.com/affinity: |+
+      container3:
+      - match:
+          key: labels/io.kubernetes.container.name
+          operator: In
+          values:
+          - container1
+    cri-resource-manager.intel.com/anti-affinity: |+
+      container3:
+      - match:
+          key: labels/io.kubernetes.container.name
+          operator: In
+          values:
+          - container2
+      container4:
+      - match:
+          key: labels/io.kubernetes.container.name
+          operator: In
+          values:
+          - container2
+          - container3
+```

--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -300,6 +300,10 @@ func (pca *podContainerAffinity) parseFull(pod *pod, value string, weight int32)
 			}
 			if a.Weight == 0 {
 				a.Weight = weight
+			} else {
+				if weight < 0 {
+					a.Weight *= -1
+				}
 			}
 			if err := a.Validate(); err != nil {
 				return err

--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// SelfReference indicates a container self-referencing value.
-	//SelfReference = "@self:"
-
 	// annotation key for specifying container affinity rules
 	keyAffinity = "affinity"
 	// annotation key for specifying container anti-affinity rules
@@ -46,21 +43,10 @@ type Affinity struct {
 
 // Expression is used to describe a criteria to select objects within a domain.
 type Expression struct {
-	//  Domain  Domain   `json:"domain"`          // domain of operation, ATM implicitly labels
-	Key    string   `json:"key"`              // domain key
+	Key    string   `json:"key"`              // key to check values of/against
 	Op     Operator `json:"operator"`         // operator to apply to value of Key and Values
 	Values []string `json:"values,omitempty"` // value(s) for domain key
 }
-
-/*
-// Domain specifies possible domains to evaluate Expressions in.
-type Domain string
-
-const (
-	// ScopeLabels specifies the operation to be performed
-	LabelsDomain Domain = "labels"
-)
-*/
 
 // Operator defines the possible operators for an Expression.
 type Operator string
@@ -178,9 +164,81 @@ func (e *Expression) Evaluate(container Container) bool {
 }
 
 // KeyValue extracts the value of the expresssion key from a container.
-func (e *Expression) KeyValue(container Container) (string, bool) {
-	value, ok := container.GetLabel(e.Key)
+func (e *Expression) KeyValue(c Container) (string, bool) {
+	value, ok, _ := c.(*container).resolveRef(e.Key)
 	return value, ok
+}
+
+// resolveRef walks an object trying to resolve a reference to a value.
+func (c *container) resolveRef(path string) (string, bool, error) {
+	var obj interface{}
+
+	c.cache.Debug("resolving %s/%s...", c.PrettyName(), path)
+
+	obj = c
+	ref := strings.Split(path, "/")
+	if len(ref) == 1 {
+		ref = []string{"labels", path}
+	}
+	for len(ref) > 0 {
+		key := ref[0]
+		c.cache.Debug("* resolve: walking %s, @%s, obj %T...", path, key, obj)
+		switch v := obj.(type) {
+		case *container:
+			switch strings.ToLower(key) {
+			case "pod":
+				pod, ok := v.GetPod()
+				if !ok {
+					return "", false, cacheError("failed to find pod (%s) for container %s",
+						v.PodID, v.Name)
+				}
+				obj = pod
+			case "labels":
+				obj = v.Labels
+			case "tags":
+				obj = v.Tags
+			case "name":
+				obj = v.Name
+			case "namespace":
+				obj = v.Namespace
+			case "qosclass":
+				obj = string(v.QOSClass)
+			}
+		case *pod:
+			switch strings.ToLower(key) {
+			case "labels":
+				obj = v.Labels
+			case "name":
+				obj = v.Name
+			case "namespace":
+				obj = v.Namespace
+			case "qosclass":
+				obj = string(v.QOSClass)
+			}
+		case map[string]string:
+			value, ok := v[key]
+			if !ok {
+				return "", false, nil
+			}
+			obj = value
+
+		default:
+			return "", false, cacheError("can't handle object of type %T in reference %s",
+				obj, path)
+
+		}
+
+		ref = ref[1:]
+	}
+
+	str, ok := obj.(string)
+	if !ok {
+		return "", false, cacheError("reference %s resolved to non-string: %T", path, obj)
+	}
+
+	c.cache.Debug("%s/%s => %s", c.PrettyName(), path, str)
+
+	return str, true, nil
 }
 
 // String returns the affinity as a string.
@@ -199,7 +257,7 @@ func (e *Expression) String() string {
 }
 
 // Try to parse affinities in simplified notation from the given annotation value.
-func (pca *podContainerAffinity) parseSimple(pod Pod, value string, weight int32) bool {
+func (pca *podContainerAffinity) parseSimple(pod *pod, value string, weight int32) bool {
 	parsed := simpleAffinity{}
 	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
 		return false
@@ -223,7 +281,7 @@ func (pca *podContainerAffinity) parseSimple(pod Pod, value string, weight int32
 }
 
 // Try to parse affinities in full notation from the given annotation value.
-func (pca *podContainerAffinity) parseFull(pod Pod, value string, weight int32) error {
+func (pca *podContainerAffinity) parseFull(pod *pod, value string, weight int32) error {
 	parsed := podContainerAffinity{}
 	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
 		return cacheError("failed to parse affinity annotation '%s': %v", value, err)
@@ -235,6 +293,7 @@ func (pca *podContainerAffinity) parseFull(pod Pod, value string, weight int32) 
 		if !ok {
 			ca = make([]*Affinity, 0, len(pa))
 		}
+
 		for _, a := range pa {
 			if a.Scope == nil {
 				a.Scope = podScope
@@ -242,13 +301,13 @@ func (pca *podContainerAffinity) parseFull(pod Pod, value string, weight int32) 
 			if a.Weight == 0 {
 				a.Weight = weight
 			}
-
 			if err := a.Validate(); err != nil {
 				return err
 			}
 
 			ca = append(ca, a)
 		}
+
 		(*pca)[name] = ca
 	}
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -323,6 +323,13 @@ type Container interface {
 	HasPending(string) bool
 	// ClearPending clears the pending change marker for the given controller.
 	ClearPending(string)
+
+	// GetTag gets the value of the given tag.
+	GetTag(string) (string, bool)
+	// SetTag sets the value of the given tag and returns its previous value..
+	SetTag(string, string) (string, bool)
+	// DeleteTag deletes the given tag, returning its deleted value.
+	DeleteTag(string) (string, bool)
 }
 
 // A cached container.
@@ -344,6 +351,7 @@ type container struct {
 	Mounts        map[string]*Mount   // mounts
 	Devices       map[string]*Device  // devices
 	TopologyHints sysfs.TopologyHints // Set of topology hints for all containers within Pod
+	Tags          map[string]string   // container tags (local dynamic labels)
 
 	Resources v1.ResourceRequirements      // container resources (from webhook annotation)
 	LinuxReq  *cri.LinuxContainerResources // used to estimate Resources if we lack annotations

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -68,6 +68,8 @@ type Pod interface {
 	GetInitContainers() []Container
 	// GetContainers returns the (non-init) containers of the pod.
 	GetContainers() []Container
+	// GetContainer returns the named container of the pod.
+	GetContainer(string) (Container, bool)
 	// GetId returns the pod id of the pod.
 	GetID() string
 	// GetUID returns the (kubernetes) unique id of the pod.
@@ -90,8 +92,6 @@ type Pod interface {
 	// GetResmgrLabel returns the value of a pod label from the
 	// cri-resource-manager namespace.
 	GetResmgrLabel(string) (string, bool)
-	// GetAnnotationKeys returns the keys of all annotations of the container.
-
 	// GetAnnotationKeys returns the keys of all pod annotations as a string slice.
 	GetAnnotationKeys() []string
 	// GetAnnotation returns the value of the given annotation and whether it was found.
@@ -133,6 +133,7 @@ type pod struct {
 	Labels       map[string]string // pod labels
 	Annotations  map[string]string // pod annotations
 	CgroupParent string            // cgroup parent directory
+	containers   map[string]string // container name to ID map
 
 	Resources *PodResourceRequirements // annotated resource requirements
 	Affinity  *podContainerAffinity    // annotated container affinity
@@ -1140,6 +1141,7 @@ func (cch *cache) Restore(data []byte) error {
 
 	for _, p := range cch.Pods {
 		p.cache = cch
+		p.containers = make(map[string]string)
 	}
 	for _, c := range cch.Containers {
 		c.cache = cch

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -88,6 +88,8 @@ func (c *container) fromCreateRequest(req *cri.CreateContainerRequest) error {
 		}
 	}
 
+	c.Tags = make(map[string]string)
+
 	// if we get more than one hint, check that there are no duplicates
 	// if len(c.TopologyHints) > 1 {
 	// 	c.TopologyHints = sysfs.DeDuplicateTopologyHints(c.TopologyHints)
@@ -133,6 +135,7 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 	c.Image = lrc.GetImage().GetImage()
 	c.Labels = lrc.Labels
 	c.Annotations = lrc.Annotations
+	c.Tags = make(map[string]string)
 
 	if p.Resources != nil {
 		if r, ok := p.Resources.InitContainers[c.Name]; ok {
@@ -789,4 +792,21 @@ func (c *container) HasPending(controller string) bool {
 	}
 	_, pending := c.pending[controller]
 	return pending
+}
+
+func (c *container) GetTag(key string) (string, bool) {
+	value, ok := c.Tags[key]
+	return value, ok
+}
+
+func (c *container) SetTag(key string, value string) (string, bool) {
+	prev, ok := c.Tags[key]
+	c.Tags[key] = value
+	return prev, ok
+}
+
+func (c *container) DeleteTag(key string) (string, bool) {
+	value, ok := c.Tags[key]
+	delete(c.Tags, key)
+	return value, ok
 }

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -41,6 +41,7 @@ func (p *pod) fromRunRequest(req *cri.RunPodSandboxRequest) error {
 		return cacheError("pod %s has no request metadata", p.ID)
 	}
 
+	p.containers = make(map[string]string)
 	p.Name = meta.Name
 	p.Namespace = meta.Namespace
 	p.State = PodState(int32(PodStateReady))
@@ -61,6 +62,7 @@ func (p *pod) fromListResponse(pod *cri.PodSandbox) error {
 		return cacheError("pod %s has no reply metadata", p.ID)
 	}
 
+	p.containers = make(map[string]string)
 	p.Name = meta.Name
 	p.Namespace = meta.Namespace
 	p.State = PodState(int32(pod.State))
@@ -107,6 +109,32 @@ func (p *pod) GetContainers() []Container {
 	}
 
 	return containers
+}
+
+// Get container pointer by its name.
+func (p *pod) getContainer(name string) *container {
+	var found *container
+
+	if id, ok := p.containers[name]; ok {
+		return p.cache.Containers[id]
+	}
+
+	for _, c := range p.GetContainers() {
+		cptr := c.(*container)
+		p.containers[cptr.Name] = cptr.ID
+		if cptr.Name == name {
+			found = cptr
+		}
+	}
+
+	return found
+}
+
+// Get container by its name.
+func (p *pod) GetContainer(name string) (Container, bool) {
+	c := p.getContainer(name)
+
+	return c, c != nil
 }
 
 // Get the id of a pod.

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/README.md
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/README.md
@@ -226,3 +226,5 @@ metadata:
           - container3
         weight: -1
 ```
+
+For a more detailed description see [the documentation of annotations](/docs/container-affinity.md).

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -325,6 +325,9 @@ func (m *mockPod) GetInitContainers() []cache.Container {
 func (m *mockPod) GetContainers() []cache.Container {
 	panic("unimplemented")
 }
+func (m *mockPod) GetContainer(string) (cache.Container, bool) {
+	panic("unimplemented")
+}
 func (m *mockPod) GetID() string {
 	panic("unimplemented")
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -302,6 +302,15 @@ func (m *mockContainer) HasPending(string) bool {
 func (m *mockContainer) ClearPending(string) {
 	panic("unimplemented")
 }
+func (m *mockContainer) GetTag(string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) SetTag(string, string) (string, bool) {
+	panic("unimplemented")
+}
+func (m *mockContainer) DeleteTag(string) (string, bool) {
+	panic("unimplemented")
+}
 
 type mockPod struct {
 	name                               string


### PR DESCRIPTION
Allow affinity expressions to reference any of the following metadata:
  - name
  - namespace
  - QoS class
  - labels
  - tags
  - any of the above (sans tags) of the containers parent pod

This mechanism enables the use more flexible and fine-grained affinities. For instance, once can now create an affinity with a scope of all containers of Guaranteed QoS class pods.