### PR TITLE
fixes/cache: add test cases for making sure CPU estimates are properly rounded for full CPUs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	google.golang.org/grpc v1.23.1
+	google.golang.org/grpc v1.26.0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
@@ -31,6 +31,8 @@ require (
 
 replace (
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0 => ./pkg/topology
+	google.golang.org/grpc => google.golang.org/grpc v1.26.0
+
 	k8s.io/api v0.0.0 => k8s.io/api v0.0.0-20200121193204-7ea599edc7fd
 	k8s.io/apiextensions-apiserver v0.0.0 => k8s.io/apiextensions-apiserver v0.0.0-20200121201129-111e9ba415da
 	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.0.0-20191121175448-79c2a76c473a

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/caddyserver/caddy v1.0.3/go.mod h1:G+ouvOY32gENkJC+jhgl62TyhvqEsFaDiZ4uw0RzP1E=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -142,6 +143,8 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esuG4MuU0Pjs5y6iknohY=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
@@ -329,6 +332,7 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -774,12 +778,16 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb h1:i1Ppqkc3WQXikh8
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.23.1 h1:q4XQuHFC6I28BKZpo6IYyb3mNO+l7lSOxRuYTCiDfXk=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
+google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
@@ -392,7 +393,7 @@ func TestCPULimitCalculationAccuracy(t *testing.T) {
 			if diff < 0 {
 				diff = -diff
 			}
-			if quota != minQuotaPeriod {
+			if quota != kubecm.MinQuotaPeriod {
 				t.Errorf("CPU limit %v: estimate %v, unexpected inaccuracy %v > %v",
 					limit, estimate, diff, expectedAccuracy)
 			} else {

--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -346,3 +346,64 @@ func TestDefaultRDTAndBlockIOClasses(t *testing.T) {
 		}
 	}
 }
+
+const (
+	// anything below 2 millicpus will yield 0 as an estimate
+	minNonZeroRequest = 2
+	// check CPU request/limit estimate accuracy up to 1024 CPU cores
+	maxCPU = 1024 * 1000
+	// we expect our estimates to be within 1 millicpu from the real ones
+	expectedAccuracy = 1
+)
+
+func TestCPURequestCalculationAccuracy(t *testing.T) {
+	for request := 0; request < maxCPU; request++ {
+		shares := MilliCPUToShares(request)
+		estimate := SharesToMilliCPU(shares)
+
+		diff := int64(request) - estimate
+		if diff > expectedAccuracy || diff < -expectedAccuracy {
+			if diff < 0 {
+				diff = -diff
+			}
+			if request > minNonZeroRequest {
+				t.Errorf("CPU request %v: estimate %v, unexpected inaccuracy %v > %v",
+					request, estimate, diff, expectedAccuracy)
+			} else {
+				t.Logf("CPU request %v: estimate %v, inaccuracy %v > %v (OK, this was expected)",
+					request, estimate, diff, expectedAccuracy)
+			}
+		}
+
+		// fail if our estimates are not accurate for full CPUs worth of millicpus
+		if (request%1000) == 0 && diff != 0 {
+			t.Errorf("CPU request %v != estimate %v (diff %v)", request, estimate, diff)
+		}
+	}
+}
+
+func TestCPULimitCalculationAccuracy(t *testing.T) {
+	for limit := int64(0); limit < int64(maxCPU); limit++ {
+		quota, period := MilliCPUToQuota(limit)
+		estimate := QuotaToMilliCPU(quota, period)
+
+		diff := limit - estimate
+		if diff > expectedAccuracy || diff < -expectedAccuracy {
+			if diff < 0 {
+				diff = -diff
+			}
+			if quota != minQuotaPeriod {
+				t.Errorf("CPU limit %v: estimate %v, unexpected inaccuracy %v > %v",
+					limit, estimate, diff, expectedAccuracy)
+			} else {
+				t.Logf("CPU limit %v: estimate %v, inaccuracy %v > %v (OK, this was expected)",
+					limit, estimate, diff, expectedAccuracy)
+			}
+		}
+
+		// fail if our estimates are not accurate for full CPUs worth of millicpus
+		if (limit%1000) == 0 && diff != 0 {
+			t.Errorf("CPU limit %v != estimate %v (diff %v)", limit, estimate, diff)
+		}
+	}
+}

--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -82,11 +82,29 @@ func estimateComputeResources(lnx *cri.LinuxContainerResources, cgroupParent str
 
 // SharesToMilliCPU converts CFS CPU shares to milliCPU.
 func SharesToMilliCPU(shares int64) int64 {
+	return sharesToMilliCPU(shares)
+}
+
+// QuotaToMilliCPU converts CFS quota and period to milliCPU.
+func QuotaToMilliCPU(quota, period int64) int64 {
+	return quotaToMilliCPU(quota, period)
+}
+
+// sharesToMilliCPU converts CFS CPU shares to milliCPU.
+func sharesToMilliCPU(shares int64) int64 {
 	if shares == minShares {
 		return 0
 	}
-
+	//return int64(float64(shares*milliCPUToCPU) / float64(sharesPerCPU) + 0.5)
 	return int64((float64(shares*milliCPUToCPU) / float64(sharesPerCPU)) + 0.5)
+}
+
+// quotaToMilliCPU converts CFS quota and period to milliCPU.
+func quotaToMilliCPU(quota, period int64) int64 {
+	if quota == 0 || period == 0 {
+		return 0
+	}
+	return int64(float64(quota*milliCPUToCPU)/float64(period) + 0.5)
 }
 
 // MilliCPUToShares converts milliCPU to CFS CPU shares.
@@ -101,15 +119,6 @@ func MilliCPUToShares(milliCPU int) int64 {
 	}
 
 	return int64(shares)
-}
-
-// QuotaToMilliCPU converts CFS quota and period to milliCPU.
-func QuotaToMilliCPU(quota, period int64) int64 {
-	if quota == 0 || period == 0 {
-		return 0
-	}
-
-	return int64(float64(quota*milliCPUToCPU)/float64(period) + 0.5)
 }
 
 // MilliCPUToQuota converts milliCPU to CFS quota and period values.


### PR DESCRIPTION
Add test cases for making sure the estimates of CPU requests/limits worth of full CPUs are accurate. Such containers are treated specially by stock kubernetes/kubelet as the 'static' policy considers Guaranteed QoS class containers with such requests eligible for exclusive CPU allocation.

Also, since the relevant related constants and functions are now exported from kubelet, pull in those ones and use them instead of duplication, whenever this is possible.