### PR TITLE
memtier: fix memory type checking, a few inherited scoring bugs. 

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/node.go
@@ -107,6 +107,7 @@ type Node interface {
 	dump(string, ...int)
 
 	GetMemoryType() memoryType
+	HasMemoryType(memoryType) bool
 	GetPhysicalNodeIDs() []system.ID
 
 	GetScore(Request) Score
@@ -401,6 +402,11 @@ func (n *node) GetMemoryType() memoryType {
 		memoryMask |= memoryHBMEM
 	}
 	return memoryMask
+}
+
+func (n *node) HasMemoryType(reqType memoryType) bool {
+	nodeType := n.GetMemoryType()
+	return (nodeType & reqType) == reqType
 }
 
 // NewNumaNode create a node for a CPU socket.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences.go
@@ -190,6 +190,7 @@ func cpuAllocationPreferences(pod cache.Pod, container cache.Container) (int, in
 func podMemoryTypePreference(pod cache.Pod, c cache.Container) memoryType {
 	value, ok := pod.GetResmgrAnnotation(keyMemoryTypePreference)
 	if !ok {
+		log.Debug("pod %s has no memory preference annotations", pod.GetName())
 		return memoryUnspec
 	}
 
@@ -200,6 +201,7 @@ func podMemoryTypePreference(pod cache.Pod, c cache.Container) memoryType {
 		name := c.GetName()
 		p, ok := preferences[name]
 		if !ok {
+			log.Debug("container %s has no entry among memory preferences", c.PrettyName())
 			return memoryUnspec
 		}
 		pref = p
@@ -213,6 +215,7 @@ func podMemoryTypePreference(pod cache.Pod, c cache.Container) memoryType {
 			pref, keyMemoryTypePreference, err)
 		return memoryUnspec
 	}
+	log.Debug("container %s has effective memory preference: %s", c.PrettyName(), mtype)
 	return mtype
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -601,11 +601,11 @@ func (p *policy) compareScores(request Request, scores map[int]Score,
 	}
 
 	// 3) matching memory type wins
-	if request.MemoryType() != memoryUnspec {
-		// see if the nodes have different memory types and whether they match the request
-		if node1.GetMemoryType() == request.MemoryType() && node2.GetMemoryType() != request.MemoryType() {
+	if reqType := request.MemoryType(); reqType != memoryUnspec {
+		if node1.HasMemoryType(reqType) && !node2.HasMemoryType(reqType) {
 			return true
-		} else if node1.GetMemoryType() != request.MemoryType() && node2.GetMemoryType() == request.MemoryType() {
+		}
+		if !node1.HasMemoryType(reqType) && node2.HasMemoryType(reqType) {
 			return false
 		}
 	}


### PR DESCRIPTION
This patch series
  - fixes memory type subset check to use proper sub-masking instead of comparison
  - fixes a few scoring bugs inherited from the original topology-aware policy code
  - adds detailed logging of the score sorting/comparison algorithm
  - adds logging of the pod's/container's memory type preferences