### PR TITLE
Makefile: add race-test target for race detection in a single dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,19 @@ else
             exit $$rc
 endif
 
+race-test racetest:
+ifndef WHAT
+	$(Q)$(GO_TEST) -race -coverprofile=coverage.txt -covermode=atomic \
+	    $(GO_MODULES)
+else
+	$(Q)cd $(WHAT) && \
+	    $(GO_TEST) -race -coverprofile=cover.out -covermode=atomic || rc=1; \
+            $(GO_CMD) tool cover -html=cover.out -o coverage.html; \
+            rm cover.out; \
+            echo "Coverage report: file://$$(realpath coverage.html)"; \
+            exit $$rc
+endif
+
 #
 # Rule for building dist-tarballs, SPEC files, RPMs, debian collateral, deb's.
 #


### PR DESCRIPTION
Add `race-test` target to run non-verbose tests with race detection enabled in
a single directory. Use as
```
    make WHAT=dir/to/test race-test
```
If `WHAT` is ommitted `race-test` is identical to `test`.