### PR TITLE
fix: don't print warnings about successful  CPU online status discovery.

### DIFF
--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -487,7 +487,6 @@ func (sys *system) discoverCPU(path string) error {
 	cpu.isolated = sys.isolated.Has(cpu.id)
 
 	if online, err := readSysfsEntry(path, "online", nil); err == nil {
-		sys.Warn("CPU %s online status: %s", cpu.path, online)
 		cpu.online = (online != "" && online[0] != '0')
 	}
 


### PR DESCRIPTION
A one-liner fix to omit annoying and useless discovery time warnings.