### PR TITLE
fix potential nil pointer dereference in CRI controller.

### DIFF
--- a/pkg/cri/resource-manager/control/cri/cri.go
+++ b/pkg/cri/resource-manager/control/cri/cri.go
@@ -86,6 +86,9 @@ func (ctl *crictl) PreCreateHook(c cache.Container) error {
 	create.Config.Envs = c.GetCRIEnvs()
 	create.Config.Mounts = c.GetCRIMounts()
 	create.Config.Devices = c.GetCRIDevices()
+	if create.Config.Linux == nil {
+		create.Config.Linux = &criapi.LinuxContainerConfig{}
+	}
 	create.Config.Linux.Resources = c.GetLinuxResources()
 
 	c.ClearPending(CRIController)


### PR DESCRIPTION
Sometimes create.Config.Linux can be nil. Revealed by critest when
running against memtier and topology-aware policies.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>