### PR TITLE
Add initial version of the blockio control

### DIFF
--- a/docs/blockio.md
+++ b/docs/blockio.md
@@ -1,0 +1,15 @@
+# Block IO
+
+## Overview
+
+Block IO controller provides means to control
+- block device IO scheduling priority (weight)
+- throttling IO bandwith
+- throttling number of IO operations.
+
+CRI Resource Manager applies block IO contoller parameters to pods via
+[cgroups block io contoller](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/blkio-controller.html).
+
+## Configuration
+
+See [sample blockio configuration](../sample-configs/blockio.cfg).

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0
 	github.com/iovisor/gobpf v0.0.0-20191024162143-7c8f8e040b4b
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/blockio/blockio.go
+++ b/pkg/blockio/blockio.go
@@ -1,0 +1,407 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockio
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/intel/cri-resource-manager/pkg/cgroups"
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/utils"
+)
+
+const (
+	// sysfsBlockDeviceIOSchedulerPaths expands (with glob) to block device scheduler files.
+	// If modified, check how to parse device node from expanded paths.
+	sysfsBlockDeviceIOSchedulerPaths = "/sys/block/*/queue/scheduler"
+)
+
+// BlockDeviceInfo holds information on a block device to be configured.
+// As users can specify block devices using wildcards ("/dev/disk/by-id/*SSD*")
+// BlockDeviceInfo.Origin is maintained for traceability: why this
+// block device is included in configuration.
+// BlockDeviceInfo.DevNode contains resolved device node, like "/dev/sda".
+type BlockDeviceInfo struct {
+	Major   int64
+	Minor   int64
+	DevNode string
+	Origin  string
+}
+
+// Our logger instance.
+var log logger.Logger = logger.NewLogger("blockio")
+
+// staticOciBlockIO connects user-defined block I/O classes to
+// corresponding OCI BlockIO parameters. "Static" means that
+// new/current block devices matching device wildcards in these
+// classes are not expanded every time new containers are assigned to
+// these classes. Devices are scanned on only at the beginning and on
+// blockio configuration changes.
+var staticOciBlockIO = map[string]cgroups.OciBlockIOParameters{}
+
+// currentIOSchedulers contains io-schedulers (found in
+// sysfsBlockDeviceIOSchedulerPaths) of device nodes:
+// {"/dev/sda": "bfq"}
+var currentIOSchedulers map[string]string
+
+// Initialize handles initial configuration and starts listening to config changes
+func Initialize() error {
+	pkgcfg.GetModule("blockio").AddNotify(configNotify)
+	applyConfig(true)
+	return nil
+}
+
+// configNotify is blockio class definition configuration notification callback.
+func configNotify(event pkgcfg.Event, source pkgcfg.Source) error {
+	log.Info("blockio I/O class configuration updated")
+	ignoreErrors := (event == pkgcfg.RevertEvent)
+	err := applyConfig(ignoreErrors)
+	return err
+}
+
+// applyConfig takes the configuration from the opt variable into use for new pods.
+func applyConfig(ignoreErrors bool) error {
+	currentIOSchedulers, ioSchedulerDetectionError := getCurrentIOSchedulers()
+	if ioSchedulerDetectionError != nil {
+		log.Warn("configuration validation partly disabled due to IO scheduler detection error %#v", ioSchedulerDetectionError.Error())
+	}
+
+	staticOciBlockIO = map[string]cgroups.OciBlockIOParameters{}
+	// Create static OCI BlockIO structures for each blockio class
+	for class := range opt.Classes {
+		ociBlockIO, err := devicesParametersToOci(opt.Classes[class], currentIOSchedulers)
+		if err != nil {
+			if ignoreErrors {
+				log.Error("ignoring: %v", err)
+			} else {
+				return err
+			}
+		}
+		// Handle all configurations as static for now. That
+		// is, the list of block devices matching Devices
+		// wildcards will not be updated without new
+		// configNotify(). class.DynamicDevices not supported
+		// yet.
+		staticOciBlockIO[class] = ociBlockIO
+	}
+	return nil
+}
+
+// SetContainerClass assigns the pod in a container to a blockio class.
+func SetContainerClass(c cache.Container, class string) error {
+	pod, ok := c.GetPod()
+	if !ok {
+		return blockioError("failed to get Pod for %s", c.PrettyName())
+	}
+
+	ociBlockIO, classIsStatic := staticOciBlockIO[class]
+	if !classIsStatic {
+		return blockioError("no OCI BlockIO parameters for class %#v", class)
+	}
+
+	blkioCgroupPodDir := cgroups.GetBlkioDir() + "/" + pod.GetCgroupParentDir()
+	containerCgroupDir := utils.GetContainerCgroupDir(blkioCgroupPodDir, c.GetID())
+	if containerCgroupDir == "" {
+		return blockioError("failed to find cgroup directory for container %s under %#v, container id %#v", c.PrettyName(), blkioCgroupPodDir, c.GetID())
+	}
+
+	err := cgroups.SetBlkioParameters(containerCgroupDir, ociBlockIO)
+	if err != nil {
+		return blockioError("assigning container %v to class %#v failed: %w", c.PrettyName(), class, err)
+	}
+
+	return nil
+}
+
+// getCurrentIOSchedulers returns currently active io-scheduler used for each block device in the system.
+func getCurrentIOSchedulers() (map[string]string, error) {
+	var ios = map[string]string{}
+	schedulerFiles, err := filepath.Glob(sysfsBlockDeviceIOSchedulerPaths)
+	if err != nil {
+		return ios, blockioError("error in IO scheduler wildcards %#v: %w", sysfsBlockDeviceIOSchedulerPaths, err)
+	}
+	for _, schedulerFile := range schedulerFiles {
+		devName := strings.SplitN(schedulerFile, "/", 5)[3]
+		schedulerDataB, err := ioutil.ReadFile(schedulerFile)
+		if err != nil {
+			// A block device may be disconnected. Continue without error.
+			log.Error("failed to read current IO scheduler %#v: %v\n", schedulerFile, err)
+			continue
+		}
+		schedulerData := string(schedulerDataB)
+		openB := strings.Index(schedulerData, "[")
+		closeB := strings.Index(schedulerData, "]")
+		if -1 < openB && openB < closeB {
+			currentScheduler := schedulerData[openB+1 : closeB]
+			ios["/dev/"+devName] = currentScheduler
+		} else {
+			return ios, blockioError("could not parse current scheduler in %#v\n", schedulerFile)
+		}
+	}
+	return ios, nil
+}
+
+// deviceParametersToOci converts single blockio class parameters into OCI BlockIO structure.
+func devicesParametersToOci(dps []DevicesParameters, currentIOSchedulers map[string]string) (cgroups.OciBlockIOParameters, error) {
+	var errors *multierror.Error
+	oci := cgroups.NewOciBlockIOParameters()
+	for _, dp := range dps {
+		var err error
+		var weight, throttleReadBps, throttleWriteBps, throttleReadIOPS, throttleWriteIOPS int64
+		weight, err = parseAndValidateInt64("Weight", dp.Weight, -1, 10, 1000)
+		errors = multierror.Append(errors, err)
+		throttleReadBps, err = parseAndValidateInt64("ThrottleReadBps", dp.ThrottleReadBps, -1, 0, -1)
+		errors = multierror.Append(errors, err)
+		throttleWriteBps, err = parseAndValidateInt64("ThrottleWriteBps", dp.ThrottleWriteBps, -1, 0, -1)
+		errors = multierror.Append(errors, err)
+		throttleReadIOPS, err = parseAndValidateInt64("ThrottleReadIOPS", dp.ThrottleReadIOPS, -1, 0, -1)
+		errors = multierror.Append(errors, err)
+		throttleWriteIOPS, err = parseAndValidateInt64("ThrottleWriteIOPS", dp.ThrottleWriteIOPS, -1, 0, -1)
+		errors = multierror.Append(errors, err)
+		if dp.Devices == nil {
+			if weight > -1 {
+				oci.Weight = weight
+			}
+			if throttleReadBps > -1 || throttleWriteBps > -1 || throttleReadIOPS > -1 || throttleWriteIOPS > -1 {
+				errors = multierror.Append(errors, fmt.Errorf("ignoring throttling (rbps=%#v wbps=%#v riops=%#v wiops=%#v): Devices not listed",
+					dp.ThrottleReadBps, dp.ThrottleWriteBps, dp.ThrottleReadIOPS, dp.ThrottleWriteIOPS))
+			}
+		} else {
+			blockDevices, err := currentPlatform.configurableBlockDevices(dp.Devices)
+			if err != nil {
+				// Problems in matching block device wildcards and resolving symlinks
+				// are worth reporting, but must not block configuring blkio where possible.
+				log.Error(err.Error())
+			}
+			if len(blockDevices) == 0 {
+				log.Warn("no matches on any of Devices: %v, parameters ignored", dp.Devices)
+			}
+			for _, blockDeviceInfo := range blockDevices {
+				if weight != -1 {
+					if ios, found := currentIOSchedulers[blockDeviceInfo.DevNode]; found {
+						if ios != "bfq" && ios != "cfq" {
+							log.Warn("weight has no effect on device %#v due to "+
+								"incompatible io-scheduler %#v (bfq or cfq required)", blockDeviceInfo.DevNode, ios)
+						}
+					}
+					oci.WeightDevice = updateOrAppendWeight(oci.WeightDevice,
+						cgroups.OciWeightDeviceParameters{
+							Major:  blockDeviceInfo.Major,
+							Minor:  blockDeviceInfo.Minor,
+							Weight: weight})
+				}
+				if throttleReadBps != -1 {
+					oci.ThrottleReadBpsDevice = updateOrAppendRate(oci.ThrottleReadBpsDevice,
+						cgroups.OciRateDeviceParameters{
+							Major: blockDeviceInfo.Major,
+							Minor: blockDeviceInfo.Minor,
+							Rate:  throttleReadBps})
+				}
+				if throttleWriteBps != -1 {
+					oci.ThrottleWriteBpsDevice = updateOrAppendRate(oci.ThrottleWriteBpsDevice,
+						cgroups.OciRateDeviceParameters{
+							Major: blockDeviceInfo.Major,
+							Minor: blockDeviceInfo.Minor,
+							Rate:  throttleWriteBps})
+				}
+				if throttleReadIOPS != -1 {
+					oci.ThrottleReadIOPSDevice = updateOrAppendRate(oci.ThrottleReadIOPSDevice,
+						cgroups.OciRateDeviceParameters{
+							Major: blockDeviceInfo.Major,
+							Minor: blockDeviceInfo.Minor,
+							Rate:  throttleReadIOPS})
+				}
+				if throttleWriteIOPS != -1 {
+					oci.ThrottleWriteIOPSDevice = updateOrAppendRate(oci.ThrottleWriteIOPSDevice,
+						cgroups.OciRateDeviceParameters{
+							Major: blockDeviceInfo.Major,
+							Minor: blockDeviceInfo.Minor,
+							Rate:  throttleWriteIOPS})
+				}
+			}
+		}
+	}
+	return oci, errors.ErrorOrNil()
+}
+
+// parseAndValidateInt64 parses quantities, like "64 M", and validates that they are in given range.
+func parseAndValidateInt64(fieldName string, fieldContent string,
+	defaultValue int64, min int64, max int64) (int64, error) {
+	// Returns field content
+	if fieldContent == "" {
+		return defaultValue, nil
+	}
+	qty, err := resource.ParseQuantity(fieldContent)
+	if err != nil {
+		return defaultValue, fmt.Errorf("syntax error in %#v (%#v)", fieldName, fieldContent)
+	}
+	value := qty.Value()
+	if min != -1 && min > value {
+		return defaultValue, fmt.Errorf("value of %#v (%#v) smaller than minimum (%#v)", fieldName, value, min)
+	}
+	if max != -1 && value > max {
+		return defaultValue, fmt.Errorf("value of %#v (%#v) bigger than maximum (%#v)", fieldName, value, max)
+	}
+	return value, nil
+}
+
+// updateOrAppendRate updates Rate of a Major:Minor device if already in list, otherwise appends it
+func updateOrAppendRate(rateDevs []cgroups.OciRateDeviceParameters, newDev cgroups.OciRateDeviceParameters) []cgroups.OciRateDeviceParameters {
+	if rateDevs == nil {
+		return []cgroups.OciRateDeviceParameters{newDev}
+	}
+	for index, rateDev := range rateDevs {
+		if rateDev.Major == newDev.Major && rateDev.Minor == newDev.Minor {
+			rateDevs[index].Rate = newDev.Rate
+			return rateDevs
+		}
+	}
+	return append(rateDevs, newDev)
+}
+
+// updateOrAppendWeight updates Rate of a Major:Minor device if already in list, otherwise appends it
+func updateOrAppendWeight(weightDevs []cgroups.OciWeightDeviceParameters, newDev cgroups.OciWeightDeviceParameters) []cgroups.OciWeightDeviceParameters {
+	if weightDevs == nil {
+		return []cgroups.OciWeightDeviceParameters{newDev}
+	}
+	for index, weightDev := range weightDevs {
+		if weightDev.Major == newDev.Major && weightDev.Minor == newDev.Minor {
+			weightDevs[index].Weight = newDev.Weight
+			return weightDevs
+		}
+	}
+	return append(weightDevs, newDev)
+}
+
+// platformInterface includes functions that access the system. Enables mocking the system.
+type platformInterface interface {
+	configurableBlockDevices(devWildcards []string) ([]BlockDeviceInfo, error)
+}
+
+// defaultPlatform versions of platformInterface functions access the underlying system.
+type defaultPlatform struct{}
+
+// currentPlatform defines which platformInterface is used: defaultPlatform or a mock, for instance.
+var currentPlatform platformInterface = defaultPlatform{}
+
+// configurableBlockDevices finds major:minor numbers for device filenames (wildcards allowed)
+func (dpm defaultPlatform) configurableBlockDevices(devWildcards []string) ([]BlockDeviceInfo, error) {
+	// Return map {devNode: BlockDeviceInfo}
+	// Example: {"/dev/sda": {Major:8, Minor:0, Origin:"from symlink /dev/disk/by-id/ata-VendorXSSD from wildcard /dev/disk/by-id/*SSD*"}}
+	var errors *multierror.Error
+	blockDevices := []BlockDeviceInfo{}
+	var origin string
+
+	// 1. Expand wildcards to device filenames (may be symlinks)
+	// Example: devMatches["/dev/disk/by-id/ata-VendorSSD"] == "from wildcard \"dev/disk/by-id/*SSD*\""
+	devMatches := map[string]string{} // {devNodeOrSymlink: origin}
+	for _, devWildcard := range devWildcards {
+		devWildcardMatches, err := filepath.Glob(devWildcard)
+		if err != nil {
+			errors = multierror.Append(errors, fmt.Errorf("bad device wildcard %#v: %w", devWildcard, err))
+			continue
+		}
+		if len(devWildcardMatches) == 0 {
+			errors = multierror.Append(errors, fmt.Errorf("device wildcard %#v does not match any device nodes", devWildcard))
+			continue
+		}
+		for _, devMatch := range devWildcardMatches {
+			if devMatch != devWildcard {
+				origin = fmt.Sprintf("from wildcard %#v", devWildcard)
+			} else {
+				origin = ""
+			}
+			devMatches[devMatch] = strings.TrimSpace(fmt.Sprintf("%v %v", devMatches[devMatch], origin))
+		}
+	}
+
+	// 2. Find out real device nodes behind symlinks
+	// Example: devRealPaths["/dev/sda"] == "from symlink \"/dev/disk/by-id/ata-VendorSSD\""
+	devRealpaths := map[string]string{} // {devNode: origin}
+	for devMatch, devOrigin := range devMatches {
+		realDevNode, err := filepath.EvalSymlinks(devMatch)
+		if err != nil {
+			errors = multierror.Append(errors, fmt.Errorf("cannot filepath.EvalSymlinks(%#v): %w", devMatch, err))
+			continue
+		}
+		if realDevNode != devMatch {
+			origin = fmt.Sprintf("from symlink %#v %v", devMatch, devOrigin)
+		} else {
+			origin = devOrigin
+		}
+		devRealpaths[realDevNode] = strings.TrimSpace(fmt.Sprintf("%v %v", devRealpaths[realDevNode], origin))
+	}
+
+	// 3. Filter out everything but block devices that are not partitions
+	// Example: blockDevices[0] == {Major: 8, Minor: 0, DevNode: "/dev/sda", Origin: "..."}
+	for devRealpath, devOrigin := range devRealpaths {
+		origin := ""
+		if devOrigin != "" {
+			origin = fmt.Sprintf(" (origin: %s)", devOrigin)
+		}
+		fileInfo, err := os.Stat(devRealpath)
+		if err != nil {
+			errors = multierror.Append(errors, fmt.Errorf("cannot os.Stat(%#v): %w%s", devRealpath, err, origin))
+			continue
+		}
+		fileMode := fileInfo.Mode()
+		if fileMode&os.ModeDevice == 0 {
+			errors = multierror.Append(errors, fmt.Errorf("file %#v is not a device%s", devRealpath, origin))
+			continue
+		}
+		if fileMode&os.ModeCharDevice != 0 {
+			errors = multierror.Append(errors, fmt.Errorf("file %#v is a character device%s", devRealpath, origin))
+			continue
+		}
+		sys, ok := fileInfo.Sys().(*syscall.Stat_t)
+		major := unix.Major(sys.Rdev)
+		minor := unix.Minor(sys.Rdev)
+		if !ok {
+			errors = multierror.Append(errors, fmt.Errorf("cannot get syscall stat_t from %#v: %w%s", devRealpath, err, origin))
+			continue
+		}
+		if minor&0xf != 0 {
+			errors = multierror.Append(errors, fmt.Errorf("skipping %#v: cannot weight/throttle partitions%s", devRealpath, origin))
+			continue
+		}
+		blockDevices = append(blockDevices, BlockDeviceInfo{
+			Major:   int64(major),
+			Minor:   int64(minor),
+			DevNode: devRealpath,
+			Origin:  devOrigin,
+		})
+	}
+	return blockDevices, errors.ErrorOrNil()
+}
+
+// blockioError creates a formatted error message.
+func blockioError(format string, args ...interface{}) error {
+	return fmt.Errorf(format, args...)
+}

--- a/pkg/blockio/blockio_test.go
+++ b/pkg/blockio/blockio_test.go
@@ -1,0 +1,298 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockio
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/intel/cri-resource-manager/pkg/cgroups"
+	"github.com/intel/cri-resource-manager/pkg/testutils"
+)
+
+var knownIOSchedulers map[string]bool = map[string]bool{
+	"bfq":         true,
+	"cfq":         true,
+	"deadline":    true,
+	"kyber":       true,
+	"mq-deadline": true,
+	"none":        true,
+	"noop":        true,
+}
+
+// TestGetCurrentIOSchedulers: unit test for getCurrentIOSchedulers()
+func TestGetCurrentIOSchedulers(t *testing.T) {
+	currentIOSchedulers, err := getCurrentIOSchedulers()
+	testutils.VerifyError(t, err, 0, nil)
+	for blockDev, ioScheduler := range currentIOSchedulers {
+		s, ok := knownIOSchedulers[ioScheduler]
+		if !ok || !s {
+			t.Errorf("unknown io scheduler %#v on block device %#v", ioScheduler, blockDev)
+		}
+	}
+}
+
+// TestConfigurableBlockDevices: unit tests for configurableBlockDevices()
+func TestConfigurableBlockDevices(t *testing.T) {
+	sysfsBlockDevs, err := filepath.Glob("/sys/block/*")
+	if err != nil {
+		sysfsBlockDevs = []string{}
+	}
+	devBlockDevs := []string{}
+	for _, sysfsBlockDev := range sysfsBlockDevs {
+		if strings.HasPrefix(sysfsBlockDev, "/sys/block/sd") || strings.HasPrefix(sysfsBlockDev, "/sys/block/vd") {
+			devBlockDevs = append(devBlockDevs, strings.Replace(sysfsBlockDev, "/sys/block/", "/dev/", 1))
+		}
+	}
+	devPartitions := []string{}
+	for _, devBlockDev := range devBlockDevs {
+		devPartitions, _ = filepath.Glob(devBlockDev + "[0-9]")
+		if len(devPartitions) > 0 {
+			break
+		}
+	}
+	t.Logf("test real block devices: %v", devBlockDevs)
+	t.Logf("test partitions: %v", devPartitions)
+	tcases := []struct {
+		name                    string
+		devWildcards            []string
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+		expectedMatches         int
+		disabled                bool
+		disabledReason          string
+	}{
+		{
+			name:               "no device wildcards",
+			devWildcards:       nil,
+			expectedErrorCount: 0,
+		},
+		{
+			name:                    "bad wildcard",
+			devWildcards:            []string{"/[-/verybadwildcard]"},
+			expectedErrorCount:      1,
+			expectedErrorSubstrings: []string{"verybadwildcard", "syntax error"},
+		},
+		{
+			name:                    "not matching wildcard",
+			devWildcards:            []string{"/dev/path that should not exist/*"},
+			expectedErrorCount:      1,
+			expectedErrorSubstrings: []string{"does not match any"},
+		},
+		{
+			name:                    "two wildcards: empty string and a character device",
+			devWildcards:            []string{"/dev/null", ""},
+			expectedErrorCount:      2,
+			expectedErrorSubstrings: []string{"\"/dev/null\" is a character device", "\"\" does not match any"},
+		},
+		{
+			name:                    "not a device or even a file",
+			devWildcards:            []string{"/proc", "/proc/meminfo", "/proc/notexistingfile"},
+			expectedErrorCount:      3,
+			expectedErrorSubstrings: []string{"\"/proc\" is not a device", "\"/proc/meminfo\" is not a device"},
+		},
+		{
+			name:            "real block devices",
+			devWildcards:    devBlockDevs,
+			expectedMatches: len(devBlockDevs),
+		},
+		{
+			name:                    "partition",
+			devWildcards:            devPartitions,
+			expectedErrorCount:      len(devPartitions),
+			expectedErrorSubstrings: []string{"cannot weight/throttle partitions"},
+			disabled:                len(devPartitions) == 0,
+			disabledReason:          "no block device partitions found",
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.disabled {
+				t.Skip(tc.disabledReason)
+			}
+			realPlatform := defaultPlatform{}
+			bdis, err := realPlatform.configurableBlockDevices(tc.devWildcards)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			if len(bdis) != tc.expectedMatches {
+				t.Errorf("expected %d matching block devices, got %d", tc.expectedMatches, len(bdis))
+			}
+		})
+	}
+}
+
+// TestDevicesParametersToOci: unit tests for devicesParametersToOci
+func TestDevicesParametersToOci(t *testing.T) {
+	// switch real devicesParametersToOci to call mockPlatform.configurableBlockDevices
+	currentPlatform = mockPlatform{}
+	tcases := []struct {
+		name                    string
+		dps                     []DevicesParameters
+		iosched                 map[string]string
+		expectedOci             *cgroups.OciBlockIOParameters
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name: "all OCI fields",
+			dps: []DevicesParameters{
+				{
+					Weight: "144",
+				},
+				{
+					Devices:           []string{"/dev/sda"},
+					ThrottleReadBps:   "1G",
+					ThrottleWriteBps:  "2M",
+					ThrottleReadIOPS:  "3k",
+					ThrottleWriteIOPS: "4",
+					Weight:            "50",
+				},
+			},
+			iosched: map[string]string{"/dev/sda": "bfq"},
+			expectedOci: &cgroups.OciBlockIOParameters{
+				Weight: 144,
+				WeightDevice: []cgroups.OciWeightDeviceParameters{
+					{Major: 11, Minor: 12, Weight: 50},
+				},
+				ThrottleReadBpsDevice: []cgroups.OciRateDeviceParameters{
+					{Major: 11, Minor: 12, Rate: 1000000000},
+				},
+				ThrottleWriteBpsDevice: []cgroups.OciRateDeviceParameters{
+					{Major: 11, Minor: 12, Rate: 2000000},
+				},
+				ThrottleReadIOPSDevice: []cgroups.OciRateDeviceParameters{
+					{Major: 11, Minor: 12, Rate: 3000},
+				},
+				ThrottleWriteIOPSDevice: []cgroups.OciRateDeviceParameters{
+					{Major: 11, Minor: 12, Rate: 4},
+				},
+			},
+		},
+		{
+			name: "later match overrides value",
+			dps: []DevicesParameters{
+				{
+					Devices:         []string{"/dev/sda", "/dev/sdb", "/dev/sdc"},
+					ThrottleReadBps: "100",
+					Weight:          "110",
+				},
+				{
+					Devices:         []string{"/dev/sdb", "/dev/sdc"},
+					ThrottleReadBps: "300",
+					Weight:          "330",
+				},
+				{
+					Devices:         []string{"/dev/sdb"},
+					ThrottleReadBps: "200",
+					Weight:          "220",
+				},
+			},
+			iosched: map[string]string{"/dev/sda": "bfq", "/dev/sdb": "bfq", "/dev/sdc": "cfq"},
+			expectedOci: &cgroups.OciBlockIOParameters{
+				Weight: -1,
+				WeightDevice: []cgroups.OciWeightDeviceParameters{
+					{Major: 11, Minor: 12, Weight: 110},
+					{Major: 21, Minor: 22, Weight: 220},
+					{Major: 31, Minor: 32, Weight: 330},
+				},
+				ThrottleReadBpsDevice: []cgroups.OciRateDeviceParameters{
+					{Major: 11, Minor: 12, Rate: 100},
+					{Major: 21, Minor: 22, Rate: 200},
+					{Major: 31, Minor: 32, Rate: 300},
+				},
+			},
+		},
+		{
+			name: "invalid weights, many errors in different parameter sets",
+			dps: []DevicesParameters{
+				{
+					Weight: "99999",
+				},
+				{
+					Devices: []string{"/dev/sda"},
+					Weight:  "1",
+				},
+				{
+					Devices: []string{"/dev/sdb"},
+					Weight:  "-2",
+				},
+			},
+			expectedErrorCount: 3,
+			expectedErrorSubstrings: []string{
+				"(99999) bigger than maximum",
+				"(1) smaller than minimum",
+				"(-2) smaller than minimum",
+			},
+		},
+		{
+			name: "throttling without listing Devices",
+			dps: []DevicesParameters{
+				{
+					ThrottleReadBps:   "100M",
+					ThrottleWriteIOPS: "20k",
+				},
+			},
+			expectedErrorCount: 1,
+			expectedErrorSubstrings: []string{
+				"Devices not listed",
+				"\"100M\"",
+				"\"20k\"",
+			},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			oci, err := devicesParametersToOci(tc.dps, tc.iosched)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			if tc.expectedOci != nil {
+				testutils.VerifyDeepEqual(t, "OCI parameters", *tc.expectedOci, oci)
+			}
+		})
+	}
+}
+
+// mockPlatform implements mock versions of platformInterface functions.
+type mockPlatform struct{}
+
+// configurableBlockDevices mock always returns a set of block devices.
+func (mpf mockPlatform) configurableBlockDevices(devWildcards []string) ([]BlockDeviceInfo, error) {
+	blockDevices := []BlockDeviceInfo{}
+	for _, devWildcard := range devWildcards {
+		if devWildcard == "/dev/sda" {
+			blockDevices = append(blockDevices, BlockDeviceInfo{
+				Major:   11,
+				Minor:   12,
+				DevNode: devWildcard,
+				Origin:  fmt.Sprintf("from wildcards %v", devWildcard),
+			})
+		} else if devWildcard == "/dev/sdb" {
+			blockDevices = append(blockDevices, BlockDeviceInfo{
+				Major:   21,
+				Minor:   22,
+				DevNode: devWildcard,
+				Origin:  fmt.Sprintf("from wildcards %v", devWildcard),
+			})
+		} else if devWildcard == "/dev/sdc" {
+			blockDevices = append(blockDevices, BlockDeviceInfo{
+				Major:   31,
+				Minor:   32,
+				DevNode: devWildcard,
+				Origin:  fmt.Sprintf("from wildcards %v", devWildcard),
+			})
+		}
+	}
+	return blockDevices, nil
+}

--- a/pkg/blockio/config.go
+++ b/pkg/blockio/config.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockio
+
+import (
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+)
+
+// options captures our configurable parameters.
+type options struct {
+	// Classes define weights and throttling parameters for sets of devices.
+	Classes map[string][]DevicesParameters `json:",omitempty"`
+}
+
+// DevicesParameters defines Block IO parameters for a set of devices.
+type DevicesParameters struct {
+	Devices           []string `json:",omitempty"`
+	ThrottleReadBps   string   `json:",omitempty"`
+	ThrottleWriteBps  string   `json:",omitempty"`
+	ThrottleReadIOPS  string   `json:",omitempty"`
+	ThrottleWriteIOPS string   `json:",omitempty"`
+	Weight            string   `json:",omitempty"`
+}
+
+// Currently active set of "raw" options
+var opt = defaultOptions().(*options)
+
+// defaultOptions returns a new instance of "raw" options set to their defaults
+func defaultOptions() interface{} {
+	return &options{}
+}
+
+func init() {
+	pkgcfg.Register("blockio", "BlockIO control", opt, defaultOptions)
+}

--- a/pkg/cgroups/cgroupblkio.go
+++ b/pkg/cgroups/cgroupblkio.go
@@ -1,0 +1,179 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+const (
+	blkioCgroupDir = "/sys/fs/cgroup/blkio/"
+)
+
+// logger
+var log logger.Logger = logger.NewLogger("cgroupblkio")
+
+// cgroups blkio parameter filenames.
+var blkioWeightFiles = []string{"blkio.bfq.weight", "blkio.weight"}
+var blkioWeightDeviceFiles = []string{"blkio.bfq.weight_device", "blkio.weight_device"}
+var blkioThrottleReadBpsFiles = []string{"blkio.throttle.read_bps_device"}
+var blkioThrottleWriteBpsFiles = []string{"blkio.throttle.write_bps_device"}
+var blkioThrottleReadIOPSFiles = []string{"blkio.throttle.read_iops_device"}
+var blkioThrottleWriteIOPSFiles = []string{"blkio.throttle.write_iops_device"}
+
+// OciBlockIOParameters contains OCI standard configuration of cgroups blkio parameters.
+//
+// Effects of Weight and Rate values in SetBlkioParameters():
+// Value  |  Effect
+// -------+-------------------------------------------------------------------
+//    -1  |  Do not write to cgroups, value is missing
+//     0  |  Write to cgroups, will remove the setting as specified in cgroups blkio interface
+//  other |  Write to cgroups, sets the value
+type OciBlockIOParameters struct {
+	Weight                  int64
+	WeightDevice            []OciWeightDeviceParameters
+	ThrottleReadBpsDevice   []OciRateDeviceParameters
+	ThrottleWriteBpsDevice  []OciRateDeviceParameters
+	ThrottleReadIOPSDevice  []OciRateDeviceParameters
+	ThrottleWriteIOPSDevice []OciRateDeviceParameters
+}
+
+// OciWeightDeviceParameters contains values for
+// - blkio.[io-scheduler].weight
+type OciWeightDeviceParameters struct {
+	Major  int64
+	Minor  int64
+	Weight int64
+}
+
+// OciRateDeviceParameters contains values for
+// - blkio.throttle.read_bps_device
+// - blkio.throttle.write_bps_device
+// - blkio.throttle.read_iops_device
+// - blkio.throttle.write_iops_device
+type OciRateDeviceParameters struct {
+	Major int64
+	Minor int64
+	Rate  int64
+}
+
+// NewOciBlockIOParameters creates new OciBlockIOParameters instance.
+func NewOciBlockIOParameters() OciBlockIOParameters {
+	return OciBlockIOParameters{
+		Weight: -1,
+	}
+}
+
+// NewOciWeightDeviceParametes creates new OciWeightDeviceParameters instance.
+func NewOciWeightDeviceParametes() OciWeightDeviceParameters {
+	return OciWeightDeviceParameters{
+		Major:  -1,
+		Minor:  -1,
+		Weight: -1,
+	}
+}
+
+// NewOciRateDeviceParameters creates new OciRateDeviceParameters instance.
+func NewOciRateDeviceParameters() OciRateDeviceParameters {
+	return OciRateDeviceParameters{
+		Major: -1,
+		Minor: -1,
+		Rate:  -1,
+	}
+}
+
+// GetBlkioDir returns the cgroups blkio controller directory.
+func GetBlkioDir() string {
+	return blkioCgroupDir
+}
+
+// SetBlkioParameters writes OCI BlockIO parameters to files in cgroups blkio contoller directory.
+func SetBlkioParameters(cgroupsDir string, blockIO OciBlockIOParameters) error {
+	log.Debug("configuring cgroups blkio controller in directory %#v with parameters %+v", cgroupsDir, blockIO)
+	var errors *multierror.Error
+	if blockIO.Weight >= 0 {
+		errors = multierror.Append(errors, writeToFileInDir(cgroupsDir, blkioWeightFiles, strconv.FormatInt(blockIO.Weight, 10)))
+	}
+	for _, weightDevice := range blockIO.WeightDevice {
+		errors = multierror.Append(errors, writeDevValueToFileInDir(cgroupsDir, blkioWeightDeviceFiles, weightDevice.Major, weightDevice.Minor, weightDevice.Weight))
+	}
+	for _, rateDevice := range blockIO.ThrottleReadBpsDevice {
+		errors = multierror.Append(errors, writeDevValueToFileInDir(cgroupsDir, blkioThrottleReadBpsFiles, rateDevice.Major, rateDevice.Minor, rateDevice.Rate))
+	}
+	for _, rateDevice := range blockIO.ThrottleWriteBpsDevice {
+		errors = multierror.Append(errors, writeDevValueToFileInDir(cgroupsDir, blkioThrottleWriteBpsFiles, rateDevice.Major, rateDevice.Minor, rateDevice.Rate))
+	}
+	for _, rateDevice := range blockIO.ThrottleReadIOPSDevice {
+		errors = multierror.Append(errors, writeDevValueToFileInDir(cgroupsDir, blkioThrottleReadIOPSFiles, rateDevice.Major, rateDevice.Minor, rateDevice.Rate))
+	}
+	for _, rateDevice := range blockIO.ThrottleWriteIOPSDevice {
+		errors = multierror.Append(errors, writeDevValueToFileInDir(cgroupsDir, blkioThrottleWriteIOPSFiles, rateDevice.Major, rateDevice.Minor, rateDevice.Rate))
+	}
+	return errors.ErrorOrNil()
+}
+
+// writeDevValueToFileInDir writes MAJOR:MINOR VALUE to the first existing file under baseDir
+func writeDevValueToFileInDir(baseDir string, filenames []string, major, minor, value int64) error {
+	content := fmt.Sprintf("%d:%d %d", major, minor, value)
+	return writeToFileInDir(baseDir, filenames, content)
+}
+
+// writeToFileInDir writes content to the first existing file in the list under baseDir.
+func writeToFileInDir(baseDir string, filenames []string, content string) error {
+	var errors *multierror.Error
+	// Returns list of errors from writes, list of single error due to all filenames missing or nil on success.
+	for _, filename := range filenames {
+		filepath := filepath.Join(baseDir, filename)
+		err := currentPlatform.writeToFile(filepath, content)
+		if err == nil {
+			return nil
+		}
+		errors = multierror.Append(errors, err)
+	}
+	err := errors.ErrorOrNil()
+	if err != nil {
+		return fmt.Errorf("could not write content %#v to any of files %q: %w", content, filenames, err)
+	}
+	return nil
+}
+
+// platformInterface includes functions that access the system. Enables mocking the platform.
+type platformInterface interface {
+	writeToFile(filename string, content string) error
+}
+
+// defaultPlatform versions of platformInterface functions access the underlying system.
+type defaultPlatform struct{}
+
+// currentPlatform defines which platformInterface is used: defaultPlatform or a mock, for instance.
+var currentPlatform platformInterface = defaultPlatform{}
+
+// writeToFile writes content to an existing file.
+func (dpm defaultPlatform) writeToFile(filename string, content string) error {
+	f, err := os.OpenFile(filename, os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = fmt.Fprintf(f, content)
+	return err
+}

--- a/pkg/cgroups/cgroupblkio_test.go
+++ b/pkg/cgroups/cgroupblkio_test.go
@@ -1,0 +1,141 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/intel/cri-resource-manager/pkg/testutils"
+)
+
+// TestSetBlkioParameters: unit test for SetBlkioParameters()
+func TestSetBlkioParameters(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		cgroupsDir              string
+		blockIO                 OciBlockIOParameters
+		writesFail              int
+		expectedFsWrites        map[string]string
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:       "write full OCI struct",
+			cgroupsDir: "/my/full",
+			blockIO: OciBlockIOParameters{
+				Weight:                  10,
+				WeightDevice:            []OciWeightDeviceParameters{{Major: 1, Minor: 2, Weight: 3}},
+				ThrottleReadBpsDevice:   []OciRateDeviceParameters{{Major: 11, Minor: 12, Rate: 13}},
+				ThrottleWriteBpsDevice:  []OciRateDeviceParameters{{Major: 21, Minor: 22, Rate: 23}},
+				ThrottleReadIOPSDevice:  []OciRateDeviceParameters{{Major: 31, Minor: 32, Rate: 33}},
+				ThrottleWriteIOPSDevice: []OciRateDeviceParameters{{Major: 41, Minor: 42, Rate: 43}},
+			},
+			expectedFsWrites: map[string]string{
+				"/my/full/blkio.bfq.weight":                 "10",
+				"/my/full/blkio.bfq.weight_device":          "1:2 3",
+				"/my/full/blkio.throttle.read_bps_device":   "11:12 13",
+				"/my/full/blkio.throttle.write_bps_device":  "21:22 23",
+				"/my/full/blkio.throttle.read_iops_device":  "31:32 33",
+				"/my/full/blkio.throttle.write_iops_device": "41:42 43",
+			},
+		},
+		{
+			name:       "write empty struct",
+			cgroupsDir: "/my/empty",
+			blockIO:    OciBlockIOParameters{},
+			expectedFsWrites: map[string]string{
+				"/my/empty/blkio.bfq.weight": "0",
+			},
+		},
+		{
+			name:       "multidevice weight and throttling, no weight write on -1",
+			cgroupsDir: "/my/multidev",
+			blockIO: OciBlockIOParameters{
+				Weight:                  -1,
+				WeightDevice:            []OciWeightDeviceParameters{{1, 2, 3}, {4, 5, 6}},
+				ThrottleReadBpsDevice:   []OciRateDeviceParameters{{11, 12, 13}, {111, 112, 113}},
+				ThrottleWriteBpsDevice:  []OciRateDeviceParameters{{21, 22, 23}, {221, 222, 223}},
+				ThrottleReadIOPSDevice:  []OciRateDeviceParameters{{31, 32, 33}, {331, 332, 333}},
+				ThrottleWriteIOPSDevice: []OciRateDeviceParameters{{41, 42, 43}, {441, 442, 443}},
+			},
+			expectedFsWrites: map[string]string{
+				"/my/multidev/blkio.bfq.weight_device":          "1:2 3+4:5 6",
+				"/my/multidev/blkio.throttle.read_bps_device":   "11:12 13+111:112 113",
+				"/my/multidev/blkio.throttle.write_bps_device":  "21:22 23+221:222 223",
+				"/my/multidev/blkio.throttle.read_iops_device":  "31:32 33+331:332 333",
+				"/my/multidev/blkio.throttle.write_iops_device": "41:42 43+441:442 443",
+			},
+		},
+		{
+			name:             "no bfq.weight",
+			cgroupsDir:       "/my/nobfq",
+			blockIO:          OciBlockIOParameters{Weight: 100},
+			writesFail:       1,
+			expectedFsWrites: map[string]string{"/my/nobfq/blkio.weight": "100"},
+		},
+		{
+			name:       "all writes fail",
+			cgroupsDir: "/my/writesfail",
+			blockIO: OciBlockIOParameters{
+				Weight:       -1,
+				WeightDevice: []OciWeightDeviceParameters{{1, 0, 100}},
+			},
+			writesFail:         9999,
+			expectedErrorCount: 1,
+			expectedErrorSubstrings: []string{
+				"could not write content \"1:0 100\" to any of files",
+				"\"blkio.bfq.weight_device\"",
+				"\"blkio.weight_device\"",
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mpf := mockPlatform{
+				fsWrites:   make(map[string]string),
+				writesFail: tc.writesFail,
+			}
+			currentPlatform = &mpf
+			err := SetBlkioParameters(tc.cgroupsDir, tc.blockIO)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			if tc.expectedFsWrites != nil {
+				testutils.VerifyDeepEqual(t, "filesystem writes", tc.expectedFsWrites, mpf.fsWrites)
+			}
+		})
+	}
+}
+
+// mockPlatform implements mock versions of platformInterface functions.
+type mockPlatform struct {
+	fsWrites   map[string]string
+	writesFail int
+}
+
+func (mpf *mockPlatform) writeToFile(filename string, content string) error {
+	var newContent string
+	if mpf.writesFail > 0 {
+		mpf.writesFail--
+		return fmt.Errorf("mockPlatform: writing to %#v failed", filename)
+	}
+	if oldContent, ok := mpf.fsWrites[filename]; ok {
+		newContent = fmt.Sprintf("%s+%s", oldContent, content)
+	} else {
+		newContent = content
+	}
+	mpf.fsWrites[filename] = newContent
+	return nil
+}

--- a/pkg/cri/resource-manager/control/blockio/blockio.go
+++ b/pkg/cri/resource-manager/control/blockio/blockio.go
@@ -17,12 +17,12 @@ package blockio
 import (
 	"fmt"
 
+	"github.com/intel/cri-resource-manager/pkg/blockio"
 	"github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/client"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
-	"github.com/intel/cri-resource-manager/pkg/utils"
 )
 
 const (
@@ -30,48 +30,52 @@ const (
 	BlockIOController = cache.BlockIO
 )
 
-// blockio encapsulates the runtime state of our block I/O enforcment/controller.
-type blockio struct {
+// blockio encapsulates the runtime state of our block I/O enforcement/controller.
+type blockioctl struct {
 	cache cache.Cache // resource manager cache
 }
-
-// Our singleton block I/O controller instance.
-var singleton *blockio
 
 // Our logger instance.
 var log logger.Logger = logger.NewLogger(BlockIOController)
 
+// Our singleton block I/O controller instance.
+var singleton *blockioctl
+
 // getBlockIOController returns our singleton block I/O controller instance.
 func getBlockIOController() control.Controller {
 	if singleton == nil {
-		singleton = &blockio{}
+		singleton = &blockioctl{}
 	}
 	return singleton
 }
 
 // Start initializes the controller for enforcing decisions.
-func (ctl *blockio) Start(cache cache.Cache, client client.Client) error {
+func (ctl *blockioctl) Start(cache cache.Cache, client client.Client) error {
+	if err := blockio.Initialize(); err != nil {
+		return blockioError("failed to initialize BlockIO controls: %w", err)
+	}
+
 	ctl.cache = cache
 
 	return nil
 }
 
 // Stop shuts down the controller.
-func (ctl *blockio) Stop() {
+func (ctl *blockioctl) Stop() {
 }
 
 // PreCreateHook is the block I/O controller pre-create hook.
-func (ctl *blockio) PreCreateHook(c cache.Container) error {
+func (ctl *blockioctl) PreCreateHook(c cache.Container) error {
 	return nil
 }
 
 // PreStartHook is the block I/O controller pre-start hook.
-func (ctl *blockio) PreStartHook(c cache.Container) error {
+func (ctl *blockioctl) PreStartHook(c cache.Container) error {
 	return nil
 }
 
 // PostStartHook is the block I/O controller post-start hook.
-func (ctl *blockio) PostStartHook(c cache.Container) error {
+func (ctl *blockioctl) PostStartHook(c cache.Container) error {
 	// Notes:
 	//   Unlike in our PostUpdateHook, we don't bail out here if
 	//   there are no pending block I/O changes for the container.
@@ -86,7 +90,7 @@ func (ctl *blockio) PostStartHook(c cache.Container) error {
 }
 
 // PostUpdateHook is the block I/O controller post-update hook.
-func (ctl *blockio) PostUpdateHook(c cache.Container) error {
+func (ctl *blockioctl) PostUpdateHook(c cache.Container) error {
 	if !c.HasPending(BlockIOController) {
 		return nil
 	}
@@ -98,63 +102,55 @@ func (ctl *blockio) PostUpdateHook(c cache.Container) error {
 }
 
 // PostStop is the block I/O controller post-stop hook.
-func (ctl *blockio) PostStopHook(c cache.Container) error {
+func (ctl *blockioctl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
 // assign assigns the container to the given block I/O class.
-func (ctl *blockio) assign(c cache.Container, class string) error {
+func (ctl *blockioctl) assign(c cache.Container, class string) error {
 	if class == "" {
+		log.Debug("skip handling container %s: no matching block I/O class", c.PrettyName())
 		return nil
 	}
 
-	pod, ok := c.GetPod()
-	if !ok {
-		return blockioError("failed to get Pod for %s", c.PrettyName())
-	}
-
-	pids, err := utils.GetProcessInContainer(pod.GetCgroupParentDir(), c.GetID())
-	if err != nil {
-		return blockioError("failed to get process list of %s: %v", c.PrettyName(), err)
-	}
-
-	for _, pid := range pids {
-		log.Info(" *** should assign pid %s to block I/O class %s...", pid, class)
+	if err := blockio.SetContainerClass(c, class); err != nil {
+		return blockioError("assigning container %v to class %#v failed: %w", c.PrettyName(), class, err)
 	}
 
 	log.Info("container %s assigned to class %s", c.PrettyName(), class)
-
 	return nil
 }
 
-// BlockIOClass determines the effective block I/O class for a container.
-func (ctl *blockio) BlockIOClass(c cache.Container) string {
+// BlockIOClass determines the effective BlockIO class for a container.
+func (ctl *blockioctl) BlockIOClass(c cache.Container) string {
 	cclass := c.GetBlockIOClass()
 	if cclass == "" {
 		cclass = string(c.GetQOSClass())
 	}
-
-	bioclass, ok := opt.Classes[cclass]
+	blockioclass, ok := opt.Classes[cclass]
 	if !ok {
-		if bioclass, ok = opt.Classes["*"]; !ok {
-			bioclass = cclass
+		if blockioclass, ok = opt.Classes["*"]; !ok {
+			blockioclass = cclass
 		}
 	}
 
-	log.Debug("block I/O class for %s (%s): %q", c.PrettyName(), cclass, bioclass)
+	log.Debug("BlockIO class for %s (%s): %q", c.PrettyName(), cclass, blockioclass)
 
-	return bioclass
+	return blockioclass
 }
 
-// configNotify is our runtime configuration notification callback.
-func (ctl *blockio) configNotify(event config.Event, source config.Source) error {
-	log.Info("configuration updated")
+// configNotify is blockio class mapping configuration notification callback.
+func (ctl *blockioctl) configNotify(event config.Event, source config.Source) error {
+	// BlockIO class mapping in opt (in flags.go) has changed.
+	// It will affect only new pods. cgroupsblkio parameters of running pods
+	// is not changed.
+	log.Info("class mapping configuration updated")
 	return nil
 }
 
-// blockioError creates an block I/O-controller-specific formatted error message.
+// blockioError creates a block I/O-controller-specific formatted error message.
 func blockioError(format string, args ...interface{}) error {
-	return fmt.Errorf("block I/O: "+format, args...)
+	return fmt.Errorf("blockio: "+format, args...)
 }
 
 // Register us as a controller.

--- a/pkg/cri/resource-manager/control/blockio/flags.go
+++ b/pkg/cri/resource-manager/control/blockio/flags.go
@@ -20,7 +20,7 @@ import (
 
 // options captures our configurable parameters.
 type options struct {
-	// Class is a assigned to actual RDT class map.
+	// Classes assigned to actual blockio classes, for example Guaranteed -> HighPrioNoThrottling.
 	Classes map[string]string `json:",omitempty"`
 }
 
@@ -29,11 +29,13 @@ var opt = defaultOptions().(*options)
 
 // defaultOptions returns a new options instance, all initialized to defaults.
 func defaultOptions() interface{} {
-	return &options{Classes: make(map[string]string)}
+	return &options{
+		Classes: make(map[string]string),
+	}
 }
 
 // Register us for configuration handling.
 func init() {
 	config.Register("resource-manager.blockio", configHelp, opt, defaultOptions,
-		config.WithNotify(getBlockIOController().(*blockio).configNotify))
+		config.WithNotify(getBlockIOController().(*blockioctl).configNotify))
 }

--- a/pkg/testutils/verify.go
+++ b/pkg/testutils/verify.go
@@ -1,0 +1,49 @@
+package testutils
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// VerifyDeepEqual checks that two values (including structures) are equal, or else it fails the test.
+func VerifyDeepEqual(t *testing.T, valueName string, expectedValue interface{}, seenValue interface{}) bool {
+	if reflect.DeepEqual(expectedValue, seenValue) {
+		return true
+	}
+	t.Errorf("expected %s value %+v, got %+v", valueName, expectedValue, seenValue)
+	return false
+}
+
+// VerifyError checks a (multi)error has expected properties, or else it fails the test.
+func VerifyError(t *testing.T, err error, expectedCount int, expectedSubstrings []string) bool {
+	if expectedCount > 0 {
+		if err == nil {
+			t.Errorf("error expected, got nil")
+			return false
+		}
+		merr, ok := err.(*multierror.Error)
+		if !ok {
+			t.Errorf("expected %d errors, but got %#v instead of multierror", expectedCount, err)
+			return false
+		}
+		if len(merr.Errors) != expectedCount {
+			t.Errorf("expected %d errors, but got %d: %v", expectedCount, len(merr.Errors), merr)
+			return false
+		}
+
+	} else if expectedCount == 0 {
+		if err != nil {
+			t.Errorf("expected 0 errors, but got %v", err)
+			return false
+		}
+	}
+	for _, substring := range expectedSubstrings {
+		if !strings.Contains(err.Error(), substring) {
+			t.Errorf("expected error with substring %#v, got \"%v\"", substring, err)
+		}
+	}
+	return true
+}

--- a/sample-configs/blockio.cfg
+++ b/sample-configs/blockio.cfg
@@ -1,0 +1,55 @@
+# This configuration demonstrates how to configure cgroups block io
+# controller for pods.
+#
+# The configuration defines block device parameters for three blockio
+# classes (LowPrioThrottled, HighPrioFullSpeed and Default, feel free
+# to choose any names here). Finally resource-manager.blockio maps QOS
+# classes BestEffort, Burstable (via wildcard), and Guaranteed to
+# these classes.
+#
+# Try with: cri-resmgr -force-config blockio.cfg
+
+policy:
+  Active: none
+
+blockio:
+  Classes:
+    LowPrioThrottled:
+      # Default io-scheduler weight for all devices that are not
+      # explicitly mentioned in following items.
+      - Weight: 80 # will be written to cgroups(.bfq).weight
+
+      # Configuration for all virtio and scsi block devices.
+      - Devices:
+          - /dev/vd*
+          - /dev/sd*
+        ThrottleReadBps: 50M   # max read bytes per second
+        ThrottleWriteBps: 10M  # max write bytes per second
+        ThrottleReadIOPS: 10k  # max read io operations per second
+        ThrottleWriteIOPS: 5k  # max write io operations per second
+        Weight: 50             # io-scheduler (cfq/bfq) weight for these devices,
+                               # will be written to cgroups(.bfq).weight_device
+
+      # Configuration for SSD devices.
+      # This overrides above configuration for those /dev/sd* devices
+      # whose disk id contains "SSD"
+      - Devices:
+          - /dev/disk/by-id/*SSD*
+        ThrottleReadBps: 100M
+        ThrottleWriteBps: 40M
+        # Not mentioning Throttle*IOPS means no io operations throttling for matching devices.
+        Weight: 50
+
+    HighPrioFullSpeed:
+      - Weight: 400
+
+    # Default for any other QOS class
+    Default:
+      - Weight: 100
+
+resource-manager:
+  blockio:
+    Classes:
+      BestEffort: LowPrioThrottled
+      Guaranteed: HighPrioFullSpeed
+      "*": Default


### PR DESCRIPTION
- Assign cgroup blkio parameters to containers according to pod's
  block I/O or QOS class.
- Support cgroup v1.
- Support static configuration: existing block devices are scanned
  only on configNotify to keep pod launch overhead minimal.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>