### PR TITLE
cpuallocator: don't crash/try ever to index into an empty slice.

### DIFF
--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -213,6 +213,9 @@ func (a *allocatorHelper) takeIdleCores() {
 	cores := pickIds(a.sys.CPUIDs(),
 		func(id sysfs.ID) bool {
 			cset := a.topology.core[id].Difference(offline)
+			if cset.IsEmpty() {
+				return false
+			}
 			return cset.Intersection(a.from).Equals(cset) && cset.ToSlice()[0] == int(id)
 		})
 


### PR DESCRIPTION
Without this patch, it is possible to trick the CPU allocator to crash, with enough/the right CPUs offline, as it ends up trying to index the first element of an empty slice when looking for idle cores.