### PR TITLE
Update golangci-lint to v1.23.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b $(go env GOPATH)/bin v1.18.0
+          command: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b $(go env GOPATH)/bin v1.23.8
       - run: go get -u github.com/golang/protobuf/protoc-gen-go
       - run: go get -u google.golang.org/grpc
       - run: make format

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Install golangci-lint
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
 
     - name: Gofmt
       run: make format

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: required
 
 before_install:
   ## checkers
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.18.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.8
 
 addons:
   apt:


### PR DESCRIPTION
Keeping the linting tools up-to-date, upgrade to fresh release
of golangci-lint.