### PR TITLE
cache: cache and reuse container.PrettyName().

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -352,6 +352,8 @@ type container struct {
 	RDTClass     string              // RDT class this container is assigned to.
 	BlockIOClass string              // Block I/O class this container is assigned to.
 	pending      map[string]struct{} // controllers with pending changes for this container
+
+	prettyName string // cached PrettyName()
 }
 
 // MountType is a propagation type.

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -146,11 +146,15 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 }
 
 func (c *container) PrettyName() string {
-	pod, ok := c.GetPod()
-	if !ok {
-		return c.PodID + ":" + c.Name
+	if c.prettyName != "" {
+		return c.prettyName
 	}
-	return pod.GetName() + ":" + c.Name
+	if pod, ok := c.GetPod(); !ok {
+		c.prettyName = c.PodID + ":" + c.Name
+	} else {
+		c.prettyName = pod.GetName() + ":" + c.Name
+	}
+	return c.prettyName
 }
 
 func (c *container) GetPod() (Pod, bool) {


### PR DESCRIPTION
Don't recalculate container.PrettyName. Calculate it once then cache internally.