### PR TITLE
fix: cache: don't return duplicates by pod.Get[Init]Containers().

### DIFF
--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -83,7 +83,10 @@ func (p *pod) GetInitContainers() []Container {
 
 	containers := []Container{}
 
-	for _, c := range p.cache.Containers {
+	for id, c := range p.cache.Containers {
+		if id != c.CacheID {
+			continue
+		}
 		if _, ok := p.Resources.InitContainers[c.ID]; ok {
 			containers = append(containers, c)
 		}
@@ -96,8 +99,8 @@ func (p *pod) GetInitContainers() []Container {
 func (p *pod) GetContainers() []Container {
 	containers := []Container{}
 
-	for _, c := range p.cache.Containers {
-		if c.PodID != p.ID {
+	for id, c := range p.cache.Containers {
+		if c.PodID != p.ID || id != c.CacheID {
 			continue
 		}
 		if p.Resources != nil {


### PR DESCRIPTION
Make sure the slices returned by pod.GetContainers() and pod.GetInitContainers() contain every container only once.