### PR TITLE
fix: resource-manager: use pseudo-absolute cgroup path in AVX metrics events.

### DIFF
--- a/pkg/cri/resource-manager/metrics/avx.go
+++ b/pkg/cri/resource-manager/metrics/avx.go
@@ -60,7 +60,7 @@ func (m *Metrics) collectAvxEvents(raw map[string]*model.MetricFamily) *AvxEvent
 	for cgroup, use := range ratio {
 		active := use >= m.opts.AvxThreshold
 		log.Debug(" %s AVX ratio = %f, active?: %v", cgroup, use, active)
-		usage[cgroup] = active
+		usage["/"+cgroup] = active
 	}
 
 	return &AvxEvent{Updates: usage}


### PR DESCRIPTION
The Pod CgroupParent is a filesystem-relative absolute path. IOW, it is a path relative to the cgroupfs root but with a "/" prepended. Therefore use similar paths in AVX metrics events. Otherwise resolving cgroups to containers fail.