### PR TITLE
Rudimentary support for CPU prioritization

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cpu.go
@@ -521,7 +521,7 @@ func (cg *cpuGrant) String() string {
 
 // takeCPUs takes up to cnt CPUs from a given CPU set to another.
 func takeCPUs(from, to *cpuset.CPUSet, cnt int) (cpuset.CPUSet, error) {
-	cset, err := cpuallocator.AllocateCpus(from, cnt)
+	cset, err := cpuallocator.AllocateCpus(from, cnt, true)
 	if err != nil {
 		return cset, err
 	}


### PR DESCRIPTION
This patch adds support for per core priority in the cpu allocator used
by static, static-plus and topology-aware built-in policies. At this
point there is only support for two stages of priority (low and high).
The new allocator heuristics added in this patch are straightforward:
depending on the caller's guidance, the allocator always simply prefers
or tries to avoid high-priority CPUs.

Detection of high priority CPUs is currently based on the base_frequency
attribute. If CPUs with different base frequencies are detected, all
higher frequency CPUs (higher than the lowest detected base frequency)
are flagged as high priority.