### PR TITLE
Fix crash in RebalanceContainers when m.policy is nil

### DIFF
--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -415,7 +415,14 @@ func (m *resmgr) RebalanceContainers() error {
 	m.Info("rebalancing (reallocating) containers...")
 
 	method := "Rebalance"
-	changes, err := m.policy.Rebalance()
+	changes := false
+	var err error
+
+	if m.policy == nil {
+		err = resmgrError("policy is nil")
+	} else {
+		changes, err = m.policy.Rebalance()
+	}
 
 	if err != nil {
 		m.Error("%s: rebalancing of containers failed: %v", method, err)


### PR DESCRIPTION
Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>