### PR TITLE
pkg/log: make EnableDebug() effective immediately

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -276,6 +276,7 @@ func ErrorBlock(prefix string, format string, args ...interface{}) {
 // EnableDebug controls debugging for the logger and returns the its previous debugging state.
 func (l *logger) EnableDebug(enable bool) bool {
 	previous := l.debug
+	l.debug = enable
 	opt.Debug.Set(l.source + ":" + map[bool]string{false: "false", true: "true"}[enable])
 	return previous
 }


### PR DESCRIPTION
Without jumping through all the configuration related hoops in order to
change the logger state. Helps writing/analyzing unit tests by making it
easy to enable debug logging.