### PR TITLE
blockio: apply new and updated configs to running containers

### DIFF
--- a/pkg/blockio/blockio_test.go
+++ b/pkg/blockio/blockio_test.go
@@ -164,19 +164,19 @@ func TestDevicesParametersToOci(t *testing.T) {
 			iosched: map[string]string{"/dev/sda": "bfq"},
 			expectedOci: &cgroups.OciBlockIOParameters{
 				Weight: 144,
-				WeightDevice: []cgroups.OciWeightDeviceParameters{
+				WeightDevice: cgroups.OciDeviceWeights{
 					{Major: 11, Minor: 12, Weight: 50},
 				},
-				ThrottleReadBpsDevice: []cgroups.OciRateDeviceParameters{
+				ThrottleReadBpsDevice: cgroups.OciDeviceRates{
 					{Major: 11, Minor: 12, Rate: 1000000000},
 				},
-				ThrottleWriteBpsDevice: []cgroups.OciRateDeviceParameters{
+				ThrottleWriteBpsDevice: cgroups.OciDeviceRates{
 					{Major: 11, Minor: 12, Rate: 2000000},
 				},
-				ThrottleReadIOPSDevice: []cgroups.OciRateDeviceParameters{
+				ThrottleReadIOPSDevice: cgroups.OciDeviceRates{
 					{Major: 11, Minor: 12, Rate: 3000},
 				},
-				ThrottleWriteIOPSDevice: []cgroups.OciRateDeviceParameters{
+				ThrottleWriteIOPSDevice: cgroups.OciDeviceRates{
 					{Major: 11, Minor: 12, Rate: 4},
 				},
 			},
@@ -203,12 +203,12 @@ func TestDevicesParametersToOci(t *testing.T) {
 			iosched: map[string]string{"/dev/sda": "bfq", "/dev/sdb": "bfq", "/dev/sdc": "cfq"},
 			expectedOci: &cgroups.OciBlockIOParameters{
 				Weight: -1,
-				WeightDevice: []cgroups.OciWeightDeviceParameters{
+				WeightDevice: cgroups.OciDeviceWeights{
 					{Major: 11, Minor: 12, Weight: 110},
 					{Major: 21, Minor: 22, Weight: 220},
 					{Major: 31, Minor: 32, Weight: 330},
 				},
-				ThrottleReadBpsDevice: []cgroups.OciRateDeviceParameters{
+				ThrottleReadBpsDevice: cgroups.OciDeviceRates{
 					{Major: 11, Minor: 12, Rate: 100},
 					{Major: 21, Minor: 22, Rate: 200},
 					{Major: 31, Minor: 32, Rate: 300},

--- a/pkg/blockio/config.go
+++ b/pkg/blockio/config.go
@@ -45,5 +45,5 @@ func defaultOptions() interface{} {
 }
 
 func init() {
-	pkgcfg.Register("blockio", "BlockIO control", opt, defaultOptions)
+	pkgcfg.Register(ConfigModuleName, "Block I/O class control", opt, defaultOptions)
 }

--- a/pkg/cgroups/cgroupblkio_test.go
+++ b/pkg/cgroups/cgroupblkio_test.go
@@ -21,6 +21,268 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/testutils"
 )
 
+func TestUpdateAppend(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		inputMajMinVals         [][]int64
+		inputItem               []int64
+		expectedMajMinVal       [][]int64
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:              "update empty list",
+			inputItem:         []int64{1, 2, 3},
+			expectedMajMinVal: [][]int64{{1, 2, 3}},
+		},
+		{
+			name:              "update appends non-existing element",
+			inputMajMinVals:   [][]int64{{10, 20, 30}, {40, 50, 60}},
+			inputItem:         []int64{1, 2, 3},
+			expectedMajMinVal: [][]int64{{10, 20, 30}, {40, 50, 60}, {1, 2, 3}},
+		},
+		{
+			name:              "update the first existing element",
+			inputMajMinVals:   [][]int64{{10, 20, 30}, {40, 50, 60}, {40, 50, 60}},
+			inputItem:         []int64{40, 50, 66},
+			expectedMajMinVal: [][]int64{{10, 20, 30}, {40, 50, 66}, {40, 50, 60}},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			devWeights := OciDeviceWeights{}
+			devRates := OciDeviceRates{}
+			expDevWeights := OciDeviceWeights{}
+			expDevRates := OciDeviceRates{}
+			for _, item := range tc.inputMajMinVals {
+				devWeights.Append(item[0], item[1], item[2])
+				devRates.Append(item[0], item[1], item[2])
+			}
+			devWeights.Update(tc.inputItem[0], tc.inputItem[1], tc.inputItem[2])
+			devRates.Update(tc.inputItem[0], tc.inputItem[1], tc.inputItem[2])
+			for _, item := range tc.expectedMajMinVal {
+				expDevWeights = append(expDevWeights, OciDeviceWeight{item[0], item[1], item[2]})
+				expDevRates = append(expDevRates, OciDeviceRate{item[0], item[1], item[2]})
+			}
+			testutils.VerifyDeepEqual(t, "device weights", expDevWeights, devWeights)
+			testutils.VerifyDeepEqual(t, "device rates", expDevRates, devRates)
+		})
+	}
+}
+
+// TestResetBlkioParameters: unit test for ResetBlkioParameters()
+func TestResetBlkioParameters(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		cgroupsDir              string
+		blockIO                 OciBlockIOParameters
+		fsContent               map[string]string
+		expectedFsWrites        map[string]string
+		expectedBlockIO         *OciBlockIOParameters
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:       "write to clean cgroups",
+			cgroupsDir: "/write/to/clean",
+			blockIO: OciBlockIOParameters{
+				Weight:                  222,
+				WeightDevice:            OciDeviceWeights{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 12, 13}, {111, 112, 113}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{21, 22, 23}, {221, 222, 223}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{31, 32, 33}, {331, 332, 333}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{41, 42, 43}, {441, 442, 443}},
+			},
+			fsContent: map[string]string{
+				"/write/to/clean/blkio.bfq.weight":                 "100\n",
+				"/write/to/clean/blkio.bfq.weight_device":          "",
+				"/write/to/clean/blkio.throttle.read_bps_device":   "",
+				"/write/to/clean/blkio.throttle.write_bps_device":  "",
+				"/write/to/clean/blkio.throttle.read_iops_device":  "",
+				"/write/to/clean/blkio.throttle.write_iops_device": "",
+			},
+			expectedFsWrites: map[string]string{
+				"/write/to/clean/blkio.bfq.weight":                 "222",
+				"/write/to/clean/blkio.bfq.weight_device":          "1:2 3+4:5 6+7:8 9",
+				"/write/to/clean/blkio.throttle.read_bps_device":   "11:12 13+111:112 113",
+				"/write/to/clean/blkio.throttle.write_bps_device":  "21:22 23+221:222 223",
+				"/write/to/clean/blkio.throttle.read_iops_device":  "31:32 33+331:332 333",
+				"/write/to/clean/blkio.throttle.write_iops_device": "41:42 43+441:442 443",
+			},
+		},
+		{
+			name:       "reset all existing",
+			cgroupsDir: "/reset/all",
+			blockIO:    NewOciBlockIOParameters(),
+			fsContent: map[string]string{
+				"/reset/all/blkio.bfq.weight":                 "200\n",
+				"/reset/all/blkio.bfq.weight_device":          "default 200\n1:2 3\n4:5 6\n",
+				"/reset/all/blkio.throttle.read_bps_device":   "11:12 13\n14:15 16\n",
+				"/reset/all/blkio.throttle.write_bps_device":  "21:22 23\n",
+				"/reset/all/blkio.throttle.read_iops_device":  "31:32 33\n",
+				"/reset/all/blkio.throttle.write_iops_device": "41:42 43\n",
+			},
+			expectedFsWrites: map[string]string{
+				"/reset/all/blkio.bfq.weight_device":          "1:2 0+4:5 0",
+				"/reset/all/blkio.throttle.read_bps_device":   "11:12 0+14:15 0",
+				"/reset/all/blkio.throttle.write_bps_device":  "21:22 0",
+				"/reset/all/blkio.throttle.read_iops_device":  "31:32 0",
+				"/reset/all/blkio.throttle.write_iops_device": "41:42 0",
+			},
+		},
+		{
+			name:       "merge",
+			cgroupsDir: "/merge",
+			blockIO: OciBlockIOParameters{
+				Weight:                  80,
+				WeightDevice:            OciDeviceWeights{{1, 2, 1113}, {7, 8, 9}},       // drop middle, update first, keep last
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 12, 13}},                    // keep the first entry
+				ThrottleWriteBpsDevice:  OciDeviceRates{{24, 25, 26}},                    // keep the last entry
+				ThrottleReadIOPSDevice:  OciDeviceRates{{31, 32, 33}, {331, 332, 333}},   // keep all
+				ThrottleWriteIOPSDevice: OciDeviceRates{{41, 42, 430}, {441, 442, 4430}}, // change all
+			},
+			fsContent: map[string]string{
+				"/merge/blkio.bfq.weight":                 "200\n",
+				"/merge/blkio.bfq.weight_device":          "default 200\n1:2 3\n4:5 6\n7:8 9",
+				"/merge/blkio.throttle.read_bps_device":   "11:12 13\n14:15 16\n",
+				"/merge/blkio.throttle.write_bps_device":  "21:22 23\n24:25 26\n",
+				"/merge/blkio.throttle.read_iops_device":  "31:32 33\n331:332 333\n",
+				"/merge/blkio.throttle.write_iops_device": "41:42 43\n441:442 443\n",
+			},
+			expectedFsWrites: map[string]string{
+				"/merge/blkio.bfq.weight":                 "80",
+				"/merge/blkio.bfq.weight_device":          "1:2 1113+7:8 9+4:5 0",
+				"/merge/blkio.throttle.read_bps_device":   "11:12 13+14:15 0",
+				"/merge/blkio.throttle.write_bps_device":  "24:25 26+21:22 0",
+				"/merge/blkio.throttle.read_iops_device":  "31:32 33+331:332 333",
+				"/merge/blkio.throttle.write_iops_device": "41:42 430+441:442 4430",
+			},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mpf := mockPlatform{
+				fsOrigContent: tc.fsContent,
+				fsWrites:      make(map[string]string),
+			}
+			currentPlatform = &mpf
+			err := ResetBlkioParameters(tc.cgroupsDir, tc.blockIO)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			if tc.expectedFsWrites != nil {
+				testutils.VerifyDeepEqual(t, "filesystem writes", tc.expectedFsWrites, mpf.fsWrites)
+			}
+		})
+	}
+}
+
+// TestGetBlkioParameters: unit test for GetBlkioParameters()
+func TestGetBlkioParameters(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		cgroupsDir              string
+		readsFail               int
+		fsContent               map[string]string
+		expectedBlockIO         *OciBlockIOParameters
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:       "empty files",
+			cgroupsDir: "/empty/ok",
+			fsContent: map[string]string{
+				"/empty/ok/blkio.bfq.weight":                 "",
+				"/empty/ok/blkio.bfq.weight_device":          "",
+				"/empty/ok/blkio.throttle.read_bps_device":   "",
+				"/empty/ok/blkio.throttle.write_bps_device":  "",
+				"/empty/ok/blkio.throttle.read_iops_device":  "",
+				"/empty/ok/blkio.throttle.write_iops_device": "",
+			},
+			expectedBlockIO:         &OciBlockIOParameters{Weight: -1},
+			expectedErrorCount:      1, // weight is not expected to be empty
+			expectedErrorSubstrings: []string{"parsing weight"},
+		},
+		{
+			name:       "everything defined",
+			cgroupsDir: "/read/ok",
+			fsContent: map[string]string{
+				"/read/ok/blkio.bfq.weight": "1",
+				// test weight_device file with real "default" line
+				"/read/ok/blkio.bfq.weight_device": "default 10\n1:2 3\n",
+				// test parsing two lines and skipping empty lines
+				"/read/ok/blkio.throttle.read_bps_device": "\n11:22 33\n\n111:222 333\n",
+				// test single line file
+				"/read/ok/blkio.throttle.write_bps_device": "1111:2222 3333\n",
+				// test single line, missing LF at the end
+				"/read/ok/blkio.throttle.read_iops_device": "11111:22222 33333",
+				// test small and large values
+				"/read/ok/blkio.throttle.write_iops_device": "0:0 0\n4294967296:4294967297 9223372036854775807\n",
+			},
+			expectedBlockIO: &OciBlockIOParameters{
+				Weight:                  1,
+				WeightDevice:            OciDeviceWeights{{1, 2, 3}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 22, 33}, {111, 222, 333}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{1111, 2222, 3333}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{11111, 22222, 33333}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{0, 0, 0}, {4294967296, 4294967297, 9223372036854775807}},
+			},
+		},
+		{
+			name:       "test bad lines",
+			cgroupsDir: "read/bad",
+			fsContent: map[string]string{
+				"read/bad/blkio.bfq.weight": "xyz",
+				// test bad line in the middle
+				"read/bad/blkio.bfq.weight_device": "default 10\n1:2 3\nbad\n4:5 6\n",
+				// test no spaces
+				"read/bad/blkio.throttle.read_bps_device": "11:22:33",
+				// test too many spaces
+				"read/bad/blkio.throttle.write_bps_device": "1111 2222 3333 \n",
+				// test no colons
+				"read/bad/blkio.throttle.read_iops_device": "1111122222 33333",
+				// test missing number
+				"read/bad/blkio.throttle.write_iops_device": "0: 0\n",
+			},
+			expectedErrorCount:      6,
+			expectedErrorSubstrings: []string{"bad", "xyz", "11:22:33", "1111 2222 3333 ", "1111122222 33333", "0: 0"},
+			expectedBlockIO: &OciBlockIOParameters{
+				Weight:       -1,
+				WeightDevice: OciDeviceWeights{{1, 2, 3}, {4, 5, 6}},
+			},
+		},
+		{
+			name:               "all files missing",
+			cgroupsDir:         "/missing/err",
+			fsContent:          map[string]string{},
+			expectedBlockIO:    &OciBlockIOParameters{Weight: -1},
+			expectedErrorCount: 6,
+			expectedErrorSubstrings: []string{
+				"file not found",
+				"blkio.bfq.weight",
+				"blkio.bfq.weight_device",
+				"blkio.throttle.read_bps_device",
+				"blkio.throttle.write_bps_device",
+				"blkio.throttle.read_iops_device",
+				"blkio.throttle.write_iops_device",
+			},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mpf := mockPlatform{
+				fsOrigContent: tc.fsContent,
+				readsFail:     tc.readsFail,
+			}
+			currentPlatform = &mpf
+			blockIO, err := GetBlkioParameters(tc.cgroupsDir)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			if tc.expectedBlockIO != nil {
+				testutils.VerifyDeepEqual(t, "blockio parameters", *tc.expectedBlockIO, blockIO)
+			}
+		})
+	}
+
+}
+
 // TestSetBlkioParameters: unit test for SetBlkioParameters()
 func TestSetBlkioParameters(t *testing.T) {
 	tcases := []struct {
@@ -37,11 +299,11 @@ func TestSetBlkioParameters(t *testing.T) {
 			cgroupsDir: "/my/full",
 			blockIO: OciBlockIOParameters{
 				Weight:                  10,
-				WeightDevice:            []OciWeightDeviceParameters{{Major: 1, Minor: 2, Weight: 3}},
-				ThrottleReadBpsDevice:   []OciRateDeviceParameters{{Major: 11, Minor: 12, Rate: 13}},
-				ThrottleWriteBpsDevice:  []OciRateDeviceParameters{{Major: 21, Minor: 22, Rate: 23}},
-				ThrottleReadIOPSDevice:  []OciRateDeviceParameters{{Major: 31, Minor: 32, Rate: 33}},
-				ThrottleWriteIOPSDevice: []OciRateDeviceParameters{{Major: 41, Minor: 42, Rate: 43}},
+				WeightDevice:            OciDeviceWeights{{Major: 1, Minor: 2, Weight: 3}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{Major: 11, Minor: 12, Rate: 13}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{Major: 21, Minor: 22, Rate: 23}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{Major: 31, Minor: 32, Rate: 33}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{Major: 41, Minor: 42, Rate: 43}},
 			},
 			expectedFsWrites: map[string]string{
 				"/my/full/blkio.bfq.weight":                 "10",
@@ -65,11 +327,11 @@ func TestSetBlkioParameters(t *testing.T) {
 			cgroupsDir: "/my/multidev",
 			blockIO: OciBlockIOParameters{
 				Weight:                  -1,
-				WeightDevice:            []OciWeightDeviceParameters{{1, 2, 3}, {4, 5, 6}},
-				ThrottleReadBpsDevice:   []OciRateDeviceParameters{{11, 12, 13}, {111, 112, 113}},
-				ThrottleWriteBpsDevice:  []OciRateDeviceParameters{{21, 22, 23}, {221, 222, 223}},
-				ThrottleReadIOPSDevice:  []OciRateDeviceParameters{{31, 32, 33}, {331, 332, 333}},
-				ThrottleWriteIOPSDevice: []OciRateDeviceParameters{{41, 42, 43}, {441, 442, 443}},
+				WeightDevice:            OciDeviceWeights{{1, 2, 3}, {4, 5, 6}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 12, 13}, {111, 112, 113}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{21, 22, 23}, {221, 222, 223}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{31, 32, 33}, {331, 332, 333}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{41, 42, 43}, {441, 442, 443}},
 			},
 			expectedFsWrites: map[string]string{
 				"/my/multidev/blkio.bfq.weight_device":          "1:2 3+4:5 6",
@@ -91,7 +353,7 @@ func TestSetBlkioParameters(t *testing.T) {
 			cgroupsDir: "/my/writesfail",
 			blockIO: OciBlockIOParameters{
 				Weight:       -1,
-				WeightDevice: []OciWeightDeviceParameters{{1, 0, 100}},
+				WeightDevice: OciDeviceWeights{{1, 0, 100}},
 			},
 			writesFail:         9999,
 			expectedErrorCount: 1,
@@ -121,8 +383,21 @@ func TestSetBlkioParameters(t *testing.T) {
 
 // mockPlatform implements mock versions of platformInterface functions.
 type mockPlatform struct {
-	fsWrites   map[string]string
-	writesFail int
+	fsOrigContent map[string]string
+	fsWrites      map[string]string
+	readsFail     int
+	writesFail    int
+}
+
+func (mpf *mockPlatform) readFromFile(filename string) (string, error) {
+	if mpf.readsFail > 0 {
+		mpf.readsFail--
+		return "", fmt.Errorf("mockPlatofrm: reading from %#v failed", filename)
+	}
+	if content, ok := mpf.fsOrigContent[filename]; ok {
+		return content, nil
+	}
+	return "", fmt.Errorf("mockPlatform: file not found %#v", filename)
 }
 
 func (mpf *mockPlatform) writeToFile(filename string, content string) error {

--- a/pkg/cri/resource-manager/control/blockio/flags.go
+++ b/pkg/cri/resource-manager/control/blockio/flags.go
@@ -34,8 +34,7 @@ func defaultOptions() interface{} {
 	}
 }
 
-// Register us for configuration handling.
+// init registers blockio class mapping configuration.
 func init() {
-	config.Register("resource-manager.blockio", configHelp, opt, defaultOptions,
-		config.WithNotify(getBlockIOController().(*blockioctl).configNotify))
+	config.Register(ConfigModuleName, configHelp, opt, defaultOptions)
 }

--- a/sample-configs/blockio.cfg
+++ b/sample-configs/blockio.cfg
@@ -12,6 +12,9 @@
 policy:
   Active: none
 
+logger:
+  Debug: blockio,cgroupblkio
+
 blockio:
   Classes:
     LowPrioThrottled:


### PR DESCRIPTION
- Add cgroups file-to-oci blockio conversion.
- Add cgroups configuration transformation from whatever existing one
  to wanted configuration by adding/modifying/removing parameters.
- Hook resetting blockio parameters to CRI-RM launch and config change.
- Add unit tests.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>