### PR TITLE
avx: fix building avx512.o on Linux 5.5

### DIFF
--- a/elf/avx512.c
+++ b/elf/avx512.c
@@ -1,8 +1,5 @@
 #include <uapi/linux/bpf.h>
 #include <asm/page_types.h>
-
-/* asm/fpu/types.h assumes __packed is defined */
-#define __packed __attribute__((packed))
 #include <asm/fpu/types.h>
 
 #define SEC(NAME) __attribute__((section(NAME), used))


### PR DESCRIPTION
- Prevent accidently including userspace headers (-nostdinc).
- Fix include order - #include <linux/types.h> included
  `include/uapi/linux/types.h` when `include/linux/types.h`
  was wanted.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>