### PR TITLE
logging: fix logging races, rework/clean up logger.

### DIFF
--- a/cmd/cri-resmgr/main.go
+++ b/cmd/cri-resmgr/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager"
@@ -63,6 +64,8 @@ func main() {
 		}
 	}
 
+	logger.Flush()
+	logger.SetupDebugToggleSignal(syscall.SIGUSR1)
 	log.Info("cri-resmgr (version %s, build %s) starting...", version.Version, version.Build)
 
 	if err := instrumentation.Start(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opencensus.io v0.22.2
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/grpc v1.23.1
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -17,7 +17,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"strings"
 )
 
 //
@@ -37,7 +36,6 @@ type Logger struct {
 	Error        func(string, ...interface{})
 	Fatal        func(string, ...interface{})
 	Panic        func(string, ...interface{})
-	Block        func(func(string, ...interface{}), string, string, ...interface{})
 }
 
 // log is our Logger.
@@ -66,9 +64,6 @@ func SetLogger(logger Logger) {
 	if logger.Fatal != nil {
 		log.Fatal = logger.Fatal
 	}
-	if logger.Block != nil {
-		log.Block = logger.Block
-	}
 }
 
 func defaultLogger() Logger {
@@ -80,7 +75,6 @@ func defaultLogger() Logger {
 		Error:        errormsg,
 		Fatal:        fatalmsg,
 		Panic:        panicmsg,
-		Block:        blockmsg,
 	}
 }
 
@@ -112,10 +106,4 @@ func fatalmsg(format string, args ...interface{}) {
 func panicmsg(format string, args ...interface{}) {
 	errormsg(format, args...)
 	panic(fmt.Sprintf("fatal error: "+format+"\n", args...))
-}
-
-func blockmsg(fn func(string, ...interface{}), prefix string, format string, args ...interface{}) {
-	for _, line := range strings.Split(fmt.Sprintf(format, args...), "\n") {
-		fn("%s%s", prefix, line)
-	}
 }

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -168,17 +168,22 @@ func dumpLine(dir string, latency time.Duration, format string, args ...interfac
 	}
 }
 
+func dumpblock(fn func(string, ...interface{}), prefix string, format string, args ...interface{}) {
+	for _, line := range strings.Split(fmt.Sprintf(format, args...), "\n") {
+		fn("%s%s", prefix, line)
+	}
+}
+
 func dumpBlock(dir string, latency time.Duration, prefix, msg string) {
 	if !opt.Debug {
-		message.InfoBlock(prefix, msg)
+		message.InfoBlock(prefix, "%s", msg)
 	} else {
-		message.DebugBlock(prefix, msg)
+		message.DebugBlock(prefix, "%s", msg)
 	}
 	if opt.File != "" {
-		log.Block(
-			func(format string, args ...interface{}) {
-				dumpToFile(dir, latency, format, args...)
-			},
+		dumpblock(func(format string, args ...interface{}) {
+			dumpToFile(dir, latency, format, args...)
+		},
 			prefix, "%s", msg)
 	}
 }

--- a/pkg/log/backend.go
+++ b/pkg/log/backend.go
@@ -1,0 +1,233 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"strings"
+)
+
+//
+// Logging backend interface and default fmt-based backend implementation.
+//
+
+// BackendFn is a functions that creates a Backend instance.
+type BackendFn func() Backend
+
+// Backend can format and emit log messages.
+type Backend interface {
+	// Name returns the name of this backend.
+	Name() string
+	// Log emits log messages with the given severity, source, and Printf-like arguments.
+	Log(Level, string, string, ...interface{})
+	// Block emits a multi-line log messages, with an additional line prefix.
+	Block(Level, string, string, string, ...interface{})
+	// Flush flushes and stops initial buffering synchronously
+	Flush()
+	// Sync waits for all messages to get emitted.
+	Sync()
+	// Stop stops the backend instance.
+	Stop()
+	// SetSourceAlignment sets the maximum prefix length for optional alignment.
+	SetSourceAlignment(int)
+}
+
+// RegisterBackend registers a logger backend.
+func RegisterBackend(name string, fn BackendFn) {
+	log.backend[name] = fn
+}
+
+const (
+	// FmtBackendName is the name of our simple fmt-based logging backend.
+	FmtBackendName = "fmt"
+	// fmtBackendQueueLen is the length of the internal fmt message queue.
+	fmtBackendQueueLen = 1024
+)
+
+const (
+	levelNop Level = iota + levelHighest
+	levelStop
+)
+
+// severity tags fmtBackend uses to prefix emitted messages with.
+var fmtTags = map[Level]string{
+	LevelDebug: "D: ",
+	LevelInfo:  "I: ",
+	LevelWarn:  "W: ",
+	LevelError: "E: ",
+	LevelFatal: "FATAL ERROR: ",
+	LevelPanic: "PANIC: ",
+}
+
+// fmtBackend is our simple, default fmt.Printf-based Backend.
+type fmtBackend struct {
+	q     chan *fmtReq // request channel
+	align int          // source alignment
+}
+
+// fmtReq is the request the fmt logger goroutine uses to emit messages.
+type fmtReq struct {
+	level  Level         // logging severity level
+	source string        // logger source
+	prefix string        // block prefix
+	format string        // log message format string
+	args   []interface{} // any arguments for format
+	sync   chan struct{} // reverse-ack for synchronous requests
+	flush  bool          // Flush() and stop queueing
+}
+
+// createFmtBackend creates an fmt Backend and starts its emitter goroutine.
+func createFmtBackend() Backend {
+	f := &fmtBackend{
+		q: make(chan *fmtReq, fmtBackendQueueLen),
+	}
+	go f.run()
+	return f
+}
+
+func (*fmtBackend) Name() string {
+	return FmtBackendName
+}
+
+func (f *fmtBackend) Log(level Level, source, format string, args ...interface{}) {
+	f.log(level, source, "", format, args...)
+}
+
+func (f *fmtBackend) Block(level Level, source, prefix, format string, args ...interface{}) {
+	f.log(level, source, prefix, format, args...)
+}
+
+func (f *fmtBackend) Flush() {
+	sync := make(chan struct{})
+	f.q <- &fmtReq{
+		level: levelNop,
+		flush: true,
+		sync:  sync,
+	}
+	_ = <-sync
+	close(sync)
+}
+
+func (f *fmtBackend) Sync() {
+	sync := make(chan struct{})
+	f.q <- &fmtReq{
+		level: levelNop,
+		sync:  sync,
+	}
+	_ = <-sync
+	close(sync)
+}
+
+func (f *fmtBackend) Stop() {
+	sync := make(chan struct{})
+	f.q <- &fmtReq{
+		level: levelStop,
+		sync:  sync,
+	}
+	_ = <-sync
+	close(sync)
+}
+
+func (f *fmtBackend) SetSourceAlignment(len int) {
+	f.align = len
+}
+
+// log pushes a new log message for emitting.
+func (f *fmtBackend) log(level Level, source, prefix, format string, args ...interface{}) {
+	var sync chan struct{}
+
+	// fatal errors are synchronous
+	if level > LevelError {
+		sync = make(chan struct{})
+	}
+
+	req := &fmtReq{
+		level:  level,
+		source: source,
+		prefix: prefix,
+		format: format,
+		args:   args,
+		sync:   sync,
+		flush:  level >= LevelError, // errors force buffer flush
+	}
+	f.q <- req
+
+	if sync != nil {
+		_ = <-sync
+		close(sync)
+	}
+}
+
+// run emits log messages for the fmtBackend.
+func (f *fmtBackend) run() {
+	buf := make([]*fmtReq, 0, fmtBackendQueueLen)
+
+	//
+	// logging loop
+	//
+	//   1. if we're not buffering, emit immediately
+	//   2. if we're buffering
+	//      - run out of space or asked to flush, flush buffer then emit message
+	//
+
+	for req := range f.q {
+		if buf == nil {
+			// past initial buffering => emit
+			f.emit(req)
+		} else {
+			// flush request or buffer full => flush, stop buffering, emit
+			if req.flush || len(buf) == cap(buf) {
+				for _, r := range buf {
+					f.emit(r)
+				}
+				f.emit(req)
+				buf = nil
+			} else {
+				buf = append(buf, req)
+			}
+		}
+		if req.sync != nil {
+			req.sync <- struct{}{}
+		}
+		if req.level == levelStop {
+			return
+		}
+	}
+}
+
+// emit formats and emits a single log message.
+func (f *fmtBackend) emit(req *fmtReq) {
+	if req.level > levelHighest {
+		return
+	}
+	length := len(req.source)
+	suflen := (f.align - length) / 2
+	prelen := (f.align - (length + suflen))
+	source := "[" + fmt.Sprintf("%*s", prelen, "") + req.source + fmt.Sprintf("%*s", suflen, "") + "]"
+
+	if req.prefix == "" {
+		for _, line := range strings.Split(fmt.Sprintf(req.format, req.args...), "\n") {
+			fmt.Println(fmtTags[req.level], source, line)
+		}
+	} else {
+		for _, line := range strings.Split(fmt.Sprintf(req.format, req.args...), "\n") {
+			fmt.Println(fmtTags[req.level], source, req.prefix, line)
+		}
+	}
+}
+
+func init() {
+	RegisterBackend(FmtBackendName, createFmtBackend)
+}

--- a/pkg/log/default.go
+++ b/pkg/log/default.go
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// our default logger
+var deflog = log.get(filepath.Base(filepath.Clean(os.Args[0])))
+
+// Default returns the default Logger.
+func Default() Logger {
+	return deflog
+}
+
+// Info formats and emits an informational message.
+func Info(format string, args ...interface{}) {
+	deflog.Info(format, args...)
+}
+
+// Warn formats and emits a warning message.
+func Warn(format string, args ...interface{}) {
+	deflog.Warn(format, args...)
+}
+
+// Error formats and emits an error message.
+func Error(format string, args ...interface{}) {
+	deflog.Error(format, args...)
+}
+
+// Fatal formats and emits an error message and os.Exit()'s with status 1.
+func Fatal(format string, args ...interface{}) {
+	deflog.Fatal(format, args...)
+}
+
+// Panic formats and emits an error messages, and panics with the same.
+func Panic(format string, args ...interface{}) {
+	deflog.Panic(format, args...)
+}
+
+// Debug formats and emits a debug message.
+func Debug(format string, args ...interface{}) {
+	deflog.Debug(format, args...)
+}
+
+// InfoBlock formats and emits a multiline information message.
+func InfoBlock(prefix string, format string, args ...interface{}) {
+	deflog.InfoBlock(prefix, format, args...)
+}
+
+// WarnBlock formats and emits a multiline warning message.
+func WarnBlock(prefix string, format string, args ...interface{}) {
+	deflog.WarnBlock(prefix, format, args...)
+}
+
+// ErrorBlock formats and emits a multiline error message.
+func ErrorBlock(prefix string, format string, args ...interface{}) {
+	deflog.ErrorBlock(prefix, format, args...)
+}
+
+// DebugBlock formats and emits a multiline debug message.
+func DebugBlock(prefix string, format string, args ...interface{}) {
+	deflog.DebugBlock(prefix, format, args...)
+}
+
+func init() {
+	binary := filepath.Clean(os.Args[0])
+	source := filepath.Base(binary)
+	deflog = log.get(source)
+}

--- a/pkg/log/delay.go
+++ b/pkg/log/delay.go
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Delayed implements delayed evaluation (can lower the overhead of suppressed log.Debug).
+type Delayed interface {
+	String() string
+}
+
+// delay implements Delayed.
+type delay struct {
+	o interface{}
+}
+
+// Delay wraps its argument for delayed .String() evaluation.
+func Delay(o interface{}) Delayed {
+	return &delay{o: o}
+}
+
+// String implements stringification of its delayed argument.
+func (d *delay) String() string {
+	o := d.o
+	switch o.(type) {
+	case func() string:
+		return o.(func() string)()
+	case func() interface{}:
+		o = o.(func() interface{})()
+	}
+
+	switch o.(type) {
+	case string:
+		return o.(string)
+	case int8:
+		return strconv.FormatInt(int64(o.(int8)), 10)
+	case int16:
+		return strconv.FormatInt(int64(o.(int16)), 10)
+	case int32:
+		return strconv.FormatInt(int64(o.(int32)), 10)
+	case int64:
+		return strconv.FormatInt(o.(int64), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(o.(uint8)), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(o.(uint16)), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(o.(uint32)), 10)
+	case uint64:
+		return strconv.FormatUint(o.(uint64), 10)
+	case float32:
+		return strconv.FormatFloat(float64(o.(float32)), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(o.(float64), 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(o.(bool))
+	default:
+		return fmt.Sprintf("%v", o)
+	}
+}

--- a/pkg/log/doc.go
+++ b/pkg/log/doc.go
@@ -25,21 +25,21 @@ sources are producing debug messages.
 The available message severity levels are error, warning, and info. By default
 all log sources produce messages of all severity and none of the log sources
 produce any debug messages. For instance to enable only warnings and errors,
-and debugging for the resource-manager, policy, cache, and message sources you
-can use the config fragment below:
+and turn on debugging for the resource-manager, policy, cache, and message
+sources you can use the config fragment below:
 
   logger:
-    enable: warning,error
-    debug: resource-manager,policy,cache,messages
+    Enable: warning,error
+    Debug: resource-manager,policy,cache,messages
 
-The reserved keywords 'all' and 'none' can be used to refer to all or none of
-the log sources. For instance, the following fragment enables full logging and
-debugging:
+You can prefix a source or a list of source names with 'off' or 'on' to toggle
+them on or off. For instance, to turn on debugging for all except the cache and
+resource-manager sources you can use the following fragment:
 
   logger:
-    enable: all
-    debug: all
+    Debug: on:*,off:cache,resource-manager
 
-The very same logger settings can be also controlled using the --logger-source
-and --logger-debug command line options.
+The same logger settings can be also controlled using the --logger-source and
+and --logger-debug command line options. As an alternative for '*' you can also
+use 'all'.
 `

--- a/pkg/log/flags.go
+++ b/pkg/log/flags.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Intel Corporation. All Rights Reserved.
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,301 +17,298 @@ package log
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
-	"github.com/intel/cri-resource-manager/pkg/config"
-	"strconv"
 	"strings"
+
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/utils"
 )
 
 const (
-	// DefaultLevel is the default lowest unsuppressed severity.
+	// DefaultLevel is the default logging severity level.
 	DefaultLevel = LevelInfo
-
-	// Flag for selecting logger backend.
-	optionLogger = "logger"
+	// command-line argument prefix.
+	optPrefix = "logger"
+	// Flag for enabling/disabling normal non-debug logging for sources.
+	optEnable = optPrefix + "-sources"
+	// Flag for enabling/disabling debug logging for sources.
+	optDebug = optPrefix + "-debug"
 	// Flag for selecting logging level.
-	optionLevel = "logger-level"
-	// Flag for enabling logging sources.
-	optionSource = "logger-source"
-	// Flag for enabling/disabling logging sources.
-	optionDebug = "logger-debug"
+	optLevel = optPrefix + "-level"
+	// Flag for selecting logging backend.
+	optLogger = optPrefix
+	// configModule is our module name in the runtime configuration.
+	configModule = optPrefix
 )
-
-// LevelNames maps severity levels to names.
-var LevelNames = map[Level]string{
-	LevelDebug: "debug",
-	LevelInfo:  "info",
-	LevelWarn:  "warn",
-	LevelError: "error",
-}
-
-// NamedLevels maps severity names to levels.
-var NamedLevels = map[string]Level{
-	"debug":   LevelDebug,
-	"info":    LevelInfo,
-	"warn":    LevelWarn,
-	"warning": LevelWarn,
-	"error":   LevelError,
-}
-
-// Logging can be configured both from the command line and through pkg/config.
-// Options given on the command line change both the defaults and the runtime
-// configuration. Configuration received via pkg/config only changes the runtime
-// configuration. An empty runtime configuration is initialized to the defaults.
 
 // Logger options configurable via the command line or pkg/config.
 type options struct {
-	Level  Level       // lowest unsuppressed severity
-	Logger backendName // name of active backend
-	Enable stateMap    // enabled logger sources, all if nil
-	Debug  stateMap    // enable debug flags, all if nil
+	// Level is the logging severity/level.
+	Level Level
+	// Enable is a map for enabling/disabling normal logging for sources.
+	Enable srcmap
+	// Debug is a map for enabling/disabling debug logging for sources.
+	Debug srcmap
+	// Logger is the name of the logger backend to use.
+	Logger backendName
 }
 
-type stateMap map[string]bool
+// srcmap tracks logging or debugging settings for sources.
+type srcmap map[string]bool
+
+// backendName is a name for a Backend.
 type backendName string
 
-// Our default and runtime configuration.
+// Default configuration given on the command line (or set via pkg/flag).
 var defaults = &options{
+	Logger: FmtBackendName,
 	Level:  DefaultLevel,
-	Logger: backendName(fmtBackendName),
-	Enable: stateMap{"*": true},
-	Debug:  stateMap{"*": false},
+	Enable: make(srcmap),
+	Debug:  make(srcmap),
 }
-var opt = defaultOptions().(*options)
 
-// Set is the flag.Value setter for Level.
+// Runtime configuration, from an agent, fallback, or forced configuration file.
+var opt = &options{
+	Logger: FmtBackendName,
+	Level:  DefaultLevel,
+	Enable: make(srcmap),
+	Debug:  make(srcmap),
+}
+
+// Set sets the level from the given name.
 func (l *Level) Set(value string) error {
-	level, ok := NamedLevels[value]
+	levels := map[string]Level{
+		"debug":   LevelDebug,
+		"info":    LevelInfo,
+		"warning": LevelWarn,
+		"error":   LevelError,
+		"fatal":   LevelFatal,
+		"panic":   LevelPanic,
+	}
+	level, ok := levels[strings.ToLower(value)]
 	if !ok {
-		return loggerError("unknown log level '%s'", value)
+		return loggerError("invalid logging level %s", value)
 	}
+
 	*l = level
-
-	if l == &defaults.Level {
-		opt.updateLoggers()
-		opt.Level = level
-	}
+	opt.Level = level
+	SetLevel(level)
 
 	return nil
 }
 
-// String is the flag.Value stringification for Level.
+// String returns the name of the level.
 func (l Level) String() string {
-	if name, ok := LevelNames[l]; ok {
-		return name
+	names := map[Level]string{
+		LevelDebug: "debug",
+		LevelInfo:  "info",
+		LevelWarn:  "warning",
+		LevelError: "error",
+		LevelFatal: "fatal",
+		LevelPanic: "panic",
+	}
+	if level, ok := names[l]; ok {
+		return level
 	}
 
-	return LevelNames[LevelInfo]
+	return names[LevelInfo]
 }
 
+// Set sets the name of the active Backend.
 func (n *backendName) Set(value string) error {
-	*n = backendName(value)
-	activateBackend(value)
-
-	if n == &defaults.Logger {
-		opt.Logger = *n
+	if err := SetBackend(value); err != nil {
+		return err
 	}
 
 	return nil
 }
 
+// String returns the name of the active backend.
 func (n backendName) String() string {
 	return string(n)
 }
 
-func (m *stateMap) Set(value string) error {
+// Set sets entries of srcmap by parsing the given value.
+func (m *srcmap) Set(value string) error {
+	log.Lock()
+	defer log.Unlock()
+
+	sm := *m
+	prev, state, src := "", "", ""
+	for _, entry := range strings.Split(value, ",") {
+		statesrc := strings.Split(entry, ":")
+		switch len(statesrc) {
+		case 2:
+			state, src = statesrc[0], statesrc[1]
+		case 1:
+			state, src = "", statesrc[0]
+		default:
+			return loggerError("invalid state spec '%s' in source map", entry)
+		}
+
+		if state != "" {
+			prev = state
+		} else {
+			state = prev
+			if state == "" {
+				state = "on"
+			}
+		}
+		if src == "all" {
+			src = "*"
+		}
+
+		enabled, err := utils.ParseEnabled(state)
+		if err != nil {
+			return loggerError("invalid state '%s' in source map", state)
+		}
+		sm[src] = enabled
+	}
+
+	// propagate command-line to runtime defaults, reconfigure loggers
+	if m == &defaults.Enable {
+		opt.Enable.copy(sm)
+		log.update(sm, nil)
+	}
+	if m == &defaults.Debug {
+		opt.Debug.copy(sm)
+		log.update(nil, sm)
+	}
+
+	return nil
+}
+
+// String returns a string representation of the srcmap.
+func (m *srcmap) String() string {
+	log.RLock()
+	defer log.RUnlock()
+
+	off := ""
+	on := ""
+	for src, state := range *m {
+		if state {
+			if on == "" {
+				on = src
+			} else {
+				on += "," + src
+			}
+		} else {
+			if off == "" {
+				off = src
+			} else {
+				off += "," + src
+			}
+		}
+	}
+
+	if off == "" {
+		return "on:" + on
+	}
+	if on == "" {
+		return "off:" + off
+	}
+
+	return "on:" + on + "," + "off:" + off
+}
+
+// MarshalJSON is the JSON marshaller for srcmap.
+func (m srcmap) MarshalJSON() ([]byte, error) {
+	raw := map[string][]string{"on": {}, "off": {}}
+	which := map[bool][]string{false: raw["off"], true: raw["on"]}
+
+	for src, state := range m {
+		which[state] = append(which[state], src)
+	}
+
+	return json.Marshal(raw)
+}
+
+// UnmarshalJSON is the JSON unmarshaller for srcmap.
+func (m *srcmap) UnmarshalJSON(raw []byte) error {
 	var err error
 
-	if m != &defaults.Enable && m != &defaults.Debug { // from the command line we cumulate these
-		*m = make(stateMap)
-	}
+	*m = make(map[string]bool)
 
-	prev := "on"
-	for _, req := range strings.Split(strings.TrimSpace(value), ",") {
-		var state bool
-		status := prev
-		names := ""
-		split := strings.SplitN(req, ":", 2)
-
-		switch len(split) {
-		case 1:
-			names = split[0]
-		case 2:
-			status = split[0]
-			names = split[1]
-			prev = status
-		default:
-			continue
-		}
-
-		switch status {
-		case "on", "enable", "enabled":
-			state = true
-		case "off", "disable", "disabled":
-			state = false
-		default:
-			if state, err = strconv.ParseBool(status); err != nil {
-				return loggerError("invalid state '%s' in spec '%s': %v", status, value, err)
+	boolmap := map[bool][]string{}
+	if err := json.Unmarshal(raw, &boolmap); err == nil {
+		for state, sources := range boolmap {
+			for _, src := range sources {
+				if src == "all" {
+					src = "*"
+				}
+				(*m)[src] = state
 			}
 		}
+		return nil
+	}
 
-		for _, f := range strings.Split(names, ",") {
-			switch f {
-			case "all", "*":
-				(*m)["*"] = state
-			case "none":
-				(*m)["*"] = !state
-			default:
-				(*m)[f] = state
+	rawmap := map[string][]string{}
+	if err = json.Unmarshal(raw, &rawmap); err == nil {
+		for state, sources := range rawmap {
+			for _, src := range sources {
+				if src == "all" {
+					src = "*"
+				}
+				(*m)[src], err = utils.ParseEnabled(state)
+				if err != nil {
+					return loggerError("source '%s' has invalid state '%s' in logger source map",
+						src, state)
+				}
 			}
 		}
+		return nil
 	}
 
-	var optMap *stateMap
-
-	switch {
-	case m == &defaults.Enable:
-		optMap = &opt.Enable
-	case m == &defaults.Debug:
-		optMap = &opt.Debug
-	}
-
-	if optMap != nil {
-		*optMap = make(stateMap)
-		for key, value := range *m {
-			(*optMap)[key] = value
+	cfgstr := ""
+	if err = json.Unmarshal(raw, &cfgstr); err == nil {
+		if err := m.Set(cfgstr); err != nil {
+			return loggerError("failed to unmarshal logger source map/configuration '%s': %v",
+				string(raw), err)
 		}
-		opt.updateLoggers()
+		return nil
 	}
+
+	return loggerError("failed to unmarshal logger source map '%s': %v",
+		string(raw), err)
+}
+
+// copy state from another srcmap.
+func (m srcmap) copy(o srcmap) {
+	for src, state := range o {
+		m[src] = state
+	}
+}
+
+// configNotify is the configuration change notification callback for options.
+func (o *options) configNotify(event pkgcfg.Event, src pkgcfg.Source) error {
+	deflog.Info("logger configuration event %v", event)
+
+	deflog.Info("*  log level: %v", opt.Level)
+	deflog.Info("*    logging: %v", opt.Enable.String())
+	deflog.Info("*  debugging: %v", opt.Debug.String())
+
+	log.Lock()
+	defer log.Unlock()
+
+	log.setLevel(opt.Level)
+	log.setBackend(opt.Logger.String())
+
+	if len(opt.Enable) == 0 {
+		opt.Enable.copy(defaults.Enable)
+	}
+	if len(opt.Debug) == 0 {
+		opt.Debug.copy(defaults.Debug)
+	}
+	log.update(opt.Enable, opt.Debug)
 
 	return nil
 }
 
-func (m *stateMap) String() string {
-	if *m == nil {
-		return "all"
-	}
-	if len(*m) == 0 {
-		return "none"
-	}
-
-	tVal, tSep := "", ""
-	fVal, fSep := "", ""
-
-	for name, state := range *m {
-		if name == "*" {
-			name = "all"
-		}
-		if state {
-			tVal += tSep + name
-			tSep = ","
-		} else {
-			fVal += fSep + name
-			fSep = ","
-		}
-	}
-
-	if tVal != "" {
-		tVal = "on:" + tVal
-	}
-	if fVal != "" {
-		fVal = "off:" + fVal
-	}
-
-	switch {
-	case fVal == "":
-		return tVal
-	case tVal == "":
-		return fVal
-	case tVal != "" && fVal != "":
-		return tVal + "," + fVal
-	}
-	return ""
-}
-
-func (m *stateMap) isEnabled(name string) bool {
-	if m == nil || *m == nil {
-		return false
-	}
-
-	if state, ok := (*m)[name]; ok {
-		return state
-	}
-	if state, ok := (*m)["*"]; ok {
-		return state
-	}
-
-	return false
-}
-
-func (o *options) MarshalJSON() ([]byte, error) {
-	cfg := map[string]string{
-		"Level":  o.Level.String(),
-		"Logger": string(o.Logger),
-	}
-	if o.Enable != nil {
-		cfg["Enable"] = o.Enable.String()
-	}
-	if o.Debug != nil {
-		cfg["Debug"] = o.Debug.String()
-	}
-
-	return json.Marshal(cfg)
-}
-
-func (o *options) UnmarshalJSON(raw []byte) error {
-	cfg := map[string]string{}
-
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return loggerError("failed to unmarshal logger configuration: %v", err)
-	}
-
-	*o = *defaults
-
-	for key, value := range cfg {
-		switch key {
-		case "Level":
-			if err := o.Level.Set(value); err != nil {
-				return err
-			}
-		case "Logger":
-			o.Logger = backendName(value)
-			activateBackend(value)
-		case "Enable":
-			if err := o.Enable.Set(value); err != nil {
-				return err
-			}
-		case "Debug":
-			if err := o.Debug.Set(value); err != nil {
-				return err
-			}
-		default:
-			return loggerError("unknown configuration entry '%s' (%s)", key, value)
-		}
-	}
-
-	return nil
-}
-
-func (o *options) sourceEnabled(source string) bool {
-	return o.Enable.isEnabled(source)
-}
-
-func (o *options) debugEnabled(source string) bool {
-	return o.Debug.isEnabled(source)
-}
-
-func loggerError(format string, args ...interface{}) error {
-	return fmt.Errorf("log: "+format, args...)
-}
-
-// defaultOptions returns a new options instance initialized to defaults.
 func defaultOptions() interface{} {
 	o := &options{
-		Level:  defaults.Level,
 		Logger: defaults.Logger,
-		Enable: make(stateMap),
-		Debug:  make(stateMap),
+		Level:  defaults.Level,
+		Enable: make(srcmap),
+		Debug:  make(srcmap),
 	}
 	for key, value := range defaults.Enable {
 		o.Enable[key] = value
@@ -319,26 +316,14 @@ func defaultOptions() interface{} {
 	for key, value := range defaults.Debug {
 		o.Debug[key] = value
 	}
+
 	return o
-}
-
-// configNotify updates our runtime configuration.
-func (o *options) configNotify(event config.Event, source config.Source) error {
-	defLogger.Info("logger configuration %v", event)
-
-	opt.updateLoggers()
-
-	defLogger.Info(" * log level: %v", opt.Level)
-	defLogger.Info(" * enabled sources: %v", opt.Enable.String())
-	defLogger.Info(" * enabled debugging: %v", opt.Debug.String())
-
-	return nil
 }
 
 // Register us for command line parsing and configuration handling.
 func init() {
-	cfglog := NewLogger("config")
-	config.SetLogger(config.Logger{
+	cfglog := log.get("config")
+	pkgcfg.SetLogger(pkgcfg.Logger{
 		DebugEnabled: cfglog.DebugEnabled,
 		Debug:        cfglog.Debug,
 		Info:         cfglog.Info,
@@ -348,17 +333,19 @@ func init() {
 		Panic:        cfglog.Panic,
 	})
 
-	flag.Var(&defaults.Level, optionLevel,
-		"least severity of log messages to start passing through.")
-	flag.Var(&defaults.Enable, optionSource,
-		"value is a comma-separated logger source names to enable.\n"+
-			"Specify '*' or all for enabling logging for all sources.")
-	flag.Var(&defaults.Debug, optionDebug,
-		"value is a comma-separated logger source names to enable debug for.\n"+
-			"Specify '*' or all for enabling debugging for all sources.")
-	flag.Var(&defaults.Logger, optionLogger,
-		"select logging backend to use")
+	flag.Var(&defaults.Logger, optLogger,
+		"override logger backend to use.")
+	flag.Var(&defaults.Level, optLevel,
+		"lowest severity level to pass through (info, warning, error)")
+	flag.Var(&defaults.Enable, optEnable,
+		"comma-separated list of source names to enable/disable.\n"+
+			"Specify '*' or 'all' to enable all sources, which is also the default.\n"+
+			"Prefix a source or list with 'off:' to disable.")
+	flag.Var(&defaults.Debug, optDebug,
+		"comma-separated list of source names to enable debug messages for.\n"+
+			"Specify '*' or 'all' to enable all sources.\n"+
+			"Prefix a source or list with 'off:' to disable, which is also the default state.")
 
-	config.Register("logger", configHelp, opt, defaultOptions,
-		config.WithNotify(opt.configNotify))
+	pkgcfg.Register(configModule, configHelp, opt, defaultOptions,
+		pkgcfg.WithNotify(opt.configNotify))
 }

--- a/pkg/log/flags.go
+++ b/pkg/log/flags.go
@@ -346,7 +346,6 @@ func init() {
 		Error:        cfglog.Error,
 		Fatal:        cfglog.Fatal,
 		Panic:        cfglog.Panic,
-		Block:        cfglog.Block,
 	})
 
 	flag.Var(&defaults.Level, optionLevel,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Intel Corporation. All Rights Reserved.
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,394 +16,279 @@ package log
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
+	"sync"
 )
 
-// Level is the log message severity level below which we suppress messages.
-type Level int32
-
-const (
-	// LevelDebug corresponds to debug messages.
-	LevelDebug Level = iota
-	// LevelInfo corresponds to informational messages.
-	LevelInfo
-	// LevelWarn corresponds to warning messages.
-	LevelWarn
-	// LevelError corresponds to error messages.
-	LevelError
-)
-
-// Logger is the interface for configuring and producing log messages.
-type Logger interface {
-	Info(format string, args ...interface{})
-	Warn(format string, args ...interface{})
-	Error(format string, args ...interface{})
-	Fatal(format string, args ...interface{})
-	Panic(format string, args ...interface{})
-
-	EnableDebug(bool) bool
-	DebugEnabled() bool
-	Debug(format string, args ...interface{})
-	Block(fn func(string, ...interface{}), prefix string, format string, args ...interface{})
-	DebugBlock(prefix string, format string, args ...interface{})
-	InfoBlock(prefix string, format string, args ...interface{})
-	WarnBlock(prefix string, format string, args ...interface{})
-	ErrorBlock(prefix string, format string, args ...interface{})
-
-	Stop()
+// logging encapsulates the full runtime state of logging.
+type logging struct {
+	sync.RWMutex
+	loggers map[string]logger    // source to logger mapping
+	sources map[logger]string    // logger to source mapping
+	configs map[logger]config    // logger configuration
+	maxname int                  // longest enabled/debugging source name
+	level   Level                // logging severity level
+	disable srcmap               // logging source configuration
+	debug   srcmap               // debugging source configuration
+	backend map[string]BackendFn // registered backends
+	active  Backend              // logging backend
+	forced  bool                 // whether forced debugging is on
 }
 
-// Backend is an entity that can emit log messages.
-type Backend interface {
-	Name() string
-	PrefixPreference() bool
-	Enabled(Level) bool
-	Info(message string)
-	Warn(message string)
-	Error(message string)
-
-	Debug(message string)
+// our logging runtime state
+var log = &logging{
+	level:   LevelInfo,
+	loggers: make(map[string]logger),
+	sources: make(map[logger]string),
+	configs: make(map[logger]config),
+	disable: make(srcmap),
+	debug:   make(srcmap),
+	backend: make(map[string]BackendFn),
+	active:  createFmtBackend(),
 }
 
-// Our logger instance.
-type logger struct {
-	source  string // logger source/module name
-	enabled bool   // logger source module
-	level   Level  // first non-suppressed severity level
-	debug   bool   // debugging for this instance
-	prefix  string // message prefix
+// Flush flushes any initial message buffer and turns buffering on.
+func Flush() {
+	log.RLock()
+	defer log.RUnlock()
+	log.active.Flush()
 }
 
-// log is our runtime state.
-type log struct {
-	level    Level              // lowest unsuppressed severity
-	active   Backend            // active backend
-	loggers  map[string]*logger // running loggers (log sources)
-	backends map[string]Backend // registered backends (real loggers)
-	srcalign int                // longest name of active source seen
+// Sync waits for all current messages to get processed.
+func Sync() {
+	log.RLock()
+	defer log.RUnlock()
+	log.active.Sync()
 }
 
-var logging = &log{
-	active: &fmtBackend{},
-}
-
-// Get an existing logger or create a new one.
+// Get returns the Logger for source, creating one if necessary.
 func Get(source string) Logger {
-	l, ok := logging.loggers[source]
-	if !ok {
-		return newLogger(source)
-	}
-	return l
+	return log.get(source)
 }
 
-// NewLogger creates a new logger, getting the existing one if possible.
+// NewLogger is an alias for Get().
 func NewLogger(source string) Logger {
-	return Get(source)
+	return log.get(source)
 }
 
-// newLogger creates a new logger instance.
-func newLogger(source string) Logger {
-	source = strings.Trim(source, "[] ")
+// EnableLogging enables non-debug logging for the source.
+func EnableLogging(source string) bool {
+	log.Lock()
+	defer log.Unlock()
 
-	if logging.loggers == nil {
-		logging.loggers = make(map[string]*logger)
+	return log.setLogging(source, true)
+}
+
+// DisableLogging disables non-debug logging for the given source.
+func DisableLogging(source string) bool {
+	log.Lock()
+	defer log.Unlock()
+
+	return log.setLogging(source, false)
+}
+
+// LoggingEnabled checks if non-debug logging is enabled for the source.
+func LoggingEnabled(source string) bool {
+	log.RLock()
+	defer log.RUnlock()
+
+	return log.isLogging(source)
+}
+
+// EnableDebug enables debug logging for the source.
+func EnableDebug(source string) bool {
+	log.Lock()
+	defer log.Unlock()
+
+	return log.setDebugging(source, true)
+}
+
+// DisableDebug disables debug logging for the given source.
+func DisableDebug(source string) bool {
+	log.Lock()
+	defer log.Unlock()
+
+	return log.setDebugging(source, false)
+}
+
+// DebugEnabled checks if debug logging is enabled for the source.
+func DebugEnabled(source string) bool {
+	log.RLock()
+	defer log.RUnlock()
+
+	return log.isDebugging(source)
+}
+
+// SetLevel sets the logging severity level.
+func SetLevel(level Level) {
+	log.setLevel(level)
+}
+
+// SetBackend activates the named Backend for logging.
+func SetBackend(name string) error {
+	log.Lock()
+	defer log.Unlock()
+
+	return log.setBackend(name)
+}
+
+// setLevel sets the logging severity level.
+func (log *logging) setLevel(level Level) {
+	log.level = level
+}
+
+// setBackend activates the named Backend for logging.
+func (log *logging) setBackend(name string) error {
+	createFn, ok := log.backend[name]
+	if !ok {
+		return loggerError("can't activate unknown backend '%s'", name)
 	}
 
-	if l := logging.loggers[source]; l != nil {
-		return l
+	log.active.Stop()
+	log.active = createFn()
+
+	return nil
+}
+
+// forceDebug enables/disables forced full debugging.
+func (log *logging) forceDebug(state bool) bool {
+	log.Lock()
+	defer log.Unlock()
+
+	old := log.forced
+	log.forced = state
+	log.update(nil, nil)
+
+	return old
+}
+
+// debugForced checks if full debugging is forced.
+func (log *logging) debugForced() bool {
+	return log.forced
+}
+
+// get returns the logger for source, creating one if necessary (write-locks log).
+func (log *logging) get(source string) Logger {
+	log.Lock()
+	defer log.Unlock()
+
+	if id, ok := log.loggers[source]; ok {
+		return id
 	}
 
-	l := &logger{
-		source:  source,
-		enabled: opt.sourceEnabled(source),
-		debug:   opt.debugEnabled(source),
-		level:   opt.Level,
-	}
-	logging.loggers[source] = l
-
-	return l
+	return log.create(source)
 }
 
-// Optional call to stop a logger once it is not needed any more.
-func (l *logger) Stop() {
-	l.enabled = false
-	delete(logging.loggers, l.source)
-}
-
-func (l *logger) shouldPrefix() bool {
-	return logging.active.PrefixPreference()
-}
-
-func (l *logger) passthrough(level Level) bool {
-	return (l.enabled && l.level <= level) || (level == LevelDebug && l.debug)
-}
-
-func (l *logger) formatMessage(format string, args ...interface{}) string {
-	if len(l.source) > logging.srcalign {
-		logging.srcalign = len(l.source)
-		l.prefix = ""
-		for _, l := range logging.loggers {
-			l.prefix = ""
-		}
-
-	}
-	if l.prefix == "" {
-		suf := (logging.srcalign - len(l.source)) / 2
-		pre := logging.srcalign - (len(l.source) + suf)
-		l.prefix = "[" + fmt.Sprintf("%-*s", pre, "") + l.source + fmt.Sprintf("%*s", suf, "") + "] "
+// create creates a new logger for a source (should be called with log write-locked).
+func (log *logging) create(source string) Logger {
+	id := logger(len(log.loggers))
+	if uint64(id) >= maxLoggers {
+		panic(fmt.Sprintf("max. number of loggers (%d) exhausted", maxLoggers))
 	}
 
-	prefix := ""
-	if l.shouldPrefix() {
-		prefix = l.prefix
+	cfg := mkConfig(id, log.isLogging(source), log.isDebugging(source))
+	log.loggers[source] = id
+	log.sources[id] = source
+	log.configs[id] = cfg
+
+	if (cfg.isEnabled() || log.forced) && len(source) > log.maxname {
+		log.realign(len(source))
 	}
 
-	return prefix + fmt.Sprintf(format, args...)
+	return id
 }
 
-// Emit an info message (lowest priority).
-func (l *logger) Info(format string, args ...interface{}) {
-	if !l.passthrough(LevelInfo) {
-		return
+// setLogging sets the logging state of the source (should be called with log write-locked).
+func (log *logging) setLogging(source string, state bool) bool {
+	// logging is opt-out (enabled by default) and administered by negated state
+	old := log.isLogging(source)
+	log.disable[source] = !state
+
+	return old
+}
+
+// isLogging gets the logging state of the source (should be called with log read-locked).
+func (log *logging) isLogging(source string) bool {
+	if state, ok := log.disable[source]; ok {
+		return !state
 	}
-	logging.active.Info(l.formatMessage(format, args...))
-}
-
-// Emit a warning message.
-func (l *logger) Warn(format string, args ...interface{}) {
-	if !l.passthrough(LevelWarn) {
-		return
-	}
-	logging.active.Warn(l.formatMessage(format, args...))
-}
-
-// Emit an error message.
-func (l *logger) Error(format string, args ...interface{}) {
-	if !l.passthrough(LevelError) {
-		return
-	}
-	logging.active.Error(l.formatMessage(format, args...))
-}
-
-// Emit a fatal error message and exit.
-func (l *logger) Fatal(format string, args ...interface{}) {
-	logging.active.Error(l.formatMessage(format, args...))
-	os.Exit(1)
-}
-
-// Emit a fatal error message and panic.
-func (l *logger) Panic(format string, args ...interface{}) {
-	message := l.formatMessage(format, args...)
-	logging.active.Error(message)
-	panic(message)
-}
-
-// Default logger/source.
-var defLogger = NewLogger("default")
-
-// Default gets the default logger.
-func Default() Logger {
-	return defLogger
-}
-
-// Info emit an info message with the default soruce.
-func Info(format string, args ...interface{}) {
-	defLogger.Info(format, args...)
-}
-
-// Warn emit a warning message with the default source.
-func Warn(format string, args ...interface{}) {
-	defLogger.Warn(format, args...)
-}
-
-// Error emit an error message with the default source.
-func Error(format string, args ...interface{}) {
-	defLogger.Error(format, args...)
-}
-
-// Fatal emit a fatal error message with the default source.
-func Fatal(format string, args ...interface{}) {
-	defLogger.Fatal(format, args...)
-}
-
-// Panic emit a fatal error message with the default source and panic.
-func Panic(format string, args ...interface{}) {
-	defLogger.Panic(format, args...)
-}
-
-// Debug emit a debug message with the default source.
-func Debug(format string, args ...interface{}) {
-	defLogger.Debug(format, args...)
-}
-
-// EnableDebug controls debugging for the default source.
-func EnableDebug(enable bool) bool {
-	return defLogger.EnableDebug(enable)
-}
-
-// DebugEnabled returns the debugging state of the default source.
-func DebugEnabled() bool {
-	return defLogger.DebugEnabled()
-}
-
-// Block emits a block of messages with the given emitting/printing function.
-func Block(fn func(string, ...interface{}), prefix string, format string, args ...interface{}) {
-	defLogger.Block(fn, prefix, format, args...)
-}
-
-// DebugBlock emits a block of debug messages with the default source.
-func DebugBlock(prefix string, format string, args ...interface{}) {
-	defLogger.DebugBlock(prefix, format, args...)
-}
-
-// InfoBlock emits a block of info messages with the default source.
-func InfoBlock(prefix string, format string, args ...interface{}) {
-	defLogger.InfoBlock(prefix, format, args...)
-}
-
-// WarnBlock emits a block of warning messages with the default source.
-func WarnBlock(prefix string, format string, args ...interface{}) {
-	defLogger.WarnBlock(prefix, format, args...)
-}
-
-// ErrorBlock emits a block of error messages with the default source.
-func ErrorBlock(prefix string, format string, args ...interface{}) {
-	defLogger.ErrorBlock(prefix, format, args...)
-}
-
-// EnableDebug controls debugging for the logger and returns the its previous debugging state.
-func (l *logger) EnableDebug(enable bool) bool {
-	previous := l.debug
-	l.debug = enable
-	opt.Debug.Set(l.source + ":" + map[bool]string{false: "false", true: "true"}[enable])
-	return previous
-}
-
-// Check if debugging is enabled.
-func (l *logger) DebugEnabled() bool {
-	return l.debug
-}
-
-// Emit a debug message.
-func (l *logger) Debug(format string, args ...interface{}) {
-	if !l.debug {
-		return
-	}
-	logging.active.Debug(l.formatMessage(format, args...))
-}
-
-// Block emits a block of messages with using the given emitting function.
-func (l *logger) Block(fn func(string, ...interface{}), prefix string, format string, args ...interface{}) {
-	for _, line := range strings.Split(fmt.Sprintf(format, args...), "\n") {
-		fn("%s%s", prefix, line)
-	}
-}
-
-// Emit a block of debug messages.
-func (l *logger) DebugBlock(prefix string, format string, args ...interface{}) {
-	if !l.debug {
-		return
+	if state, ok := log.disable["*"]; ok {
+		return !state
 	}
 
-	l.Block(l.Debug, prefix, format, args...)
-}
-
-// Emit a block of info messages.
-func (l *logger) InfoBlock(prefix string, format string, args ...interface{}) {
-	l.Block(l.Info, prefix, format, args...)
-}
-
-// Emit a block of warning messages.
-func (l *logger) WarnBlock(prefix string, format string, args ...interface{}) {
-	l.Block(l.Warn, prefix, format, args...)
-}
-
-// Emit a block of error messages.
-func (l *logger) ErrorBlock(prefix string, format string, args ...interface{}) {
-	l.Block(l.Error, prefix, format, args...)
-}
-
-// RegisterBackend registers a logger backend.
-func RegisterBackend(b Backend) {
-	name := b.Name()
-
-	if logging.backends == nil {
-		logging.backends = make(map[string]Backend)
-	}
-
-	logging.backends[name] = b
-
-	if string(opt.Logger) == name {
-		logging.active = b
-	}
-}
-
-// activateBackend selects the logger backend to activate.
-func activateBackend(name string) {
-	if b, ok := logging.backends[string(opt.Logger)]; ok {
-		logging.active = b
-	} else {
-		logging.active = &fmtBackend{}
-	}
-
-	logging.active.Info(fmt.Sprintf("activated logger backend '%s'", logging.active.Name()))
-}
-
-// Update loggers when debug flags or sources change.
-func (o *options) updateLoggers() {
-	for s, l := range logging.loggers {
-		l.enabled = opt.sourceEnabled(s)
-		l.debug = opt.debugEnabled(s)
-		l.level = opt.Level
-	}
-}
-
-//
-// fallback fmt backend, using fmt.*Printf
-//
-
-const (
-	fmtBackendName = "fmt"
-)
-
-type fmtBackend struct{}
-
-var _ Backend = &fmtBackend{}
-
-func (f *fmtBackend) Name() string {
-	return "fmt"
-}
-
-func (f *fmtBackend) PrefixPreference() bool {
 	return true
 }
 
-func (f *fmtBackend) Info(message string) {
-	fmt.Println("I: " + message)
+// setDebugging sets the debugging state of the source (should be called with log write-locked).
+func (log *logging) setDebugging(source string, state bool) bool {
+	// debugging is opt-in (disabled by default)
+	old := log.isDebugging(source)
+	log.debug[source] = state
+
+	return old
 }
 
-func (f *fmtBackend) Warn(message string) {
-	fmt.Println("W: " + message)
+// isDebugging gets the debugging state of the source (should be called with log read-locked).
+func (log *logging) isDebugging(source string) bool {
+	if state, ok := log.debug[source]; ok {
+		return state
+	}
+	if state, ok := log.debug["*"]; ok {
+		return state
+	}
+
+	return false
 }
 
-func (f *fmtBackend) Error(message string) {
-	fmt.Println("E: " + message)
+// realign updates prefix alignment.
+func (log *logging) realign(maxname int) {
+	if log.maxname != 0 && log.maxname == maxname {
+		return
+	}
+	if maxname == 0 {
+		for id, cfg := range log.configs {
+			if !cfg.isEnabled() {
+				continue
+			}
+			if length := len(log.sources[id]); length > maxname {
+				maxname = length
+			}
+		}
+	}
+	log.maxname = maxname
+	log.active.SetSourceAlignment(maxname)
 }
 
-func (f *fmtBackend) Debug(message string) {
-	fmt.Println("D: " + message)
+// update updates the state of all loggers.
+func (log *logging) update(enabled srcmap, debug srcmap) {
+	if enabled != nil {
+		log.disable = make(srcmap)
+		for src, state := range enabled {
+			log.disable[src] = !state
+		}
+	}
+	if debug != nil {
+		log.debug = make(srcmap)
+		for src, state := range debug {
+			log.debug[src] = state
+		}
+	}
+	maxname := 0
+	for id, cfg := range log.configs {
+		source := log.sources[id]
+		logging := log.isLogging(source)
+		debugging := log.isDebugging(source)
+		cfg.setEnabled(log.isLogging(source), log.isDebugging(source))
+		log.configs[id] = cfg
+		if logging || debugging || log.forced {
+			if length := len(source); length > maxname {
+				maxname = length
+			}
+		}
+	}
+	log.realign(maxname)
 }
 
-func (f *fmtBackend) Enabled(l Level) bool {
-	return l >= opt.Level
-}
-
-func init() {
-	RegisterBackend(&fmtBackend{})
-
-	binary := filepath.Clean(os.Args[0])
-	source := filepath.Base(binary)
-	defLogger = newLogger(source)
+// loggerError produces a formatted logger-specific error.
+func loggerError(format string, args ...interface{}) error {
+	return fmt.Errorf("logger: "+format, args...)
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,530 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// a test Backend that can log and optionally record messages for verification
+type testlogger struct {
+	sync.RWMutex                     // debug by signal testcase needs locking
+	protect      bool                // true if we should lock during Log()/check()
+	recorded     []string            // messages record()ed by Log() for check()
+	logfn        func(Level, string) // logger function (log(), save(), or log()+save())
+	test         *testing.T          // runtime test case/state
+}
+
+var testlog *testlogger
+
+func createTestLogger() Backend {
+	tl := &testlogger{}
+	tl.logfn = tl.log
+	testlog = tl
+	return testlog
+}
+
+const testLoggerName = "testlogger"
+
+func (l *testlogger) Name() string {
+	return testLoggerName
+}
+
+func (l *testlogger) Log(level Level, source, format string, args ...interface{}) {
+	l.logfn(level, fmt.Sprintf("["+source+"] "+format, args...))
+}
+
+func (l *testlogger) Block(level Level, source, prefix, format string, args ...interface{}) {
+	l.logfn(level, fmt.Sprintf("["+source+"] "+format, args...))
+}
+
+func (l *testlogger) Flush()                 {}
+func (l *testlogger) Sync()                  {}
+func (l *testlogger) Stop()                  {}
+func (l *testlogger) SetSourceAlignment(int) {}
+
+func setup(test *testing.T, quiet bool, record int, parallel bool) *testlogger {
+	if err := SetBackend(testLoggerName); err != nil {
+		test.Errorf("failed to activate test backend '%s': %v", testLoggerName, err)
+		return nil
+	}
+	l := testlog
+
+	l.test = test
+	if record > 0 {
+		l.recorded = make([]string, 0, record)
+	} else {
+		l.recorded = nil
+	}
+	switch {
+	case quiet && record == 0:
+		l.logfn = func(Level, string) {}
+	case !quiet && record > 0:
+		l.logfn = func(level Level, msg string) { l.log(level, msg); l.record(level, msg) }
+		l.protect = parallel
+	case !quiet:
+		l.logfn = l.log
+	default:
+		l.logfn = l.record
+		l.protect = parallel
+	}
+
+	return l
+}
+
+func (l *testlogger) lock() {
+	if l.protect {
+		l.RWMutex.Lock()
+	}
+}
+func (l *testlogger) unlock() {
+	if l.protect {
+		l.RWMutex.Unlock()
+	}
+}
+func (l *testlogger) rlock() {
+	if l.protect {
+		l.RWMutex.RLock()
+	}
+}
+func (l *testlogger) runlock() {
+	if l.protect {
+		l.RWMutex.RUnlock()
+	}
+}
+
+func (l *testlogger) log(level Level, msg string) {
+	fmt.Println("<log-test>", fmtTags[level], msg)
+}
+
+func (l *testlogger) record(level Level, msg string) {
+	l.lock()
+	defer l.unlock()
+	l.recorded = append(l.recorded, msg)
+}
+
+func (l *testlogger) check(expected []string, ordered bool, checkSources map[string]struct{}) {
+	var recorded []string
+
+	l.rlock()
+	defer l.runlock()
+
+	if !ordered {
+		recorded = make([]string, 0, len(l.recorded))
+		copy(recorded, l.recorded)
+		sort.Strings(recorded)
+		sort.Strings(expected)
+	} else {
+		recorded = l.recorded
+	}
+
+	for i, j := 0, 0; i < len(recorded) && j < len(expected); {
+		split := strings.SplitN(recorded[i], "] ", 2)
+		i++
+
+		source, message := strings.Trim(split[0], "[] "), split[1]
+		if _, check := checkSources[source]; checkSources != nil && !check {
+			continue
+		}
+
+		if message != expected[j] {
+			l.test.Errorf("%s failed, #%d message is '%s', expected '%s'",
+				l.test.Name(), j, message, expected[j])
+			return
+		}
+		j++
+	}
+}
+
+// TestBackendOverride tests the effect of overriding the active log backend.
+func TestBackendOverride(t *testing.T) {
+	tl := setup(t, false, 1024, false)
+
+	SetLevel(LevelInfo)
+	test := NewLogger("test")
+	messages := []string{
+		"this is a test info message",
+		"this is a test warning message",
+		"this is a test error message",
+	}
+	test.Info(messages[0])
+	test.Warn(messages[1])
+	test.Error(messages[2])
+
+	tl.check(messages, true, nil)
+}
+
+// TestSeverityFiltering tests the severity-level based filtering.
+func TestSeverityFiltering(t *testing.T) {
+	tl := setup(t, false, 1024, false)
+
+	test := NewLogger("test")
+	// level to logger function mapping
+	logfns := map[Level]func(string){
+		LevelDebug: func(s string) { test.Debug(s) },
+		LevelInfo:  func(s string) { test.Info(s) },
+		LevelWarn:  func(s string) { test.Warn(s) },
+		LevelError: func(s string) { test.Error(s) },
+	}
+	// a bunch of debug-toggling functions to loop through
+	setDebugFns := []func() bool{
+		func() bool { test.EnableDebug(false); return false },
+		func() bool { test.EnableDebug(true); return true },
+		func() bool { flag.Set(optDebug, "off:*"); return false },
+		func() bool { flag.Set(optDebug, "on:*"); return true },
+		func() bool { flag.Set(optDebug, "on:*"); test.EnableDebug(false); return false },
+		func() bool { flag.Set(optDebug, "off:*"); test.EnableDebug(true); return true },
+	}
+	// a bunch of logging level settings to loop through
+	loggingLevels := []Level{
+		LevelDebug, LevelInfo, LevelWarn, LevelError,
+		LevelError, LevelWarn, LevelInfo, LevelDebug,
+	}
+	// function to generate a single message
+	mkmsg := func(threshold, level Level, msg string, count int) string {
+		return fmt.Sprintf("filtering: %s, message: %s -> "+msg+" #%d", threshold, level, count)
+	}
+
+	cnt := 0
+	expected := []string{}
+	for _, setDebugFn := range setDebugFns {
+		debugging := setDebugFn()
+		for _, threshold := range loggingLevels {
+			SetLevel(threshold)
+			for _, msg := range []string{
+				"test",
+				"message",
+				"test message",
+				"test message once more",
+				"test message a final time",
+			} {
+				for _, msgLevel := range []Level{LevelDebug, LevelInfo, LevelWarn, LevelError} {
+					msg := mkmsg(threshold, msgLevel, msg, cnt)
+					logfns[msgLevel](msg)
+					cnt++
+					switch {
+					case msgLevel == LevelDebug && debugging:
+						expected = append(expected, msg)
+					case msgLevel != LevelDebug && msgLevel >= threshold:
+						expected = append(expected, msg)
+					}
+				}
+			}
+		}
+	}
+
+	tl.check(expected, true, nil)
+}
+
+// TestForcedDebugToggling tests toggling debug on/off by a signal.
+func TestForcedDebugToggling(t *testing.T) {
+	tl := setup(t, false, 1024, true)
+
+	SetLevel(LevelInfo)
+	test := NewLogger("test")
+
+	debugSignal := syscall.SIGUSR1
+	SetupDebugToggleSignal(debugSignal)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, debugSignal)
+	flag.Set(optDebug, "off:*")
+	debugging := false
+
+	expected := []string{}
+	messages := []string{"debug", "info", "warning", "error"}
+	for i := 0; i < 2; i++ {
+		for _, msg := range messages {
+			var logfn func(string, ...interface{})
+
+			filtered := false
+			switch msg {
+			case "debug":
+				logfn = test.Debug
+				filtered = !debugging
+			case "info":
+				logfn = test.Info
+			case "warning":
+				logfn = test.Warn
+			case "error":
+				logfn = test.Error
+			default:
+				continue
+			}
+			logfn("%s", msg)
+			if !filtered {
+				expected = append(expected, msg)
+			}
+		}
+		log.forceDebug(!log.debugForced())
+		debugging = !debugging
+	}
+
+	sources := map[string]struct{}{
+		"test": {},
+	}
+
+	tl.check(expected, true, sources)
+}
+
+func getenv(key string, fallback interface{}) interface{} {
+	strval := os.Getenv(key)
+	if strval == "" {
+		return fallback
+	}
+	switch defv := fallback.(type) {
+	case int:
+		v, err := strconv.ParseInt(strval, 10, 0)
+		if err != nil {
+			fmt.Printf("error: invalid environment variable %s = %s: %v\n", key, strval, err)
+			return defv
+		}
+		return int(v)
+	case time.Duration:
+		v, err := time.ParseDuration(strval)
+		if err != nil {
+			fmt.Printf("error: invalid enviroment variable %s = %s: %v\n", key, strval, err)
+			return defv
+		}
+		return v
+	case []bool:
+		v := []bool{}
+		for _, strb := range strings.Split(strval, ",") {
+			b, err := strconv.ParseBool(strb)
+			if err != nil {
+				fmt.Printf("error: invalid environment variable %s = %s: %v\n", key, strval, err)
+				return defv
+			}
+			v = append(v, b)
+		}
+		return v
+
+	default:
+		panic(fmt.Sprintf("enviroment variable %s=%s with unhandled type %T",
+			key, strval, fallback))
+	}
+}
+
+var (
+	// number of concurrent loggers, togglers, test duration, test verbosity
+	numLoggers    = getenv("LOGTEST_LOGGERS", 32).(int)
+	numTogglers   = getenv("LOGTEST_TOGGLERS", 4).(int)
+	testDuration  = getenv("LOGTEST_DURATION", 10*time.Second).(time.Duration)
+	testVerbosity = getenv("LOGTEST_VERBOSITY", []bool{true, false}).([]bool)
+)
+
+// createLoggers creates a bunch of loggers.
+func createLoggers(cnt int) []Logger {
+	loggers := make([]Logger, cnt, cnt)
+	for idx := range loggers {
+		switch idx % 7 {
+		case 0:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<0>-test", idx))
+		case 1:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<1>-logger", idx))
+		case 2:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<2>-logging", idx))
+		case 3:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<3>-log", idx))
+		case 4:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<4>-logger", idx))
+		case 5:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<5>-tester", idx))
+		default:
+			loggers[idx] = NewLogger(fmt.Sprintf("%d-<->-logger-tester", idx))
+		}
+
+		// fuzz a but more by enabling debugging only for a quasi-random subset of loggers
+		if (idx % 11) == 0 {
+			loggers[idx].EnableDebug(true)
+		}
+
+	}
+	return loggers
+}
+
+// exercise exercises a set of loggers in pseudo-random order.
+func exercise(loggers []Logger, levels []Level, start, stop chan struct{}, wg *sync.WaitGroup) {
+	rnd := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+	idx := rnd.Perm(len(loggers))
+
+	for _, i := range idx {
+		loggers[i].Info("logger <%s> waiting for start...", loggers[i].Source())
+	}
+	_ = <-start
+
+	done := false
+	cnt := 0
+	for !done {
+		for _, i := range idx {
+			log := loggers[idx[i]]
+			for _, level := range levels {
+				switch level {
+				case LevelDebug:
+					log.Debug("logged debug message #%d", cnt)
+				case LevelInfo:
+					log.Info("logged info message #%d", cnt)
+				case LevelWarn:
+					log.Warn("logged warning message #%d", cnt)
+				case LevelError:
+					log.Error("logged error message #%d", cnt)
+				}
+			}
+		}
+		cnt++
+
+		select {
+		case _ = <-stop:
+			done = true
+		default:
+		}
+	}
+
+	for _, i := range idx {
+		loggers[i].Info("logger <%s> stopped...", loggers[i].Source())
+	}
+
+	if wg != nil {
+		wg.Done()
+	}
+}
+
+// toggle toggles debug-logging on/off for a set of loggers in pseudo-random order.
+func toggle(loggers []Logger, start, stop chan struct{}, m *sync.Mutex, wg *sync.WaitGroup) {
+	rnd := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+	idx := rnd.Perm(len(loggers))
+
+	for _, i := range idx {
+		loggers[i].Info("toggler <%s> waiting for start...", loggers[i].Source())
+	}
+	_ = <-start
+
+	done := false
+	cnt := 0
+	for !done {
+		nth := 3 + cnt%7
+		cfg := "on:*,"
+		sep := "off:"
+		for i := 0; i < len(idx)/4; i++ {
+			log := loggers[idx[i]]
+			if i != 0 && i%nth == 0 {
+				cfg += sep + log.Source()
+				sep = ","
+			}
+		}
+		Info("toggling %s...", cfg)
+		m.Lock()
+		flag.Set("logging-debug", cfg)
+		m.Unlock()
+		cnt++
+
+		select {
+		case _ = <-stop:
+			done = true
+		default:
+		}
+	}
+
+	for _, i := range idx {
+		loggers[i].Info("toggler <%s> stopped...", loggers[i].Source())
+	}
+
+	if wg != nil {
+		wg.Done()
+	}
+}
+
+// prepareLoggerGoroutines prepares a bunch of goroutines for logging.
+func prepareLoggerGoroutines(loggers []Logger, start, stop chan struct{}, wg *sync.WaitGroup) {
+	levelCombos := [][]Level{
+		{LevelDebug},
+		{LevelInfo},
+		{LevelWarn},
+		{LevelError},
+		{LevelDebug, LevelInfo},
+		{LevelDebug, LevelInfo, LevelWarn, LevelError},
+		{LevelDebug, LevelInfo, LevelDebug, LevelWarn, LevelDebug, LevelError},
+	}
+
+	min, max := 0, 0
+	for i := 0; i < len(loggers); i += 5 {
+		if min = i - 5; min < 0 {
+			min = 0
+		}
+		if max = i + 5; max > len(loggers) {
+			max = len(loggers)
+		}
+		subset := loggers[min:max]
+		levels := levelCombos[i%len(levelCombos)]
+
+		wg.Add(1)
+		go func(loggers []Logger, levels []Level) {
+			exercise(loggers, levels, start, stop, wg)
+		}(subset, levels)
+	}
+}
+
+// prepareTogglerGoroutines prepares a bunch of goroutines for toggling.
+func prepareTogglerGoroutines(loggers []Logger, start, stop chan struct{}, wg *sync.WaitGroup) {
+	var flagMutex sync.Mutex
+	for i := 0; i < numTogglers; i++ {
+		go func() {
+			toggle(loggers, start, stop, &flagMutex, wg)
+		}()
+		wg.Add(1)
+	}
+}
+
+// TestConcurrentLogging tests logging from multiple goroutines.
+func TestConcurrentLogging(t *testing.T) {
+	var wg sync.WaitGroup
+
+	loggers := createLoggers(numLoggers)
+
+	numCPUs := runtime.NumCPU()
+	for _, verbose := range testVerbosity {
+		runtime.GOMAXPROCS(numCPUs)
+		setup(t, !verbose, 0, false)
+		start := make(chan struct{})
+		stop := make(chan struct{})
+
+		prepareLoggerGoroutines(loggers, start, stop, &wg)
+		prepareTogglerGoroutines(loggers, start, stop, &wg)
+
+		Info("starting %d loggers with %d togglers, %v duration...",
+			numLoggers, numTogglers, testDuration)
+		close(start)
+		time.Sleep(testDuration)
+		close(stop)
+		wg.Wait()
+
+		numCPUs++
+	}
+}
+
+func init() {
+	RegisterBackend(testLoggerName, createTestLogger)
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,295 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"math"
+	"os"
+)
+
+// Level describes the severity of log messages.
+type Level int
+
+const (
+	// LevelDebug is the severity for debug messages.
+	LevelDebug Level = iota
+	// LevelInfo is the severity for informational messages.
+	LevelInfo
+	// LevelWarn is the severity for warnings.
+	LevelWarn
+	// LevelError is the severity for errors.
+	LevelError
+	// LevelPanic is the severity for panic messages.
+	LevelPanic
+	// LevelFatal is the severity for fatal errors.
+	LevelFatal
+	// levelHighest is the highest externally visible level
+	levelHighest
+)
+
+// Logger is the interface for producing log messages for/from a particular source.
+type Logger interface {
+	// Debug formats and emits a debug message.
+	Debug(format string, args ...interface{})
+	// Info formats and emits an informational message.
+	Info(format string, args ...interface{})
+	// Warn formats and emits a warning message.
+	Warn(format string, args ...interface{})
+	// Error formats and emits an error message.
+	Error(format string, args ...interface{})
+	// Panic formats and emits an error message then panics with the same.
+	Panic(format string, args ...interface{})
+	// Fatal formats and emits an error message and os.Exit()'s with status 1.
+	Fatal(format string, args ...interface{})
+
+	// DebugBlock formats and emits a multiline debug message.
+	DebugBlock(prefix string, format string, args ...interface{})
+	// InfoBlock formats and emits a multiline information message.
+	InfoBlock(prefix string, format string, args ...interface{})
+	// WarnBlock formats and emits a multiline warning message.
+	WarnBlock(prefix string, format string, args ...interface{})
+	// ErrorBlock formats and emits a multiline error message.
+	ErrorBlock(prefix string, format string, args ...interface{})
+
+	// EnableDebug enables debug messages for this Logger.
+	EnableDebug(bool) bool
+	// DebugEnabled checks if debug messages are enabled for this Logger.
+	DebugEnabled() bool
+
+	// Source returns the source name of this Logger.
+	Source() string
+}
+
+// logger implements our Logger.
+type logger uint
+
+// EnableDebug enables/disables debug logging for this logger.
+func (l logger) EnableDebug(state bool) bool {
+	log.Lock()
+	defer log.Unlock()
+
+	cfg, _ := log.configs[l]
+	old := cfg.setDebugging(state)
+	log.configs[l] = cfg
+
+	return old
+}
+
+// DebugEnabled checks debug logging is enabled for this logger.
+func (l logger) DebugEnabled() bool {
+	log.RLock()
+	defer log.RUnlock()
+
+	cfg, _ := log.configs[l]
+
+	return cfg.isDebugging()
+}
+
+// Source returns the source for the given logger.
+func (l logger) Source() string {
+	log.RLock()
+	defer log.RUnlock()
+
+	source, _ := log.sources[l]
+
+	return source
+}
+
+// Debug logs a debug message.
+func (l logger) Debug(format string, args ...interface{}) {
+	level := LevelDebug
+	if cfg, active, emit := l.config(level); emit {
+		active.Log(level, cfg.source(), format, args...)
+	}
+}
+
+// Info logs a informational message.
+func (l logger) Info(format string, args ...interface{}) {
+	level := LevelInfo
+	if cfg, active, emit := l.config(level); emit {
+		active.Log(LevelInfo, cfg.source(), format, args...)
+	}
+}
+
+// Warn logs a warning message.
+func (l logger) Warn(format string, args ...interface{}) {
+	level := LevelWarn
+	if cfg, active, emit := l.config(level); emit {
+		active.Log(level, cfg.source(), format, args...)
+	}
+}
+
+// Error logs an error message.
+func (l logger) Error(format string, args ...interface{}) {
+	level := LevelError
+	if cfg, active, emit := l.config(level); emit {
+		active.Log(level, cfg.source(), format, args...)
+	}
+}
+
+// Fatal logs a fatal error message and os.Exit(1)'s.
+func (l logger) Fatal(format string, args ...interface{}) {
+	level := LevelFatal
+	cfg, active, _ := l.config(level)
+	active.Log(level, cfg.source(), format, args...)
+
+	os.Exit(1)
+}
+
+// Panic logs a panic message and panic()'s.
+func (l logger) Panic(format string, args ...interface{}) {
+	level := LevelPanic
+	cfg, active, _ := l.config(level)
+	active.Log(level, cfg.source(), format, args...)
+
+	panic(fmt.Sprintf(cfg.source()+" "+format, args...))
+}
+
+// DebugBlock logs a multi-line debug message.
+func (l logger) DebugBlock(prefix string, format string, args ...interface{}) {
+	level := LevelDebug
+	if cfg, active, emit := l.config(level); emit {
+		active.Block(level, cfg.source(), prefix, format, args...)
+	}
+}
+
+// InfoBlock logs a multi-line informational message.
+func (l logger) InfoBlock(prefix string, format string, args ...interface{}) {
+	level := LevelInfo
+	if cfg, active, emit := l.config(level); emit {
+		active.Block(level, cfg.source(), prefix, format, args...)
+	}
+}
+
+// WarnBlock logs a multi-line warning message.
+func (l logger) WarnBlock(prefix string, format string, args ...interface{}) {
+	level := LevelWarn
+	if cfg, active, emit := l.config(level); emit {
+		active.Block(level, cfg.source(), prefix, format, args...)
+	}
+}
+
+// ErrorBlock logs a multi-line error message.
+func (l logger) ErrorBlock(prefix string, format string, args ...interface{}) {
+	level := LevelError
+	if cfg, active, emit := l.config(level); emit {
+		active.Block(level, cfg.source(), prefix, format, args...)
+	}
+}
+
+// config returns the logger's configuration and if the level is logged.
+func (l logger) config(level Level) (config, Backend, bool) {
+	if level != LevelDebug && level < log.level {
+		return config{}, nil, false
+	}
+
+	log.RLock()
+	cfg, _ := log.configs[l]
+	active := log.active
+	forced := log.forced
+	log.RUnlock()
+
+	switch level {
+	case LevelInfo:
+		return cfg, active, cfg.isLogging()
+	case LevelDebug:
+		return cfg, active, cfg.isDebugging() || forced
+	default:
+		return cfg, active, true
+	}
+}
+
+//
+// Runtime configuration of a single logger instance.
+//
+
+const (
+	maxLoggers = math.MaxUint16
+	loggingBit = (1 << iota)
+	debuggingBit
+)
+
+// config is the configuration parameters for a single logger stuffed into a single uint64
+type config struct {
+	id     uint16
+	enable uint16
+}
+
+// mkConfig creates a configuration with the given parameters.
+func mkConfig(logger logger, logging, debugging bool) config {
+	cfg := config{id: uint16(logger)}
+	cfg.setEnabled(logging, debugging)
+	return cfg
+}
+
+// logger extracts the logger id from this config.
+func (cfg *config) logger() logger {
+	return logger(cfg.id)
+}
+
+// setEnabled sets the logging and debugging bits for this config.
+func (cfg *config) setEnabled(logging, debugging bool) {
+	if logging {
+		cfg.enable = loggingBit
+	} else {
+		cfg.enable = 0
+	}
+	if debugging {
+		cfg.enable |= debuggingBit
+	}
+}
+
+// isEnabled check if this config has the logging or debugging bit set.
+func (cfg *config) isEnabled() bool {
+	return cfg.enable != 0
+}
+
+// setLogging sets/clears the logging bit in this config.
+func (cfg *config) setLogging(enable bool) bool {
+	old := (cfg.enable & loggingBit) != 0
+	if enable {
+		cfg.enable |= loggingBit
+	} else {
+		cfg.enable &^= loggingBit
+	}
+	return old
+}
+
+// isLogging tests if this config has its logging bit enabled.
+func (cfg *config) isLogging() bool {
+	return (cfg.enable & loggingBit) != 0
+}
+
+// setDebugging sets/clears the debugging bit in this config.
+func (cfg *config) setDebugging(enable bool) bool {
+	old := (cfg.enable & debuggingBit) != 0
+	if enable {
+		cfg.enable |= debuggingBit
+	} else {
+		cfg.enable &^= debuggingBit
+	}
+	return old
+}
+
+// isDebugging tests if this config has its debugging bit enabled.
+func (cfg *config) isDebugging() bool {
+	return (cfg.enable & debuggingBit) != 0
+}
+
+// source returns the source name for ths config.
+func (cfg config) source() string {
+	return cfg.logger().Source()
+}

--- a/pkg/log/ratelimit.go
+++ b/pkg/log/ratelimit.go
@@ -1,0 +1,127 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	goxrate "golang.org/x/time/rate"
+)
+
+// Rate specifies maximum per-message logging rate.
+type Rate struct {
+	// rate limit
+	Limit goxrate.Limit
+	// allowed bursts
+	Burst int
+	// optional message window size
+	Window int
+}
+
+// ratelimited implements rate-limited logging with a sliding window of unique messages.
+type ratelimited struct {
+	Logger
+	sync.Mutex
+	rate   Rate
+	window []string
+	limits map[string]*goxrate.Limiter
+}
+
+const (
+	// DefaultWindow is the default message window size for rate limiting.
+	DefaultWindow = 256
+	// MinimumWindow is the smallest message window size for rate limiting.
+	MinimumWindow = 32
+)
+
+// Every defines a rate limit for the given interval.
+func Every(interval time.Duration) goxrate.Limit {
+	return goxrate.Every(interval)
+}
+
+// Interval returns a Rate for the given interval.
+func Interval(interval time.Duration) Rate {
+	return Rate{Limit: Every(interval), Burst: 1}
+}
+
+// RateLimit returns a ratelimited version of the given logger.
+func RateLimit(log Logger, rate Rate) Logger {
+	switch {
+	case rate.Window == 0:
+		rate.Window = DefaultWindow
+	case rate.Window < MinimumWindow:
+		rate.Window = MinimumWindow
+	}
+	if rate.Burst < 1 {
+		rate.Burst = 1
+	}
+	return &ratelimited{
+		Logger: log,
+		rate:   rate,
+		window: make([]string, 0, rate.Window),
+		limits: make(map[string]*goxrate.Limiter),
+	}
+}
+
+func (rl *ratelimited) Debug(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if limit := rl.getMessageLimit(msg); limit.Allow() {
+		rl.Logger.Debug("<rate-limited> %s", msg)
+	}
+}
+
+func (rl *ratelimited) Info(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if limit := rl.getMessageLimit(msg); limit.Allow() {
+		rl.Logger.Info("<rate-limited> %s", msg)
+	}
+}
+
+func (rl *ratelimited) Warn(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if limit := rl.getMessageLimit(msg); limit.Allow() {
+		rl.Logger.Warn("<rate-limited> %s", msg)
+	}
+}
+
+func (rl *ratelimited) Error(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if limit := rl.getMessageLimit(msg); limit.Allow() {
+		rl.Logger.Error("<rate-limited> %s", msg)
+	}
+}
+
+// Get existing message limit or create a new one, shifting out the oldest if window is full.
+func (rl *ratelimited) getMessageLimit(msg string) *goxrate.Limiter {
+	rl.Lock()
+	defer rl.Unlock()
+
+	limit, ok := rl.limits[msg]
+	if ok {
+		return limit
+	}
+
+	limit = goxrate.NewLimiter(rl.rate.Limit, rl.rate.Burst)
+	if len(rl.limits) == rl.rate.Window {
+		delete(rl.limits, rl.window[0])
+		rl.window = rl.window[1:]
+	}
+	rl.window = append(rl.window, msg)
+	rl.limits[msg] = limit
+
+	return limit
+}

--- a/pkg/log/ratelimit_test.go
+++ b/pkg/log/ratelimit_test.go
@@ -1,0 +1,78 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	goxrate "golang.org/x/time/rate"
+)
+
+func TestRateLimit(t *testing.T) {
+	ratelimit := RateLimit(Default(), Rate{Window: MinimumWindow, Limit: Every(time.Second)})
+	rl := ratelimit.(*ratelimited)
+
+	limiters := make(map[string]*goxrate.Limiter)
+
+	// fill message window, store limiters for checking
+	messages := make([]string, 0, MinimumWindow)
+	for idx := 0; idx < cap(messages); idx++ {
+		msg := fmt.Sprintf("message #%d", idx)
+		messages = append(messages, msg)
+		limiters[msg] = rl.getMessageLimit(msg)
+	}
+
+	// check looked up vs. stored limters
+	for msg, limiter := range limiters {
+		if rl.getMessageLimit(msg) != limiter {
+			t.Errorf("unexpected new limiter for message %s", msg)
+		}
+	}
+
+	// create more messages, store limiters for checking
+	recent := make([]string, 0, MinimumWindow/5)
+	for i := 0; i < cap(recent); i++ {
+		msg := fmt.Sprintf("message #%d", len(messages)+i)
+		recent = append(recent, msg)
+		limiters[msg] = rl.getMessageLimit(msg)
+	}
+
+	// check looked up vs. stored limiters
+	for _, msg := range recent {
+		if rl.getMessageLimit(msg) != limiters[msg] {
+			t.Errorf("unexpected new limiter for recent message %s", msg)
+		}
+	}
+
+	// check in-window part of old messages
+	for idx := len(recent); idx < len(messages); idx++ {
+		msg := messages[idx]
+		l := rl.getMessageLimit(msg)
+		if l != limiters[msg] {
+			t.Errorf("unexpected new limiter for old message %s", msg)
+		}
+	}
+
+	// check shifted out part of old messages
+	for idx := 0; idx < len(recent); idx++ {
+		msg := messages[idx]
+		l := rl.getMessageLimit(msg)
+		if l == limiters[msg] {
+			t.Errorf("unexpected old limiter for old message %s", msg)
+		}
+	}
+}

--- a/pkg/log/signal.go
+++ b/pkg/log/signal.go
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"os"
+	"os/signal"
+)
+
+// signal notification channel
+var signals chan os.Signal
+
+// SetupDebugToggleSignal sets up a signal handler to toggle full debugging on/off.
+func SetupDebugToggleSignal(sig os.Signal) {
+	log.Lock()
+	defer log.Unlock()
+
+	clearDebugToggleSignal()
+
+	signals = make(chan os.Signal, 1)
+	signal.Notify(signals, sig)
+
+	go func(sig <-chan os.Signal) {
+		state := map[bool]string{false: "off", true: "on"}
+		for {
+			select {
+			case _, ok := <-sig:
+				if !ok {
+					return
+				}
+			}
+			forced := log.debugForced()
+			deflog.Info("toggling forced full debugging %s...", state[!forced])
+			log.forceDebug(!forced)
+			if log.forced {
+				deflog.Debug("forced full debugging is now %s...", state[forced])
+			} else {
+				deflog.Info("forced full debugging is now %s...", state[forced])
+			}
+		}
+	}(signals)
+}
+
+// ClearDebugToggleSignal removes any signal handlers for toggling debug on/off.
+func ClearDebugToggleSignal() {
+	log.Lock()
+	defer log.Unlock()
+	clearDebugToggleSignal()
+}
+
+func clearDebugToggleSignal() {
+	if signals != nil {
+		signal.Stop(signals)
+		close(signals)
+		signals = nil
+	}
+}

--- a/pkg/utils/parse.go
+++ b/pkg/utils/parse.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseEnabled returns whether the given string represents an 'enabled' state.
+func ParseEnabled(value string) (bool, error) {
+	switch strings.ToLower(value) {
+	case "true", "on", "enable", "enabled", "1":
+		return true, nil
+	case "false", "off", "disable", "disabled", "0":
+		return false, nil
+	default:
+		return false, fmt.Errorf("ParseEnabled: invalid string %q", value)
+	}
+}


### PR DESCRIPTION
This patch set reworks the pkg/log, the common logger implementation with the primary aim being
  - to make the logger race-free/properly locked
  - clean up the implementation
  - add unit tests for logging

The set of fixes, changes and improvements are:
  - logging now should be race-free and multiple goroutine-safe (sans bugs)
  - filter early messages until/unless the daemon decides to start up, or there is an error
  - support for toggling full debugging on/off using SIGUSR1
  - format, serialize and emit messages from an asynchronous goroutine
  - properly handle and format multi-line messages without dedicated multi-line function calls
  - unit test
