### PR TITLE
config: always call registration-time notifiers first.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,9 +122,12 @@ func Register(path, description string, ptr interface{}, getfn GetConfigFn, opts
 
 	m.check()
 
+	foreign := m.notifiers
+	m.notifiers = nil
 	for _, opt := range opts {
 		opt.apply(m)
 	}
+	m.notifiers = append(m.notifiers, foreign...)
 
 	return m
 }


### PR DESCRIPTION
Make sure that 'owning' configuration notification callbacks (attached during module registration as a `config.WithNotify()` option passed to `config.Register()`), are always invoked *before* 'foreign' notification callbacks (attached using `config.AddNotify()`). This establishes a notification invocation order that is defined well enough to be relied on.

Without this patch, notification callbacks were internally stored and therefore invoked in the temporal order of registration. If a foreign callback was attached to a yet to be created module, then eventually the module's own configuration callback(s) ended up registered and called after any such foreign one.