### PR TITLE
log: get rid of/hide pre-startup info/debug messages.

### DIFF
--- a/cmd/cri-resmgr/main.go
+++ b/cmd/cri-resmgr/main.go
@@ -55,6 +55,7 @@ func main() {
 		os.Exit(0)
 	}
 
+	log.Flush()
 	log.Info("cri-resmgr (version %s, build %s) starting...", version.Version, version.Build)
 
 	if err := instrumentation.Start(); err != nil {


### PR DESCRIPTION
This patch attempts to the address the reported annoyance with printing initial/startup messages even when cri-resmgr eventually decides not to (as opposed to not being able to) start up. This can happen if any of the `--help`, `--version`, or `--print-config` options are present on the command line.

The patch adds `Logger.Flush()` as support for buffering messages.
The default `fmt` backend now queues initial messages until

  - a logged fatal error occurs (`Fatal()` or `Panic()` called), or
  - the buffer is flushed, or
  - we run out of buffer space (after the arbitrary choice of *64* queued messages)

For cri-resmgr, we Flush() the buffer once we decide in `main()`
to really start up (no --help, --version, or --print-config given).