### PR TITLE
topology-aware: start using sysfs.System interface.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -65,10 +65,74 @@ func (fake *mockSystemCPUPackage) NodeIDs() []system.ID {
 	return []system.ID{}
 }
 
+type mockCPU struct {
+	id            system.ID
+	node          mockSystemNode
+	pkg           mockSystemCPUPackage
+	isolated      bool
+	online        bool
+	baseFrequency uint64
+}
+
+func (c *mockCPU) BaseFrequency() uint64 {
+	return c.baseFrequency
+}
+func (c *mockCPU) ID() system.ID {
+	return c.id
+}
+func (c *mockCPU) PackageID() system.ID {
+	return c.pkg.ID()
+}
+func (c *mockCPU) NodeID() system.ID {
+	return c.node.ID()
+}
+func (c *mockCPU) CoreID() system.ID {
+	return c.id
+}
+func (c *mockCPU) ThreadCPUSet() cpuset.CPUSet {
+	return cpuset.NewCPUSet()
+}
+func (c *mockCPU) FrequencyRange() system.CPUFreq {
+	return system.CPUFreq{}
+}
+func (c *mockCPU) Online() bool {
+	return c.online
+}
+func (c *mockCPU) Isolated() bool {
+	return c.isolated
+}
+func (c *mockCPU) SetFrequencyLimits(min, max uint64) error {
+	return nil
+}
+
 type mockSystem struct {
 	isolatedCPU int
 }
 
+func (fake *mockSystem) CPU(system.ID) system.CPU {
+	return &mockCPU{}
+}
+func (fake *mockSystem) CPUCount() int {
+	return 0
+}
+func (fake *mockSystem) Discover(flags system.DiscoveryFlag) error {
+	return nil
+}
+func (fake *mockSystem) CPUIDs() []system.ID {
+	return []system.ID{}
+}
+func (fake *mockSystem) PackageCount() int {
+	return 0
+}
+func (fake *mockSystem) ThreadCount() int {
+	return 0
+}
+func (fake *mockSystem) SetCPUFrequencyLimits(min, max uint64, cpus system.IDSet) error {
+	return nil
+}
+func (fake *mockSystem) SetCpusOnline(online bool, cpus system.IDSet) (system.IDSet, error) {
+	return system.NewIDSet(), nil
+}
 func (fake *mockSystem) Node(id system.ID) system.Node {
 	return &mockSystemNode{id: id}
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
@@ -82,7 +82,7 @@ type Node interface {
 	// Get the height of this node (inverse of depth: tree depth - node depth).
 	NodeHeight() int
 	// System returns the policy sysfs instance.
-	System() discoveredSystem
+	System() system.System
 	// Policy returns the policy back pointer.
 	Policy() *policy
 	// DiscoverCPU
@@ -320,7 +320,7 @@ func (n *node) BreadthFirst(fn func(Node) error) error {
 }
 
 // System returns the policy System instance.
-func (n *node) System() discoveredSystem {
+func (n *node) System() system.System {
 	return n.policy.sys
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -41,24 +41,11 @@ type allocations struct {
 	CPU    map[string]CPUGrant
 }
 
-// TODO(rojkov): this is the interface of system.System we consume in this Go package. Should be moved to the package which is supposed to provide the interface.
-type discoveredSystem interface {
-	Node(system.ID) system.Node
-	Package(system.ID) system.CPUPackage
-	Offlined() cpuset.CPUSet
-	Isolated() cpuset.CPUSet
-	CPUSet() cpuset.CPUSet
-	SocketCount() int
-	NUMANodeCount() int
-	PackageIDs() []system.ID
-	NodeIDs() []system.ID
-}
-
 // policy is our runtime state for the topology aware policy.
 type policy struct {
 	options     policyapi.BackendOptions // options we were created or reconfigured with
 	cache       cache.Cache              // pod/container cache
-	sys         discoveredSystem         // system/HW topology info
+	sys         system.System            // system/HW topology info
 	allowed     cpuset.CPUSet            // bounding set of CPUs we're allowed to use
 	reserved    cpuset.CPUSet            // system-/kube-reserved CPUs
 	reserveCnt  int                      // number of CPUs to reserve if given as resource.Quantity


### PR DESCRIPTION
Remove `discoveredSystem` interface and use `sysfs.System` interface instead.