### PR TITLE
Makefile: fix discovery of protoc command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_TEST   := $(GO_CMD) test $(TEST_TAGS)
 GO_CILINT_CHECKERS := -D unused,staticcheck,errcheck,deadcode,structcheck,gosimple -E golint,gofmt
 
 # Protoc compiler and protobuf definitions we might need to recompile.
-PROTOC    := $(shell command -v protoc)
+PROTOC    := $(shell command -v protoc;)
 PROTOBUFS  = $(shell find cmd pkg -name \*.proto)
 PROTOCODE := $(patsubst %.proto,%.pb.go,$(PROTOBUFS))
 


### PR DESCRIPTION
On systems where 'command' is only available as a shell built-in. Adding
the semicolon causes gmake to invoke a true shell environment and the
command succeeds. Without this fix protoc utility is not found correctly
and every invocation of 'make' causes annoying
"make: command: Command not found"
to be printed in the terminal.