### PR TITLE
policy: make Bypassed() a member of the policy interface

### DIFF
--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/metrics"
-	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
 
@@ -45,7 +44,7 @@ func (m *resmgr) setupEventProcessing() error {
 
 // startEventProcessing starts event and metrics processing.
 func (m *resmgr) startEventProcessing() error {
-	if policy.Bypassed() {
+	if m.policy.Bypassed() {
 		return nil
 	}
 

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -42,7 +42,7 @@ func (m *resmgr) setupRequestProcessing() error {
 		return resmgrError("failed to register resource-manager CRI interceptors: %v", err)
 	}
 
-	m.relay.Server().SetBypassCheckFn(policy.Bypassed)
+	m.relay.Server().SetBypassCheckFn(m.policy.Bypassed)
 
 	return nil
 }
@@ -69,7 +69,7 @@ func (m *resmgr) startRequestProcessing() error {
 
 // syncWithCRI synchronizes cache pods and containers with the CRI runtime.
 func (m *resmgr) syncWithCRI(ctx context.Context) ([]cache.Container, []cache.Container, error) {
-	if policy.Bypassed() || !m.relay.Client().HasRuntimeService() {
+	if m.policy.Bypassed() || !m.relay.Client().HasRuntimeService() {
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
Fixes a segfault caused by config updates where the configuration of the
policy layer and the policy instance get out-of-sync. This happens
because we do not currently handle run-time configuration updates of
the upper policy layer. If we start with an empty config, (i.e. null
policy) no policy backend gets initialized. But, after a config update
the active policy in the configuration might have changed to something
else. Now, Bypassed() returned false (because it was looking at the
config) but in reality we did not have any policy backend. This caused a
segfault at request processing as we tried to do policy decisions with a
nil backend.

Even for the future, when config updates are fixed/supported, it is
probably safest to get this information directly from the policy
instance, rather than from its configuration.