### PR TITLE
rdt: drop 'resctrl-path' config option and cmdline flag

### DIFF
--- a/pkg/cri/resource-manager/control/rdt/doc.go
+++ b/pkg/cri/resource-manager/control/rdt/doc.go
@@ -30,7 +30,6 @@ Here is a sample configuration fragment for this controller which sets up
 mappings for the 3 Kubernetes QoS classes and defines also a default class.
 
   rdt:
-    ResctrlPath: /sys/fs/resctrl
     Classes:
       Guaranteed: BestRDT
       Burstable: ModerateRDT

--- a/pkg/cri/resource-manager/control/rdt/flags.go
+++ b/pkg/cri/resource-manager/control/rdt/flags.go
@@ -15,10 +15,7 @@
 package rdt
 
 import (
-	"flag"
-
 	"github.com/intel/cri-resource-manager/pkg/config"
-	"github.com/intel/cri-resource-manager/pkg/rdt"
 )
 
 // options captures our configurable parameters.
@@ -31,30 +28,16 @@ type options struct {
 
 // Our runtime configuration.
 var opt = defaultOptions().(*options)
-var defaultPath string
-
-// resctrlPath returns the default path for the resctrl pseudo-filesystem mount point.
-func resctrlPath() string {
-	if defaultPath != "" {
-		return defaultPath
-	}
-	path, _ := rdt.ResctrlMountPath()
-	return path
-}
 
 // defaultOptions returns a new options instance, all initialized to defaults.
 func defaultOptions() interface{} {
 	return &options{
-		ResctrlPath: resctrlPath(),
-		Classes:     make(map[string]string),
+		Classes: make(map[string]string),
 	}
 }
 
 // Register command line options and for configuration handling.
 func init() {
-	flag.StringVar(&defaultPath, "resctrl-path", resctrlPath(),
-		"Path of the resctrl filesystem mountpoint")
-
 	config.Register("resource-manager.rdt", configHelp, opt, defaultOptions,
 		config.WithNotify(getRDTController().(*rdtctl).configNotify))
 }

--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -53,7 +53,7 @@ func getRDTController() control.Controller {
 
 // Start initializes the controller for enforcing decisions.
 func (ctl *rdtctl) Start(cache cache.Cache, client client.Client) error {
-	if err := rdt.Initialize(opt.ResctrlPath); err != nil {
+	if err := rdt.Initialize(); err != nil {
 		return rdtError("failed to initialize RDT controls: %v", err)
 	}
 

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -54,13 +54,13 @@ var rdt *control = &control{
 // NOTE: should only be called once in order to avoid adding multiple notifiers
 // TODO: support make multiple initializations, allowing e.g. "hot-plug" when
 // 		 resctrl filesystem is mounted
-func Initialize(resctrlpath string) error {
+func Initialize() error {
 	var err error
 
 	rdt = &control{Logger: log}
 
 	// Get info from the resctrl filesystem
-	rdt.info, err = getRdtInfo(resctrlpath)
+	rdt.info, err = getRdtInfo()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The option is rather useless because in practice we depend on
(auto-)detecting the resctrl mount (options and mount point), anyway,
for determining the mode (percentage or MBPs) of MB allocation.
Simplifies the code and hopefully reduces confusion of the end users.