### PR TITLE
log: formatting and post-configuration fixes.

### DIFF
--- a/pkg/log/backend.go
+++ b/pkg/log/backend.go
@@ -63,12 +63,12 @@ const (
 
 // severity tags fmtBackend uses to prefix emitted messages with.
 var fmtTags = map[Level]string{
-	LevelDebug: "D: ",
-	LevelInfo:  "I: ",
-	LevelWarn:  "W: ",
-	LevelError: "E: ",
-	LevelFatal: "FATAL ERROR: ",
-	LevelPanic: "PANIC: ",
+	LevelDebug: "D:",
+	LevelInfo:  "I:",
+	LevelWarn:  "W:",
+	LevelError: "E:",
+	LevelFatal: "FATAL ERROR:",
+	LevelPanic: "PANIC:",
 }
 
 // fmtBackend is our simple, default fmt.Printf-based Backend.
@@ -207,9 +207,10 @@ func (f *fmtBackend) run() {
 
 // emit formats and emits a single log message.
 func (f *fmtBackend) emit(req *fmtReq) {
-	if req.level > levelHighest {
+	if req.level >= levelHighest {
 		return
 	}
+
 	length := len(req.source)
 	suflen := (f.align - length) / 2
 	prelen := (f.align - (length + suflen))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -138,6 +138,10 @@ func (log *logging) setLevel(level Level) {
 
 // setBackend activates the named Backend for logging.
 func (log *logging) setBackend(name string) error {
+	if log.active.Name() == name {
+		return nil
+	}
+
 	createFn, ok := log.backend[name]
 	if !ok {
 		return loggerError("can't activate unknown backend '%s'", name)
@@ -145,6 +149,7 @@ func (log *logging) setBackend(name string) error {
 
 	log.active.Stop()
 	log.active = createFn()
+	log.active.SetSourceAlignment(log.maxname)
 
 	return nil
 }
@@ -246,7 +251,7 @@ func (log *logging) realign(maxname int) {
 	}
 	if maxname == 0 {
 		for id, cfg := range log.configs {
-			if !cfg.isEnabled() {
+			if !cfg.isEnabled() && !log.forced {
 				continue
 			}
 			if length := len(log.sources[id]); length > maxname {


### PR DESCRIPTION
This gift just keeps on giving...
This fix should stop reconfiguration from screwing up logging.