### PR TITLE
fixes: make sure config socket and cache dirs exist

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -536,6 +536,11 @@ func NewCache(options Options) (Cache, error) {
 		implicit:   make(map[string]*ImplicitAffinity),
 	}
 
+	if err := os.MkdirAll(options.CacheDir, 0700); err != nil {
+		return nil, cacheError("failed to create cache directory %s: %v",
+			options.CacheDir, err)
+	}
+
 	if err := cch.Load(); err != nil {
 		return nil, err
 	}

--- a/pkg/cri/resource-manager/config/server.go
+++ b/pkg/cri/resource-manager/config/server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -57,6 +58,12 @@ func NewConfigServer(cb SetConfigCb) (Server, error) {
 
 // Start runs server instance.
 func (s *server) Start(socket string) error {
+	// Make sure we have a directory for the socket
+	if err := os.MkdirAll(filepath.Dir(socket), 0700); err != nil {
+		return serverError("failed to create directory for socket %s: %v",
+			socket, err)
+	}
+
 	// Remove socket file if it exists
 	if err := os.Remove(socket); err != nil && !os.IsNotExist(err) {
 		return serverError("failed to unlink socket file: %s", err)


### PR DESCRIPTION
Make sure during startup that we have directories to put the config server socket and the cache file in.
Fixes #181 .