### PR TITLE
fixes: resource-manager: don't deadlock event handler.

### DIFF
--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -133,7 +133,5 @@ func (m *resmgr) processAvx(e *metrics.AvxEvent) bool {
 
 // resolveCgroupPath resolves a cgroup path to a container.
 func (m *resmgr) resolveCgroupPath(path string) (cache.Container, bool) {
-	m.Lock()
-	defer m.Unlock()
 	return m.cache.LookupContainerByCgroup(path)
 }


### PR DESCRIPTION
Ouch... Don't deadlock main event handler on first AVX event
on the processEvent() -> processAvx() -> resolveCgroupPath()
path.