### PR TITLE
[rebalancing] resource-manager: add skeletal events- and metrics-based rebalancing

### DIFF
--- a/pkg/avx/collector.go
+++ b/pkg/avx/collector.go
@@ -63,7 +63,6 @@ var (
 
 	bpfBinaryName  = "avx512.o"
 	bpfInstallpath = "/usr/libexec/bpf"
-	cgroupV2path   = "/sys/fs/cgroup/unified"
 
 	// our logger instance
 	log = logger.NewLogger("avx")
@@ -168,7 +167,7 @@ func NewCollector() (prometheus.Collector, error) {
 	}
 
 	return &collector{
-		root:                     cgroupV2path,
+		root:                     cgroups.V2path,
 		bpfModule:                bpfModule,
 		avxContextSwitchCounters: avxSwitchCounters,
 		allContextSwitchCounters: allSwitchCounters,
@@ -312,8 +311,6 @@ func (c collector) collectLastCPUStats(ch chan<- prometheus.Metric) {
 }
 
 func init() {
-	flag.StringVar(&cgroupV2path, "cgroupv2-path", cgroupV2path,
-		"Path to cgroup-v2 mountpoint")
 	flag.StringVar(&bpfInstallpath, "bpf-install-path", bpfInstallpath,
 		"Path to eBPF install directory")
 }

--- a/pkg/cgroups/v2path.go
+++ b/pkg/cgroups/v2path.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"flag"
+)
+
+var (
+	// V2path is the mount point for the cgroup V2 pseudofilesystem.
+	V2path string
+)
+
+func init() {
+	flag.StringVar(&V2path, "cgroupv2-path", "/sys/fs/cgroup/unified",
+		"Path to cgroup-v2 mountpoint")
+}

--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -1,0 +1,139 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resmgr
+
+import (
+	"time"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/metrics"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+// Our logger instance for events.
+var evtlog = logger.NewLogger("events")
+
+// setupEventProcessing sets up event and metrics processing.
+func (m *resmgr) setupEventProcessing() error {
+	var err error
+
+	m.events = make(chan interface{}, 8)
+	m.stop = make(chan interface{})
+	options := metrics.Options{
+		PollInterval: opt.MetricsTimer,
+		Events:       m.events,
+	}
+	if m.metrics, err = metrics.NewMetrics(options); err != nil {
+		return resmgrError("failed to create metrics (pre)processor: %v", err)
+	}
+
+	return nil
+}
+
+// startEventProcessing starts event and metrics processing.
+func (m *resmgr) startEventProcessing() error {
+	if err := m.metrics.Start(); err != nil {
+		return resmgrError("failed to start metrics (pre)processor: %v", err)
+	}
+
+	stop := m.stop
+	go func() {
+		rebalanceTimer := time.NewTicker(opt.RebalanceTimer)
+		for {
+			select {
+			case _ = <-stop:
+				return
+			case event := <-m.events:
+				m.processEvent(event)
+			case _ = <-rebalanceTimer.C:
+				if err := m.RebalanceContainers(); err != nil {
+					evtlog.Error("rebalancing failed: %v", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// stopEventProcessing stops event and metrics processing.
+func (m *resmgr) stopEventProcessing() {
+	close(m.stop)
+	m.metrics.Stop()
+}
+
+// SendEvent injects the given event to the resource manaager's event processing loop.
+func (m *resmgr) SendEvent(event interface{}) error {
+	if m.events == nil {
+		return resmgrError("can't send event, no event channel")
+	}
+	select {
+	case m.events <- event:
+		return nil
+	default:
+		return resmgrError("can't send event of type %T, event channel full", event)
+	}
+}
+
+// processEvent processes the given event.
+func (m *resmgr) processEvent(e interface{}) {
+	evtlog.Debug("received event of type %T...", e)
+
+	m.Lock()
+	defer m.Unlock()
+
+	switch event := e.(type) {
+	case string:
+		evtlog.Debug("'%s'...", event)
+	case *metrics.Event:
+		m.processAvx(event.Avx)
+	default:
+		evtlog.Warn("event of unexpected type %T...", e)
+	}
+}
+
+// processAvx processes AVX512 events.
+func (m *resmgr) processAvx(e *metrics.AvxEvent) bool {
+	if e == nil {
+		return false
+	}
+
+	changes := false
+	for cgroup, active := range e.Updates {
+		c, ok := m.resolveCgroupPath(cgroup)
+		if !ok {
+			continue
+		}
+		// XXX This is just for testing, we should effectively drive state transitions
+		//     through a low-pass filter.
+		if active {
+			if _, wasTagged := c.SetTag(cache.TagAVX512, "true"); !wasTagged {
+				evtlog.Info("container %s STARTED using AVX512 instructions", c.PrettyName())
+			}
+		} else {
+			if _, wasTagged := c.DeleteTag(cache.TagAVX512); wasTagged {
+				evtlog.Info("container %s STOPPED using AVX512 instructions", c.PrettyName())
+			}
+		}
+	}
+	return changes
+}
+
+// resolveCgroupPath resolves a cgroup path to a container.
+func (m *resmgr) resolveCgroupPath(path string) (cache.Container, bool) {
+	m.Lock()
+	defer m.Unlock()
+	return m.cache.LookupContainerByCgroup(path)
+}

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -16,6 +16,7 @@ package resmgr
 
 import (
 	"flag"
+	"time"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
 )
@@ -31,6 +32,8 @@ type options struct {
 	ResctrlPath    string
 	FallbackConfig string
 	ForceConfig    string
+	MetricsTimer   time.Duration
+	RebalanceTimer time.Duration
 }
 
 // Relay command line options.
@@ -55,4 +58,9 @@ func init() {
 		"Fallback configuration to use unless/until one is available from the cache or agent.")
 	flag.StringVar(&opt.ForceConfig, "force-config", "",
 		"Configuration used to override the one stored in the cache. Does not override the agent.")
+
+	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 30*time.Second,
+		"Interval for polling/gathering runtime metrics data. Use 'disable' for disabling.")
+	flag.DurationVar(&opt.RebalanceTimer, "rebalance-interval", 5*time.Minute,
+		"Minimum interval between two container rebalancing attempts. Use 'disable' for disabling.")
 }

--- a/pkg/cri/resource-manager/metrics/avx.go
+++ b/pkg/cri/resource-manager/metrics/avx.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	model "github.com/prometheus/client_model/go"
+	"path/filepath"
+
+	"github.com/intel/cri-resource-manager/pkg/cgroups"
+)
+
+// AvxEvent describes cgroup/container AVX512 instruction usage.
+type AvxEvent struct {
+	// Updates contains updates to cgroup/container AVX512 instruction usage.
+	Updates map[string]bool
+}
+
+func (m *Metrics) collectAvxEvents(raw map[string]*model.MetricFamily) *AvxEvent {
+	all, ok := raw["all_switch_count_per_cgroup"]
+	if !ok {
+		return nil
+	}
+	dump("all context switches", all)
+
+	avx, ok := raw["avx_switch_count_per_cgroup"]
+	if !ok {
+		return nil
+	}
+	dump("AVX context switches", avx)
+
+	ratio := map[string]float64{}
+	for _, v := range avx.Metric {
+		cgroup, err := filepath.Rel(cgroups.V2path, v.Label[0].GetValue())
+		if err != nil {
+			continue
+		}
+		ratio[cgroup] = v.Gauge.GetValue()
+	}
+	for _, v := range all.Metric {
+		cgroup, err := filepath.Rel(cgroups.V2path, v.Label[0].GetValue())
+		if err != nil {
+			continue
+		}
+		ratio[cgroup] /= v.Gauge.GetValue()
+	}
+
+	usage := map[string]bool{}
+	for cgroup, use := range ratio {
+		active := use >= m.opts.AvxThreshold
+		log.Debug(" %s AVX ratio = %f, active?: %v", cgroup, use, active)
+		usage[cgroup] = active
+	}
+
+	return &AvxEvent{Updates: usage}
+}

--- a/pkg/cri/resource-manager/metrics/metrics.go
+++ b/pkg/cri/resource-manager/metrics/metrics.go
@@ -1,0 +1,172 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	model "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/metrics"
+	// pull in all metrics collectors
+	_ "github.com/intel/cri-resource-manager/pkg/metrics/register"
+)
+
+const (
+	// DefaultAvxThreshold is the cutoff below which a cgroup/container is not an AVX user.
+	DefaultAvxThreshold = float64(0.1)
+)
+
+// Event is a set of metrics events we deliver to be acted upon.
+type Event struct {
+	Avx *AvxEvent // AVX512 container usage changes
+}
+
+// Options describes options for metrics collection and processing.
+type Options struct {
+	// PollInterval is the interval for polling raw metrics.
+	PollInterval time.Duration
+	// Events is the channel for delivering metrics events.
+	Events chan interface{}
+	// AvxThreshold is the threshold (0 - 1) for a cgroup to be considered AVX512-active
+	AvxThreshold float64
+}
+
+// Metrics implements collecting, caching and processing of raw metrics.
+type Metrics struct {
+	opts Options               // metrics collecting options
+	g    prometheus.Gatherer   // prometheus/raw metrics gatherer
+	stop chan interface{}      // channel to stop polling goroutine
+	raw  []*model.MetricFamily // latest set of raw metrics
+}
+
+// Our logger instance.
+var log = logger.NewLogger("metrics")
+
+// NewMetrics creates a new instance for metrics collecting and processing.
+func NewMetrics(opts Options) (*Metrics, error) {
+	if opts.Events == nil {
+		return nil, metricsError("invalid options, nil Event channel")
+	}
+	if opts.AvxThreshold == 0.0 {
+		opts.AvxThreshold = DefaultAvxThreshold
+	}
+
+	g, err := metrics.NewMetricGatherer()
+	if err != nil {
+		return nil, metricsError("failed to create raw metrics gatherer: %v", err)
+	}
+
+	return &Metrics{
+		opts: opts,
+		raw:  make([]*model.MetricFamily, 0),
+		g:    g,
+	}, nil
+}
+
+// Start starts metrics collection and processing.
+func (m *Metrics) Start() error {
+	if m.stop != nil {
+		return nil
+	}
+
+	stop := make(chan interface{})
+	go func() {
+		pollTimer := time.NewTicker(m.opts.PollInterval)
+		for {
+			select {
+			case _ = <-stop:
+				pollTimer.Stop()
+				return
+			case _ = <-pollTimer.C:
+				if err := m.poll(); err != nil {
+					log.Error("failed to poll raw metrics: %v", err)
+					continue
+				}
+
+				if err := m.process(); err != nil {
+					log.Error("failed to deliver metrics event: %v", err)
+				}
+			}
+		}
+	}()
+	m.stop = stop
+
+	return nil
+}
+
+// Stop stops metrics collection and processing.
+func (m *Metrics) Stop() {
+	close(m.stop)
+	m.stop = nil
+}
+
+// poll does a single round of raw metrics collection.
+func (m *Metrics) poll() error {
+	f, err := m.g.Gather()
+	if err != nil {
+		return metricsError("failed to poll raw metrics: %v", err)
+	}
+	m.raw = f
+	return nil
+}
+
+// process processes the collected raw metrics.
+func (m *Metrics) process() error {
+	raw := map[string]*model.MetricFamily{}
+	for _, f := range m.raw {
+		dump(" <metric "+*f.Name+"> ", f)
+		raw[*f.Name] = f
+	}
+
+	event := &Event{
+		Avx: m.collectAvxEvents(raw),
+	}
+
+	return m.sendEvent(event)
+}
+
+// sendEvent sends a metrics-based event for processing.
+func (m *Metrics) sendEvent(e *Event) error {
+	select {
+	case m.opts.Events <- e:
+		return nil
+	default:
+		return metricsError("failed to deliver event (channel full?)")
+	}
+}
+
+// dump debug-dumps the given MetricFamily data
+func dump(prefix string, f *model.MetricFamily) {
+	if !log.DebugEnabled() {
+		return
+	}
+	buf := &bytes.Buffer{}
+	if _, err := expfmt.MetricFamilyToText(buf, f); err != nil {
+		return
+	}
+	log.DebugBlock("  <"+prefix+"> ", "%s", strings.TrimSpace(buf.String()))
+}
+
+// metricsError returns a new formatted error specific to metrics-processing.
+func metricsError(format string, args ...interface{}) error {
+	return fmt.Errorf("metrics: "+format, args...)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 var (
 	builtInCollectors    = make(map[string]InitCollector)
 	registeredCollectors = []prometheus.Collector{}
-	log                  = logger.NewLogger("metrics")
+	log                  = logger.NewLogger("collectors")
 )
 
 // InitCollector is the type for functions that initialize collectors.


### PR DESCRIPTION
Note: *this PR set requires (IOW includes) #156 .*

This patch set adds a new metrics collector subpackage to the top-level generic resource-manager and initial code to the resource manager itself to trigger periodic rebalancing of the allocated container resources.

The metrics collector subpackage periodically
  - polls the low-level collectors to acquire up-to-date *raw data*,
  - preprocesses the data to produce events for the resource manager, and
  - delivers these events to the resource manager

The events produced are (supposed to be) more *domain-specific* and better suited for consumption by the resource manager than just the collected low-level raw metrics data.

The resource manager
  - pulls events from the metrics collector
  - periodically triggers rebalancing

This initial patch set only implements events related to AVX512 instruction usage. Producing relevant data for the policy-specific rebalancing algorithm needs further patches.