### PR TITLE
[rebalancing] policy: add Rebalance(), stub backend implementations.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/eda/eda.go
+++ b/pkg/cri/resource-manager/policy/builtin/eda/eda.go
@@ -125,6 +125,12 @@ func (eda *eda) UpdateResources(c cache.Container) error {
 	return nil
 }
 
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (eda *eda) Rebalance() (bool, error) {
+	eda.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
 // ExportResourceData provides resource data to export for the container.
 func (eda *eda) ExportResourceData(c cache.Container) map[string]string {
 	return nil

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -81,6 +81,12 @@ func (n *none) UpdateResources(c cache.Container) error {
 	return nil
 }
 
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (n *none) Rebalance() (bool, error) {
+	n.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
 // ExportResourceData provides resource data to export for the container.
 func (n *none) ExportResourceData(c cache.Container) map[string]string {
 	return nil

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -165,6 +165,12 @@ func (p *staticplus) UpdateResources(c cache.Container) error {
 	return nil
 }
 
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (p *staticplus) Rebalance() (bool, error) {
+	p.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
 // ExportResourceData provides resource data to export for the container.
 func (p *staticplus) ExportResourceData(c cache.Container) map[string]string {
 	a, ok := p.allocations[c.GetCacheID()]

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -237,6 +237,12 @@ func (stp *stp) UpdateResources(c cache.Container) error {
 	return nil
 }
 
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (stp *stp) Rebalance() (bool, error) {
+	stp.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
 // ExportResourceData provides resource data to export for the container.
 func (stp *stp) ExportResourceData(c cache.Container) map[string]string {
 	return nil

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -160,6 +160,12 @@ func (s *static) UpdateResources(c cache.Container) error {
 	return nil
 }
 
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (s *static) Rebalance() (bool, error) {
+	s.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
 // ExportResourceData provides resource data to export for the container.
 func (s *static) ExportResourceData(c cache.Container) map[string]string {
 	data := map[string]string{}

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -104,6 +104,8 @@ type Backend interface {
 	ReleaseResources(cache.Container) error
 	// UpdateResources updates resource allocations of a container.
 	UpdateResources(cache.Container) error
+	// Rebalance tries an optimal allocation of resources for the current container.
+	Rebalance() (bool, error)
 	// ExportResourceData provides resource data to export for the container.
 	ExportResourceData(cache.Container) map[string]string
 }
@@ -120,6 +122,8 @@ type Policy interface {
 	ReleaseResources(cache.Container) error
 	// UpdateResources updates resource allocations of a container.
 	UpdateResources(cache.Container) error
+	// Rebalance tries to find an optimal allocation of resources for the current containers.
+	Rebalance() (bool, error)
 	// ExportResourceData exports/updates resource data for the container.
 	ExportResourceData(cache.Container)
 }
@@ -233,6 +237,11 @@ func (p *policy) ReleaseResources(c cache.Container) error {
 // UpdateResources updates resource allocations of a container.
 func (p *policy) UpdateResources(c cache.Container) error {
 	return p.backend.UpdateResources(c)
+}
+
+// Rebalance tries to find a more optimal allocation of resources for the current containers.
+func (p *policy) Rebalance() (bool, error) {
+	return p.backend.Rebalance()
 }
 
 // ExportResourceData exports/updates resource data for the container.


### PR DESCRIPTION
Add a mechanism for optimizing resource allocation for the current set of running containers.

Rebalance() is the primary mechanism for rebalancing/optimizing the resource allocations for the current set of running containers. The resource manager will (eventually) trigger rebalancing periodically. It is up to the policy backend to decide what kind of rebalancing strategy it implements.

The current API presents no way for the upper layer to restrict which containers are in the scope of rebalancing. Regardless, implementations should honor the existing/implied QoS-semantics of pods/containers: containers in Guaranteed QoS pods are not to be disrupted/touched.