### PR TITLE
fix: fail to start up if another instance is already running.

### DIFF
--- a/pkg/cri/server/server.go
+++ b/pkg/cri/server/server.go
@@ -175,6 +175,7 @@ func (s *server) createGrpcServer() error {
 			return serverError("failed to create server: socket %s already in use",
 				s.options.Socket)
 		}
+		s.Warn("removing abandoned socket '%s' in use...", s.options.Socket)
 		os.Remove(s.options.Socket)
 		l, err = net.Listen("unix", s.options.Socket)
 		if err != nil {

--- a/pkg/utils/net.go
+++ b/pkg/utils/net.go
@@ -96,7 +96,7 @@ func WaitForServer(socket string, timeout time.Duration, opts ...interface{}) er
 
 // ServerActiveAt checks if a gRPC server is accepting connections at the socket.
 func ServerActiveAt(socket string) bool {
-	return WaitForServer(socket, 1*time.Microsecond) == nil
+	return WaitForServer(socket, time.Second) == nil
 }
 
 // Check if a socket connection error looks fatal.
@@ -153,7 +153,7 @@ func isFatalDialError(err error) bool {
 			case os.IsNotExist(ne):
 				return false
 			case ne.Err == syscall.ECONNREFUSED:
-				return false
+				return true
 			default:
 				err = ne
 				continue


### PR DESCRIPTION
Try harder detecting and refuse to start up if our server socket is already in use by another running instance.

Fixes #178 .