### PR TITLE
instrumentation: create new Jaeger Exporter on (re-start)

### DIFF
--- a/pkg/instrumentation/jaeger.go
+++ b/pkg/instrumentation/jaeger.go
@@ -53,4 +53,5 @@ func (s *Service) stopJaegerExporter() {
 	if s.jexport != nil {
 		trace.UnregisterExporter(s.jexport)
 	}
+	s.jexport = nil
 }

--- a/pkg/instrumentation/service.go
+++ b/pkg/instrumentation/service.go
@@ -117,6 +117,8 @@ func (s *Service) stop() error {
 		return nil
 	}
 
+	log.Info("stopping instrumentation service...")
+
 	s.unregisterGrpcViews()
 	s.stopJaegerExporter()
 	s.stopPrometheusExporter()

--- a/pkg/instrumentation/service.go
+++ b/pkg/instrumentation/service.go
@@ -38,9 +38,6 @@ type Service struct {
 func createService() *Service {
 	s := &Service{ServeMux: http.NewServeMux()}
 
-	if err := s.createJaegerExporter(); err != nil {
-		log.Error("failed to create instrumentation service: %v", err)
-	}
 	if err := s.createPrometheusExporter(); err != nil {
 		log.Error("failed to create instrumentation service: %v", err)
 	}
@@ -93,6 +90,9 @@ func (s *Service) start() error {
 
 	log.Info("starting instrumentation service...")
 
+	if err := s.createJaegerExporter(); err != nil {
+		log.Error("%v", err)
+	}
 	s.createHTTP()
 	s.startJaegerExporter()
 	s.startPrometheusExporter()


### PR DESCRIPTION
Otherwise the Jaeger related config changes have no effect.