### PR TITLE
topology: Fix golint warnings

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -260,7 +260,7 @@ type Container interface {
 	DeleteDevice(string)
 
 	// Get any attached topology hints.
-	GetTopologyHints() topology.TopologyHints
+	GetTopologyHints() topology.Hints
 
 	// GetCPUPeriod gets the CFS CPU period of the container.
 	GetCPUPeriod() int64
@@ -338,24 +338,24 @@ type Container interface {
 
 // A cached container.
 type container struct {
-	cache         *cache                 // our cache of objects
-	ID            string                 // container runtime id
-	PodID         string                 // associate pods runtime id
-	CacheID       string                 // our cache id
-	Name          string                 // container name
-	Namespace     string                 // container namespace
-	State         ContainerState         // created/running/exited/unknown
-	QOSClass      v1.PodQOSClass         // QoS class, if the container had one
-	Image         string                 // containers image
-	Command       []string               // command to run in container
-	Args          []string               // arguments for command
-	Labels        map[string]string      // container labels
-	Annotations   map[string]string      // container annotations
-	Env           map[string]string      // environment variables
-	Mounts        map[string]*Mount      // mounts
-	Devices       map[string]*Device     // devices
-	TopologyHints topology.TopologyHints // Set of topology hints for all containers within Pod
-	Tags          map[string]string      // container tags (local dynamic labels)
+	cache         *cache             // our cache of objects
+	ID            string             // container runtime id
+	PodID         string             // associate pods runtime id
+	CacheID       string             // our cache id
+	Name          string             // container name
+	Namespace     string             // container namespace
+	State         ContainerState     // created/running/exited/unknown
+	QOSClass      v1.PodQOSClass     // QoS class, if the container had one
+	Image         string             // containers image
+	Command       []string           // command to run in container
+	Args          []string           // arguments for command
+	Labels        map[string]string  // container labels
+	Annotations   map[string]string  // container annotations
+	Env           map[string]string  // environment variables
+	Mounts        map[string]*Mount  // mounts
+	Devices       map[string]*Device // devices
+	TopologyHints topology.Hints     // Set of topology hints for all containers within Pod
+	Tags          map[string]string  // container tags (local dynamic labels)
 
 	Resources v1.ResourceRequirements      // container resources (from webhook annotation)
 	LinuxReq  *cri.LinuxContainerResources // used to estimate Resources if we lack annotations

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -495,7 +495,7 @@ func (c *container) DeleteDevice(path string) {
 	}
 }
 
-func (c *container) GetTopologyHints() topology.TopologyHints {
+func (c *container) GetTopologyHints() topology.Hints {
 	return c.TopologyHints
 }
 
@@ -609,12 +609,12 @@ func (c *container) SetCpusetMems(value string) {
 	c.markPending(CRI)
 }
 
-func getTopologyHints(hostPath, containerPath string, readOnly bool) topology.TopologyHints {
+func getTopologyHints(hostPath, containerPath string, readOnly bool) topology.Hints {
 
 	if readOnly {
 		// if device or path is read-only, assume it as non-important for now
 		// TODO: determine topology hint, but use it with low priority
-		return topology.TopologyHints{}
+		return topology.Hints{}
 	}
 
 	// ignore topology information for small files in /etc, service files in /var/lib/kubelet and host libraries mounts
@@ -622,7 +622,7 @@ func getTopologyHints(hostPath, containerPath string, readOnly bool) topology.To
 
 	for _, path := range ignoredTopologyPaths {
 		if strings.HasPrefix(hostPath, path) || strings.HasPrefix(containerPath, path) {
-			return topology.TopologyHints{}
+			return topology.Hints{}
 		}
 	}
 
@@ -634,7 +634,7 @@ func getTopologyHints(hostPath, containerPath string, readOnly bool) topology.To
 	}
 	for _, re := range ignoredTopologyPathRegexps {
 		if re.MatchString(hostPath) || re.MatchString(containerPath) {
-			return topology.TopologyHints{}
+			return topology.Hints{}
 		}
 	}
 
@@ -645,13 +645,13 @@ func getTopologyHints(hostPath, containerPath string, readOnly bool) topology.To
 		}
 	}
 
-	return topology.TopologyHints{}
+	return topology.Hints{}
 }
 
-func getKubeletHint(cpus, mems string) (ret topology.TopologyHints) {
+func getKubeletHint(cpus, mems string) (ret topology.Hints) {
 	if cpus != "" || mems != "" {
-		ret = topology.TopologyHints{
-			topology.ProviderKubelet: topology.TopologyHint{
+		ret = topology.Hints{
+			topology.ProviderKubelet: topology.Hint{
 				Provider: topology.ProviderKubelet,
 				CPUs:     cpus,
 				NUMAs:    mems}}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/flags.go
@@ -36,8 +36,8 @@ type options struct {
 // Our runtime configuration.
 var opt = defaultOptions().(*options)
 
-// fakeHints is our flag.Value for per-pod or per-container faked topology.TopologyHints.
-type fakehints map[string]topology.TopologyHints
+// fakeHints is our flag.Value for per-pod or per-container faked topology.Hints.
+type fakehints map[string]topology.Hints
 
 // newFakeHints creates a new set of fake hints.
 func newFakeHints() fakehints {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Calculate the hint score of the given hint and CPUSet.
-func cpuHintScore(hint topology.TopologyHint, CPUs cpuset.CPUSet) float64 {
+func cpuHintScore(hint topology.Hint, CPUs cpuset.CPUSet) float64 {
 	hCPUs, err := cpuset.Parse(hint.CPUs)
 	if err != nil {
 		log.Warn("invalid hint CPUs '%s' from %s", hint.CPUs, hint.Provider)
@@ -34,7 +34,7 @@ func cpuHintScore(hint topology.TopologyHint, CPUs cpuset.CPUSet) float64 {
 }
 
 // Calculate the NUMA node score of the given hint and NUMA node.
-func numaHintScore(hint topology.TopologyHint, sysIDs ...system.ID) float64 {
+func numaHintScore(hint topology.Hint, sysIDs ...system.ID) float64 {
 	for _, idstr := range strings.Split(hint.NUMAs, ",") {
 		hID, err := strconv.ParseInt(idstr, 0, 0)
 		if err != nil {
@@ -53,7 +53,7 @@ func numaHintScore(hint topology.TopologyHint, sysIDs ...system.ID) float64 {
 }
 
 // Calculate the socket node score of the given hint and NUMA node.
-func socketHintScore(hint topology.TopologyHint, sysID system.ID) float64 {
+func socketHintScore(hint topology.Hint, sysID system.ID) float64 {
 	for _, idstr := range strings.Split(hint.Sockets, ",") {
 		id, err := strconv.ParseInt(idstr, 0, 0)
 		if err != nil {
@@ -69,7 +69,7 @@ func socketHintScore(hint topology.TopologyHint, sysID system.ID) float64 {
 }
 
 // return the cpuset for the CPU, NUMA or socket hints, preferred in this particular order.
-func (cs *cpuSupply) hintCpus(h topology.TopologyHint) cpuset.CPUSet {
+func (cs *cpuSupply) hintCpus(h topology.Hint) cpuset.CPUSet {
 	var cpus cpuset.CPUSet
 
 	switch {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint_test.go
@@ -26,7 +26,7 @@ func TestCpuHintScore(t *testing.T) {
 	tcases := []struct {
 		name     string
 		expected float64
-		hint     topology.TopologyHint
+		hint     topology.Hint
 		cpus     cpuset.CPUSet
 		disabled bool // TODO(rojkov): remove this field when the code is fixed.
 	}{
@@ -36,19 +36,19 @@ func TestCpuHintScore(t *testing.T) {
 		},
 		{
 			name: "handle unparsable cpu size gracefully",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				CPUs: "unparsable",
 			},
 		},
 		{
 			name: "non-zero cpu size hint and empty CPUs",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				CPUs: "1",
 			},
 		},
 		{
 			name: "hint corresponding to given CPU",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				CPUs: "1,2",
 			},
 			cpus:     cpuset.NewCPUSet(1),
@@ -72,25 +72,25 @@ func TestNumaHintScore(t *testing.T) {
 	tcases := []struct {
 		name     string
 		expected float64
-		hint     topology.TopologyHint
+		hint     topology.Hint
 		ids      []system.ID
 	}{
 		{
 			name: "handle unparsable NUMAs gracefully",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				NUMAs: "unparsable",
 			},
 		},
 		{
 			name: "non-zero NUMA hint and empty NUMAs",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				NUMAs: "1",
 			},
 		},
 		{
 			name: "hint corresponding to a given ID",
 			ids:  []system.ID{1},
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				NUMAs: "1,2",
 			},
 			expected: 1.0,
@@ -110,25 +110,25 @@ func TestSocketHintScore(t *testing.T) {
 	tcases := []struct {
 		name     string
 		expected float64
-		hint     topology.TopologyHint
+		hint     topology.Hint
 		id       system.ID
 	}{
 		{
 			name: "handle unparsable Sockets gracefully",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				Sockets: "unparsable",
 			},
 		},
 		{
 			name: "non-zero Sockets hint and empty Sockets",
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				Sockets: "1",
 			},
 		},
 		{
 			name: "hint corresponding to a given ID",
 			id:   1,
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				Sockets: "1,2",
 			},
 			expected: 1.0,
@@ -148,13 +148,13 @@ func TestHintCpus(t *testing.T) {
 	tcases := []struct {
 		name     string
 		supply   *cpuSupply
-		hint     topology.TopologyHint
+		hint     topology.Hint
 		expected cpuset.CPUSet
 	}{
 		{
 			name:   "handle unparsable Sockets gracefully",
 			supply: &cpuSupply{},
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				Sockets: "unparsable",
 			},
 		},
@@ -167,14 +167,14 @@ func TestHintCpus(t *testing.T) {
 					},
 				},
 			},
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				Sockets: "1",
 			},
 		},
 		{
 			name:   "handle unparsable NUMAs gracefully",
 			supply: &cpuSupply{},
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				NUMAs: "unparsable",
 			},
 		},
@@ -187,7 +187,7 @@ func TestHintCpus(t *testing.T) {
 					},
 				},
 			},
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				NUMAs: "1",
 			},
 		},
@@ -195,7 +195,7 @@ func TestHintCpus(t *testing.T) {
 		{
 			name:   "non-zero CPUs hint",
 			supply: &cpuSupply{},
-			hint: topology.TopologyHint{
+			hint: topology.Hint{
 				CPUs: "1",
 			},
 			expected: cpuset.NewCPUSet(1),
@@ -228,25 +228,25 @@ func TestString(t *testing.T) {
 		{
 			name: "non-empty CPUs",
 			fh: fakehints{
-				"key1": topology.TopologyHints{
-					"testkey3": topology.TopologyHint{ // TODO(rojkov): this is bug - this value gets ignored
+				"key1": topology.Hints{
+					"testkey3": topology.Hint{ // TODO(rojkov): this is bug - this value gets ignored
 						CPUs:    "2",
 						NUMAs:   "2",
 						Sockets: "2",
 					},
-					"testkey2": topology.TopologyHint{
+					"testkey2": topology.Hint{
 						CPUs:    "2",
 						NUMAs:   "2",
 						Sockets: "2",
 					},
 				},
-				"key2": topology.TopologyHints{
-					"testkey3": topology.TopologyHint{ // TODO(rojkov): this is bug - this value gets ignored
+				"key2": topology.Hints{
+					"testkey3": topology.Hint{ // TODO(rojkov): this is bug - this value gets ignored
 						CPUs:    "2",
 						NUMAs:   "2",
 						Sockets: "2",
 					},
-					"testkey2": topology.TopologyHint{
+					"testkey2": topology.Hint{
 						CPUs:    "2",
 						NUMAs:   "2",
 						Sockets: "2",

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -208,8 +208,8 @@ func (m *mockContainer) InsertDevice(*cache.Device) {
 func (m *mockContainer) DeleteDevice(string) {
 	panic("unimplemented")
 }
-func (m *mockContainer) GetTopologyHints() topology.TopologyHints {
-	return topology.TopologyHints{}
+func (m *mockContainer) GetTopologyHints() topology.Hints {
+	return topology.Hints{}
 }
 func (m *mockContainer) GetCPUPeriod() int64 {
 	panic("unimplemented")

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
@@ -107,7 +107,7 @@ type Node interface {
 	dump(string, ...int)
 
 	GetScore(CPURequest) CPUScore
-	HintScore(topology.TopologyHint) float64
+	HintScore(topology.Hint) float64
 }
 
 // node represents data common to all node types.
@@ -370,7 +370,7 @@ func (n *node) GetScore(req CPURequest) CPUScore {
 }
 
 // HintScore calculates the (CPU) score of the node for the given topology hint.
-func (n *node) HintScore(hint topology.TopologyHint) float64 {
+func (n *node) HintScore(hint topology.Hint) float64 {
 	return n.self.node.HintScore(hint)
 }
 
@@ -420,7 +420,7 @@ func (n *numanode) DiscoverMemset() system.IDSet {
 }
 
 // HintScore calculates the (CPU) score of the node for the given topology hint.
-func (n *numanode) HintScore(hint topology.TopologyHint) float64 {
+func (n *numanode) HintScore(hint topology.Hint) float64 {
 	switch {
 	case hint.CPUs != "":
 		return cpuHintScore(hint, n.sysnode.CPUSet())
@@ -498,7 +498,7 @@ func (n *socketnode) DiscoverMemset() system.IDSet {
 }
 
 // HintScore calculates the (CPU) score of the node for the given topology hint.
-func (n *socketnode) HintScore(hint topology.TopologyHint) float64 {
+func (n *socketnode) HintScore(hint topology.Hint) float64 {
 	switch {
 	case hint.CPUs != "":
 		return cpuHintScore(hint, n.syspkg.CPUSet())
@@ -560,7 +560,7 @@ func (n *virtualnode) DiscoverMemset() system.IDSet {
 }
 
 // HintScore calculates the (CPU) score of the node for the given topology hint.
-func (n *virtualnode) HintScore(hint topology.TopologyHint) float64 {
+func (n *virtualnode) HintScore(hint topology.Hint) float64 {
 	// don't bother calculating any scores, the root should always score 1.0
 	switch {
 	case hint.CPUs != "":

--- a/pkg/topology/go.mod
+++ b/pkg/topology/go.mod
@@ -1,3 +1,8 @@
 module github.com/intel/cri-resource-manager/pkg/topology
 
 go 1.13
+
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+)

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -37,16 +37,16 @@ const (
 	ProviderKubelet = "kubelet"
 )
 
-// TopologyHint represents various hints that can be detected from sysfs for the device
-type TopologyHint struct {
+// Hint represents various hints that can be detected from sysfs for the device
+type Hint struct {
 	Provider string
 	CPUs     string
 	NUMAs    string
 	Sockets  string
 }
 
-// TopologyHints represents set of hints collected from multiple providers
-type TopologyHints map[string]TopologyHint
+// Hints represents set of hints collected from multiple providers
+type Hints map[string]Hint
 
 func getDevicesFromVirtual(realDevPath string) (devs []string, err error) {
 	if !filepath.HasPrefix(realDevPath, "/sys/devices/virtual") {
@@ -77,14 +77,14 @@ func getDevicesFromVirtual(realDevPath string) (devs []string, err error) {
 }
 
 // NewTopologyHints return array of hints for the device and its slaves (e.g. RAID).
-func NewTopologyHints(devPath string) (hints TopologyHints, err error) {
-	hints = make(TopologyHints)
+func NewTopologyHints(devPath string) (hints Hints, err error) {
+	hints = make(Hints)
 	realDevPath, err := filepath.EvalSymlinks(devPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed get realpath for %s", devPath)
 	}
 	for p := realDevPath; strings.HasPrefix(p, mockRoot+"/sys/devices/"); p = filepath.Dir(p) {
-		hint := TopologyHint{Provider: p}
+		hint := Hint{Provider: p}
 		fileMap := map[string]*string{
 			"local_cpulist": &hint.CPUs,
 			"numa_node":     &hint.NUMAs,
@@ -143,11 +143,11 @@ func NewTopologyHints(devPath string) (hints TopologyHints, err error) {
 }
 
 // MergeTopologyHints combines org and hints.
-func MergeTopologyHints(org, hints TopologyHints) (res TopologyHints) {
+func MergeTopologyHints(org, hints Hints) (res Hints) {
 	if org != nil {
 		res = org
 	} else {
-		res = make(TopologyHints)
+		res = make(Hints)
 	}
 	for k, v := range hints {
 		if _, ok := res[k]; ok {
@@ -159,7 +159,7 @@ func MergeTopologyHints(org, hints TopologyHints) (res TopologyHints) {
 }
 
 // String returns the hints as a string.
-func (h *TopologyHint) String() string {
+func (h *Hint) String() string {
 	cpus, nodes, sockets, sep := "", "", "", ""
 
 	if h.CPUs != "" {

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -210,42 +210,42 @@ func TestGetDevicesFromVirtual(t *testing.T) {
 func TestMergeTopologyHints(t *testing.T) {
 	cases := []struct {
 		name           string
-		inputA         TopologyHints
-		inputB         TopologyHints
-		expectedOutput TopologyHints
+		inputA         Hints
+		inputB         Hints
+		expectedOutput Hints
 		expectedErr    bool
 	}{
 		{
 			name:           "empty",
 			inputA:         nil,
 			inputB:         nil,
-			expectedOutput: TopologyHints{},
+			expectedOutput: Hints{},
 		},
 		{
 			name:           "one,nil",
-			inputA:         TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
+			inputA:         Hints{"test": Hint{Provider: "test", CPUs: "0"}},
 			inputB:         nil,
-			expectedOutput: TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
+			expectedOutput: Hints{"test": Hint{Provider: "test", CPUs: "0"}},
 		},
 		{
 			name:           "nil, one",
 			inputA:         nil,
-			inputB:         TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
-			expectedOutput: TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
+			inputB:         Hints{"test": Hint{Provider: "test", CPUs: "0"}},
+			expectedOutput: Hints{"test": Hint{Provider: "test", CPUs: "0"}},
 		},
 		{
 			name:           "duplicate",
-			inputA:         TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
-			inputB:         TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
-			expectedOutput: TopologyHints{"test": TopologyHint{Provider: "test", CPUs: "0"}},
+			inputA:         Hints{"test": Hint{Provider: "test", CPUs: "0"}},
+			inputB:         Hints{"test": Hint{Provider: "test", CPUs: "0"}},
+			expectedOutput: Hints{"test": Hint{Provider: "test", CPUs: "0"}},
 		},
 		{
 			name:   "two",
-			inputA: TopologyHints{"test1": TopologyHint{Provider: "test1", CPUs: "0"}},
-			inputB: TopologyHints{"test2": TopologyHint{Provider: "test2", CPUs: "1"}},
-			expectedOutput: TopologyHints{
-				"test1": TopologyHint{Provider: "test1", CPUs: "0"},
-				"test2": TopologyHint{Provider: "test2", CPUs: "1"},
+			inputA: Hints{"test1": Hint{Provider: "test1", CPUs: "0"}},
+			inputB: Hints{"test2": Hint{Provider: "test2", CPUs: "1"}},
+			expectedOutput: Hints{
+				"test1": Hint{Provider: "test1", CPUs: "0"},
+				"test2": Hint{Provider: "test2", CPUs: "1"},
 			},
 		},
 	}
@@ -270,7 +270,7 @@ func TestNewTopologyHints(t *testing.T) {
 	cases := []struct {
 		name        string
 		input       string
-		output      TopologyHints
+		output      Hints
 		expectedErr bool
 	}{
 		{
@@ -282,8 +282,8 @@ func TestNewTopologyHints(t *testing.T) {
 		{
 			name:  "pci card1",
 			input: mockRoot + "/sys/devices/pci0000:00/0000:00:02.0/drm/card1",
-			output: TopologyHints{
-				mockRoot + "/sys/devices/pci0000:00/0000:00:02.0": TopologyHint{
+			output: Hints{
+				mockRoot + "/sys/devices/pci0000:00/0000:00:02.0": Hint{
 					Provider: mockRoot + "/sys/devices/pci0000:00/0000:00:02.0",
 					CPUs:     "0-7",
 					NUMAs:    "",


### PR DESCRIPTION
Fixed the following  warnings:
```
topology.go:41:6: type name will be used as topology.TopologyHint by other packages, and that stutters; consider calling this Hint
topology.go:49:6: type name will be used as topology.TopologyHints by other packages, and that stutters; consider calling this Hints
```