### PR TITLE
resource-manager: free any lingering instance upon pod/container recreation. 

### DIFF
--- a/pkg/cri/resource-manager/no-test-api.go
+++ b/pkg/cri/resource-manager/no-test-api.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !test
+
+package resmgr
+
+// ResourceManagerTestAPI is dummy if we're compiling without test build flag.
+type ResourceManagerTestAPI interface {
+}

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -46,6 +46,8 @@ type ResourceManager interface {
 	SetConfig(*config.RawConfig) error
 	// SendEvent sends an event to be processed by the resource manager.
 	SendEvent(event interface{}) error
+	// Add-ons for testing.
+	ResourceManagerTestAPI
 }
 
 // resmgr is the implementation of ResourceManager.

--- a/pkg/cri/resource-manager/test-api.go
+++ b/pkg/cri/resource-manager/test-api.go
@@ -1,0 +1,31 @@
+// Copyright 2029 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build test
+
+package resmgr
+
+import (
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+)
+
+// ResourceManagerTestAPI is a post-test verification helper interface.
+type ResourceManagerTestAPI interface {
+	// GetCache returns the Cache resource manager is running with.
+	GetCache() cache.Cache
+}
+
+func (m *resmgr) GetCache() cache.Cache {
+	return m.cache
+}

--- a/test/functional/e2e_test.go
+++ b/test/functional/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Intel Corporation. All Rights Reserved.
+// Copyright 2020 Intel Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,11 @@ import (
 	"testing"
 	"time"
 
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+
 	resmgr "github.com/intel/cri-resource-manager/pkg/cri/resource-manager"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/dump"
 	"google.golang.org/grpc"
 	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -40,7 +44,19 @@ func init() {
 	}
 }
 
-func runTest(t *testing.T, name string, overridenCriHandlers map[string]interface{}, testFunction func(*testing.T, api.RuntimeServiceClient, context.Context)) {
+type testEnv struct {
+	t           *testing.T
+	handlers    map[string]interface{}
+	client      api.RuntimeServiceClient
+	forceConfig string
+	mgr         resmgr.ResourceManager
+	cache       cache.Cache
+}
+
+func (env *testEnv) Run(name string, testFunction func(context.Context, *testEnv)) {
+	t := env.t
+	overriddenCriHandlers := env.handlers
+
 	t.Helper()
 	t.Run(name, func(t *testing.T) {
 		tmpDir, err := ioutil.TempDir(testDir, "requests-")
@@ -70,9 +86,20 @@ func runTest(t *testing.T, name string, overridenCriHandlers map[string]interfac
 		if err := flag.Set("logger-debug", "*"); err != nil {
 			t.Fatalf("unable to set logger-debug")
 		}
+
+		if env.forceConfig != "" {
+			path := filepath.Join(tmpDir, "forcedconfig.cfg")
+			if err := ioutil.WriteFile(path, []byte(env.forceConfig), 0644); err != nil {
+				t.Fatalf("failed to create configuration file %s: %v", path, err)
+			}
+			if err := flag.Set("force-config", path); err != nil {
+				t.Fatalf("unable to set force-config")
+			}
+		}
+
 		flag.Parse()
 
-		fakeCri := newFakeCriServer(t, filepath.Join(tmpDir, "fakecri.sock"), overridenCriHandlers)
+		fakeCri := newFakeCriServer(t, filepath.Join(tmpDir, "fakecri.sock"), overriddenCriHandlers)
 		defer fakeCri.stop()
 
 		resMgr, err := resmgr.NewResourceManager()
@@ -102,7 +129,15 @@ func runTest(t *testing.T, name string, overridenCriHandlers map[string]interfac
 
 		client := api.NewRuntimeServiceClient(conn)
 
-		testFunction(t, client, ctx)
+		env.client = client
+		env.mgr = resMgr
+		env.cache = resMgr.GetCache()
+
+		testFunction(ctx, env)
+
+		// until pkg/log fixes gets merged: wait until pkg/dump is done with
+		// logging before we run next test (and consequently do a reconfig)
+		dump.Sync()
 	})
 }
 
@@ -129,7 +164,13 @@ func TestListPodSandbox(t *testing.T) {
 				}, nil
 			},
 		}
-		runTest(t, tc.name, criHandlers, func(t *testing.T, client api.RuntimeServiceClient, ctx context.Context) {
+		env := &testEnv{
+			t:        t,
+			handlers: criHandlers,
+		}
+		env.Run(tc.name, func(ctx context.Context, env *testEnv) {
+			t := env.t
+			client := env.client
 			resp, err := client.ListPodSandbox(ctx, &api.ListPodSandboxRequest{})
 			if err != nil {
 				t.Errorf("Unexpected error: %+v", err)
@@ -165,7 +206,13 @@ func TestListContainers(t *testing.T) {
 				}, nil
 			},
 		}
-		runTest(t, tc.name, criHandlers, func(t *testing.T, client api.RuntimeServiceClient, ctx context.Context) {
+		env := &testEnv{
+			t:        t,
+			handlers: criHandlers,
+		}
+		env.Run(tc.name, func(ctx context.Context, env *testEnv) {
+			t := env.t
+			client := env.client
 			resp, err := client.ListContainers(ctx, &api.ListContainersRequest{})
 			if err != nil {
 				t.Errorf("Unexpected error: %+v", err)
@@ -175,5 +222,255 @@ func TestListContainers(t *testing.T) {
 				t.Errorf("Expected %d pods, got %d", tc.expectedContainers, len(resp.Containers))
 			}
 		})
+	}
+}
+
+func TestLingeringPodCleanup(t *testing.T) {
+	cfg := `
+policy:
+  Active: topology-aware
+  ReservedResources:
+    CPU: 750m
+`
+	tcases := []struct {
+		name         string
+		reqs         []*api.RunPodSandboxRequest
+		expectedPods int
+	}{
+		{
+			name: "create Pod #1",
+			reqs: []*api.RunPodSandboxRequest{
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+			},
+			expectedPods: 1,
+		},
+		{
+			name: "create Pods #1 and #2",
+			reqs: []*api.RunPodSandboxRequest{
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
+			},
+			expectedPods: 2,
+		},
+		{
+			name: "create Pods #1, #2, and #3",
+			reqs: []*api.RunPodSandboxRequest{
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
+				createPodRequest("Pod#3", "UID#3", "", nil, nil, ""),
+			},
+			expectedPods: 3,
+		},
+		{
+			name: "create Pods #1, #2, #3, #4, '1, '2, '3",
+			reqs: []*api.RunPodSandboxRequest{
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
+				createPodRequest("Pod#3", "UID#3", "", nil, nil, ""),
+				createPodRequest("Pod#4", "UID#4", "", nil, nil, ""),
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+				createPodRequest("Pod#2", "UID'2", "", nil, nil, ""),
+				createPodRequest("Pod#3", "UID'3", "", nil, nil, ""),
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
+				createPodRequest("Pod#3", "UID#3", "", nil, nil, ""),
+				createPodRequest("Pod#1", "UID'1", "", nil, nil, ""),
+				createPodRequest("Pod#2", "UID'2", "", nil, nil, ""),
+				createPodRequest("Pod#3", "UID'3", "", nil, nil, ""),
+				createPodRequest("Pod#4", "UID#4", "", nil, nil, ""),
+			},
+			expectedPods: 7,
+		},
+	}
+
+	numPods := 0
+	for _, tc := range tcases {
+		criHandlers := map[string]interface{}{
+			"RunPodSandbox": func(*fakeCriServer, context.Context, *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+				numPods++
+				return &api.RunPodSandboxResponse{
+					PodSandboxId: fmt.Sprintf("Pod#%d", numPods),
+				}, nil
+			},
+		}
+		env := &testEnv{
+			t:           t,
+			handlers:    criHandlers,
+			forceConfig: cfg,
+		}
+		env.Run(tc.name, func(ctx context.Context, env *testEnv) {
+			t := env.t
+			client := env.client
+			cache := env.cache
+			for _, req := range tc.reqs {
+				_, err := client.RunPodSandbox(ctx, req)
+				if err != nil {
+					t.Errorf("failed to create pod %+v: %v", req, err)
+				}
+			}
+			pods := cache.GetPods()
+			if len(pods) != tc.expectedPods {
+				t.Errorf("expected %d pods in cache, got %d (%v)", tc.expectedPods, len(pods), pods)
+			}
+		})
+	}
+}
+
+func TestLingeringContainerCleanup(t *testing.T) {
+	cfg := `
+policy:
+  Active: topology-aware
+  ReservedResources:
+    CPU: 750m
+`
+	type pod struct {
+		UID string
+		ID  string
+		req *api.RunPodSandboxRequest
+	}
+
+	type container struct {
+		pod    string
+		name   string
+		expect int
+		req    *api.CreateContainerRequest
+		ID     string
+	}
+
+	tcases := []struct {
+		name       string
+		pods       []*api.RunPodSandboxRequest
+		containers []*container
+	}{
+		{
+			name: "create containers per one pod",
+			pods: []*api.RunPodSandboxRequest{
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+			},
+			containers: []*container{
+				{pod: "UID#1", name: "Container#1", expect: 1},
+				{pod: "UID#1", name: "Container#2", expect: 2},
+			},
+		},
+		{
+			name: "create lingering containers per one pod",
+			pods: []*api.RunPodSandboxRequest{
+				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
+			},
+			containers: []*container{
+				{pod: "UID#1", name: "Container#1", expect: 1},
+				{pod: "UID#1", name: "Container#2", expect: 2},
+				{pod: "UID#1", name: "Container#3", expect: 3},
+				{pod: "UID#1", name: "Container#3", expect: 3},
+				{pod: "UID#1", name: "Container#2", expect: 3},
+				{pod: "UID#1", name: "Container#1", expect: 3},
+			},
+		},
+	}
+
+	numPods := 0
+	numContainers := 0
+	for _, tc := range tcases {
+		criHandlers := map[string]interface{}{
+			"RunPodSandbox": func(*fakeCriServer, context.Context, *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+				numPods++
+				return &api.RunPodSandboxResponse{
+					PodSandboxId: fmt.Sprintf("Pod#%d", numPods),
+				}, nil
+			},
+			"CreateContainer": func(*fakeCriServer, context.Context, *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
+				numContainers++
+				return &api.CreateContainerResponse{
+					ContainerId: fmt.Sprintf("Container#%d", numContainers),
+				}, nil
+			},
+		}
+		env := &testEnv{
+			t:           t,
+			handlers:    criHandlers,
+			forceConfig: cfg,
+		}
+		env.Run(tc.name, func(ctx context.Context, env *testEnv) {
+			t := env.t
+			client := env.client
+			cache := env.cache
+			pods := map[string]*pod{}
+
+			for _, req := range tc.pods {
+				rpl, err := client.RunPodSandbox(ctx, req)
+				if err != nil {
+					t.Errorf("failed to create pod %+v: %v", req, err)
+				} else {
+					id := rpl.PodSandboxId
+					uid := req.Config.Metadata.Uid
+					pods[uid] = &pod{
+						UID: uid,
+						ID:  id,
+						req: req,
+					}
+				}
+			}
+
+			for _, c := range tc.containers {
+				pod, ok := pods[c.pod]
+				if !ok {
+					t.Errorf("failed to find pod by UID %s", c.pod)
+					continue
+				}
+
+				c.req = createContainerRequest(pod.ID, c.name, pod.req)
+				rpl, err := client.CreateContainer(ctx, c.req)
+				if err != nil {
+					t.Errorf("failed to create container %+v: %v", c.req, err)
+				} else {
+					c.ID = rpl.ContainerId
+					cached := cache.GetContainers()
+					if len(cached) != c.expect {
+						t.Errorf("pod %s, container %s: expected %d containers in cache, got %d",
+							c.pod, c.name, c.expect, len(cached))
+					}
+				}
+			}
+		})
+	}
+}
+
+func createPodRequest(name, uid, namespace string,
+	labels, annotations map[string]string,
+	cgroupParent string) *api.RunPodSandboxRequest {
+	if namespace == "" {
+		namespace = "default"
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[kubetypes.KubernetesPodUIDLabel] = uid
+	return &api.RunPodSandboxRequest{
+		Config: &api.PodSandboxConfig{
+			Metadata: &api.PodSandboxMetadata{
+				Name:      name,
+				Uid:       uid,
+				Namespace: namespace,
+			},
+			Labels:      labels,
+			Annotations: annotations,
+			Linux: &api.LinuxPodSandboxConfig{
+				CgroupParent: cgroupParent,
+			},
+		},
+	}
+}
+
+func createContainerRequest(podID, name string,
+	podReq *api.RunPodSandboxRequest) *api.CreateContainerRequest {
+	return &api.CreateContainerRequest{
+		PodSandboxId: podID,
+		Config: &api.ContainerConfig{
+			Metadata: &api.ContainerMetadata{
+				Name: name,
+			},
+			Linux: &api.LinuxContainerConfig{},
+		},
+		SandboxConfig: podReq.Config,
 	}
 }


### PR DESCRIPTION
Free any lingering old instance of a container before recreating it.

kubelet occasionally fails to properly free crashed containers
before attempting to recreate and restart them. Check for this
and internally release any such instance if found. Likewise, do
a similar cleanup when a pod is being recreated.

Fixes #146 .