### PR TITLE
ci-build: add rules to install protoc and gRPC plugin.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
       - run:
           name: Install golangci-lint
           command: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b $(go env GOPATH)/bin v1.18.0
+      - run: go get -u github.com/golang/protobuf/protoc-gen-go
+      - run: go get -u google.golang.org/grpc
       - run: make format
       - run: make
       - run: make golangci-lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,12 @@ jobs:
     - name: Gofmt
       run: make format
 
+    - name: Protoc
+      run go get -u github.com/golang/protobuf/protoc-gen-go
+
+    - name: Protoc-gRPC
+      run: go get -u google.golang.org/grpc
+
     - name: Build
       run: make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ addons:
     - linux-headers-5.3.0-23-generic
 
 script:
+  - go get -u github.com/golang/protobuf/protoc-gen-go
+  - go get -u google.golang.org/grpc
   - make format
   - make
   - KERNEL_SRC_DIR=/lib/modules/5.3.0-23-generic/build make libexec/avx512.o


### PR DESCRIPTION
Since we'll try to automatically regenerate .pb.go files if the corresponding proto-definitions our newer, add rules to pull in protoc and gRPC plugin before we kick off a build.