### PR TITLE
system: change system structs to interfaces

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
@@ -62,7 +62,7 @@ type staticplus struct {
 	reserved    cpuset.CPUSet // pool (primarily) for system-/kube-tasks
 	isolated    cpuset.CPUSet // primary pool for exclusive allocations
 	allocations Allocations   // container cpu allocations
-	sys         *sysfs.System // system/topologu information
+	sys         sysfs.System  // system/topologu information
 	cache       cache.Cache   // system state/cache
 	shared      cpuset.CPUSet // pool for fractional and shared allocations
 }
@@ -304,7 +304,7 @@ func (p *staticplus) restoreCache() error {
 
 // requestedCpus calculates the exclusive and shared cpu allocations for a container.
 func (p *staticplus) requestedCpus(c cache.Container) (int, int) {
-	cpuReq, ok := c.GetResourceRequirements().Requests[v1.ResourceCPU]
+	cpuReq, ok := c.GetResourceRequirements().Requests[corev1.ResourceCPU]
 	if !ok {
 		return 0, 0
 	}

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
@@ -49,7 +49,7 @@ type static struct {
 	reservedCpus  cpuset.CPUSet        // CPUs reserved for system- and kube-tasks
 	availableCpus cpuset.CPUSet        // CPUs free usable by this policy
 	isolatedCpus  cpuset.CPUSet        // available CPUs isolated from normal scheduling
-	sys           *sysfs.System        // system/topology information
+	sys           sysfs.System         // system/topology information
 	numHT         int                  // number of hyperthreads per core
 	state         cache.Cache          // policy/state cache
 }
@@ -389,10 +389,10 @@ func (s *static) guaranteedCPUs(pod cache.Pod, container cache.Container) int {
 
 	s.Debug("* QoS class for pod %s (%s) is %s", pod.GetID(), pod.GetName(), qos)
 
-	if qos != v1.PodQOSGuaranteed {
+	if qos != corev1.PodQOSGuaranteed {
 		return 0
 	}
-	cpuQuantity := container.GetResourceRequirements().Requests[v1.ResourceCPU]
+	cpuQuantity := container.GetResourceRequirements().Requests[corev1.ResourceCPU]
 	if cpuQuantity.Value()*1000 != cpuQuantity.MilliValue() {
 		return 0
 	}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -26,15 +26,54 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
+type mockSystemNode struct {
+	id        system.ID // node id
+	packageID system.ID // node id
+	distance  int
+}
+
+func (fake *mockSystemNode) MemoryInfo() (*system.MemInfo, error) {
+	return nil, nil
+}
+func (fake *mockSystemNode) PackageID() system.ID {
+	return fake.packageID
+}
+func (fake *mockSystemNode) ID() system.ID {
+	return fake.id
+}
+func (fake *mockSystemNode) CPUSet() cpuset.CPUSet {
+	return cpuset.NewCPUSet()
+}
+func (fake *mockSystemNode) Distance() []int {
+	return []int{}
+}
+func (fake *mockSystemNode) DistanceFrom(id system.ID) int {
+	return 0
+}
+
+type mockSystemCPUPackage struct {
+	id system.ID // package id
+}
+
+func (fake *mockSystemCPUPackage) ID() system.ID {
+	return fake.id
+}
+func (fake *mockSystemCPUPackage) CPUSet() cpuset.CPUSet {
+	return cpuset.NewCPUSet()
+}
+func (fake *mockSystemCPUPackage) NodeIDs() []system.ID {
+	return []system.ID{}
+}
+
 type mockSystem struct {
 	isolatedCPU int
 }
 
-func (fake *mockSystem) Node(system.ID) *system.Node {
-	return &system.Node{}
+func (fake *mockSystem) Node(id system.ID) system.Node {
+	return &mockSystemNode{id: id}
 }
-func (fake *mockSystem) Package(system.ID) *system.Package {
-	return &system.Package{}
+func (fake *mockSystem) Package(id system.ID) system.CPUPackage {
+	return &mockSystemCPUPackage{id: id}
 }
 func (fake *mockSystem) Offlined() cpuset.CPUSet {
 	return cpuset.NewCPUSet()

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
@@ -132,16 +132,16 @@ type nodeself struct {
 
 // socketnode represents a physical CPU package/socket in the system.
 type socketnode struct {
-	node                   // common node data
-	id     system.ID       // NUMA node socket id
-	syspkg *system.Package // corresponding system.Package
+	node                     // common node data
+	id     system.ID         // NUMA node socket id
+	syspkg system.CPUPackage // corresponding system.Package
 }
 
 // numanode represents a NUMA node in the system.
 type numanode struct {
-	node                 // common node data
-	id      system.ID    // NUMA node system id
-	sysnode *system.Node // corresponding system.Node
+	node                // common node data
+	id      system.ID   // NUMA node system id
+	sysnode system.Node // corresponding system.Node
 }
 
 // virtualnode represents a virtual node (ATM only the root in a multi-socket system).

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -15,7 +15,7 @@
 package topologyaware
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
@@ -43,8 +43,8 @@ type allocations struct {
 
 // TODO(rojkov): this is the interface of system.System we consume in this Go package. Should be moved to the package which is supposed to provide the interface.
 type discoveredSystem interface {
-	Node(system.ID) *system.Node
-	Package(system.ID) *system.Package
+	Node(system.ID) system.Node
+	Package(system.ID) system.CPUPackage
 	Offlined() cpuset.CPUSet
 	Isolated() cpuset.CPUSet
 	CPUSet() cpuset.CPUSet
@@ -200,7 +200,7 @@ func (p *policy) Rebalance() (bool, error) {
 	movable := []cache.Container{}
 
 	for _, c := range containers {
-		if c.GetQOSClass() != v1.PodQOSGuaranteed {
+		if c.GetQOSClass() != corev1.PodQOSGuaranteed {
 			p.ReleaseResources(c)
 			movable = append(movable, c)
 		}

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -60,7 +60,7 @@ type Options struct {
 // BackendOptions describes the options for a policy backend instance
 type BackendOptions struct {
 	// System provides system/HW/topology information
-	System *system.System
+	System system.System
 	// System state/cache
 	Cache cache.Cache
 	// Resource availibility constraint
@@ -131,9 +131,9 @@ type Policy interface {
 
 // Policy instance/state.
 type policy struct {
-	cache   cache.Cache    // system state cache
-	backend Backend        // our active backend
-	system  *system.System // system/HW/topology info
+	cache   cache.Cache   // system state cache
+	backend Backend       // our active backend
+	system  system.System // system/HW/topology info
 }
 
 // backend is a registered Backend.


### PR DESCRIPTION
Make the `sysfs` package use interfaces instead of plain objects so we can mock them in tests. Use `CPUPackage` (and corresponding type `cpuPackage struct`) because "package" is a reserved word in Go. Also add `DiscoverSystemAt()` method for testing with fake sysfs directory hierarchy.

Note: relates to PR https://github.com/intel/cri-resource-manager/pull/90.