### PR TITLE
rdt: un-export Control interface

### DIFF
--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Info contains information about the RDT support in the system
-type Info struct {
+type info struct {
 	resctrlPath string
 	numClosids  uint64
 	cacheIds    []uint64
@@ -51,17 +51,17 @@ type mbInfo struct {
 }
 
 // l3Info is a helper method for a "unified API" for getting L3 information
-func (i Info) l3Info() l3Info {
+func (i info) l3Info() l3Info {
 	switch {
 	case i.l3code.Supported():
-		return rdtInfo.l3code
+		return i.l3code
 	case i.l3data.Supported():
-		return rdtInfo.l3data
+		return i.l3data
 	}
-	return rdtInfo.l3
+	return i.l3
 }
 
-func (i Info) l3CbmMask() Bitmask {
+func (i info) l3CbmMask() Bitmask {
 	mask := i.l3Info().cbmMask
 	if mask != 0 {
 		return mask
@@ -69,13 +69,13 @@ func (i Info) l3CbmMask() Bitmask {
 	return Bitmask(^uint64(0))
 }
 
-func (i Info) l3MinCbmBits() uint64 {
+func (i info) l3MinCbmBits() uint64 {
 	return i.l3Info().minCbmBits
 }
 
-func getRdtInfo(resctrlpath string) (Info, error) {
+func getRdtInfo(resctrlpath string) (info, error) {
 	var err error
-	info := Info{resctrlPath: resctrlpath}
+	info := info{resctrlPath: resctrlpath}
 
 	// Check that RDT is available
 	infopath := filepath.Join(resctrlpath, "info")

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -22,6 +22,21 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// TestRdt tests the rdt public API, i.e. exported functionality of the package
+func TestRdt(t *testing.T) {
+	// Test uninitialized interface
+	rdt = &control{Logger: log}
+
+	cls := GetClasses()
+	if len(cls) != 0 {
+		t.Errorf("uninitialized rdt contains classes %s", cls)
+	}
+
+	if err := SetProcessClass("class-name", "1234"); err == nil {
+		t.Errorf("expected an error when setting rdt class via an uninitialized interface")
+	}
+}
+
 func TestBitMap(t *testing.T) {
 	// Test ListStr()
 	testSet := map[Bitmask]string{


### PR DESCRIPTION
The resctrl API is essentially a singleton on the system level, thus,
there should be no reason to have multiple RDT separate control
interfaces in CRI-RM, either. This drops the 'Control' interface and
replaces that with "singleton" functions.

Also, add minimal unit test for the public interface, testing that an
uninitialized rdt interface works as expected.