### PR TITLE
pkg/sysfs: kludge to exclude test data from (zip archives in) go get.

### DIFF
--- a/pkg/sysfs/testdata/go.mod
+++ b/pkg/sysfs/testdata/go.mod
@@ -1,0 +1,3 @@
+// This is a kludge to work around the golang toolchain not being able
+// to handle packages with any files with a colon (:) in their name,
+// even if those are not golang sources.


### PR DESCRIPTION
This is a fix to #152 as a less intrusive alternative to #154 .
```
The zip archive code used in the go toolchain can't handle files
with a colon (:) in their name, even if those files are not used
by the toolchain in any way.

As a workaround, we force such files to be excluded from the parent
module by dropping an empty go.mod file above their location in the
source tree.

Workaround spotted in https://github.com/golang/go/issues/26672.
```