### PR TITLE
cache: set default RDT and Block I/O classes when injecting container into cache.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/config"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/topology"
 )
@@ -43,6 +44,11 @@ const (
 
 	// TagAVX512 tags containers that use AVX512 instructions.
 	TagAVX512 = "AVX512"
+
+	// RDTClassKey is the pod annotation key for specifying a container RDT class.
+	RDTClassKey = "rdtclass" + "." + kubernetes.ResmgrKeyNamespace
+	// BlockIOClassKey is the pod annotation key for specifying a container Block I/O class.
+	BlockIOClassKey = "blockioclass" + "." + kubernetes.ResmgrKeyNamespace
 )
 
 // PodState is the pod state in the runtime.

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -112,6 +112,14 @@ type Pod interface {
 	// cri-resource-manager namespace.
 	GetResmgrAnnotationObject(key string, objPtr interface{},
 		decode func([]byte, interface{}) error) (bool, error)
+	// GetEffectiveAnnotation returns the effective annotation for a container.
+	// For any given key $K and container $C it will look for annotations in
+	// this order and return the first one found:
+	//     $K/container.$C
+	//     $K/pod
+	//     $K
+	// and return the value of the first key found.
+	GetEffectiveAnnotation(key, container string) (string, bool)
 	// GetCgroupParentDir returns the pods cgroup parent directory.
 	GetCgroupParentDir() string
 	// GetPodResourceRequirements returns container resource requirements if the
@@ -210,6 +218,8 @@ type Container interface {
 	// GetAnnotation returns the value of a container annotation from the
 	// cri-resource-manager namespace.
 	GetResmgrAnnotation(key string, objPtr interface{}) (string, bool)
+	// GetEffectiveAnnotation returns the effective annotation for the container from the pod.
+	GetEffectiveAnnotation(key string) (string, bool)
 	// GetAnnotations returns a copy of all container annotations.
 	GetAnnotations() map[string]string
 	// GetEnvKeys returns the keys of all container environment variables.

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -312,6 +312,14 @@ func (c *container) GetResmgrAnnotation(key string, objPtr interface{}) (string,
 	return c.GetAnnotation(kubernetes.ResmgrKey(key), objPtr)
 }
 
+func (c *container) GetEffectiveAnnotation(key string) (string, bool) {
+	pod, ok := c.GetPod()
+	if !ok {
+		return "", false
+	}
+	return pod.GetEffectiveAnnotation(key, c.Name)
+}
+
 func (c *container) GetAnnotations() map[string]string {
 	if c.Annotations == nil {
 		return nil

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -275,6 +275,18 @@ func (p *pod) GetResmgrAnnotationObject(key string, objPtr interface{},
 	return p.GetAnnotationObject(kubernetes.ResmgrKey(key), objPtr, decode)
 }
 
+// Get the effective annotation for the container.
+func (p *pod) GetEffectiveAnnotation(key, container string) (string, bool) {
+	if v, ok := p.Annotations[key+"/container."+container]; ok {
+		return v, true
+	}
+	if v, ok := p.Annotations[key+"/pod"]; ok {
+		return v, true
+	}
+	v, ok := p.Annotations[key]
+	return v, ok
+}
+
 // Get the cgroup parent directory of a pod, if known.
 func (p *pod) GetCgroupParentDir() string {
 	return p.CgroupParent

--- a/pkg/cri/resource-manager/introspect/introspect.go
+++ b/pkg/cri/resource-manager/introspect/introspect.go
@@ -82,12 +82,13 @@ type Node struct {
 
 // System describes the underlying HW/system.
 type System struct {
-	Sockets    map[int]*Socket // physical sockets in the system
-	Nodes      map[int]*Node   // NUMA nodes in the system
-	Isolated   string          // kernel-isolated CPUs
-	Offlined   string          // CPUs offline
-	RDTClasses []string        // RDT classes
-	Policy     string          // active policy
+	Sockets        map[int]*Socket // physical sockets in the system
+	Nodes          map[int]*Node   // NUMA nodes in the system
+	Isolated       string          // kernel-isolated CPUs
+	Offlined       string          // CPUs offline
+	RDTClasses     []string        // list of RDT classes
+	BlockIOClasses []string        // list of block I/O classes
+	Policy         string          // active policy
 }
 
 // State is the current introspected state of the resource manager.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -273,6 +273,9 @@ func (m *mockContainer) GetResmgrAnnotationKeys() []string {
 func (m *mockContainer) GetResmgrAnnotation(string, interface{}) (string, bool) {
 	panic("unimplemented")
 }
+func (m *mockContainer) GetEffectiveAnnotation(string) (string, bool) {
+	panic("unimplemented")
+}
 func (m *mockContainer) GetAnnotations() map[string]string {
 	panic("unimplemented")
 }
@@ -507,6 +510,9 @@ func (m *mockPod) GetResmgrAnnotation(key string) (string, bool) {
 	return m.returnValue1FotGetResmgrAnnotation, m.returnValue2FotGetResmgrAnnotation
 }
 func (m *mockPod) GetResmgrAnnotationObject(string, interface{}, func([]byte, interface{}) error) (bool, error) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetEffectiveAnnotation(string, string) (string, bool) {
 	panic("unimplemented")
 }
 func (m *mockPod) GetCgroupParentDir() string {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -245,6 +245,9 @@ func (m *mockContainer) GetResmgrAnnotationKeys() []string {
 func (m *mockContainer) GetResmgrAnnotation(string, interface{}) (string, bool) {
 	panic("unimplemented")
 }
+func (m *mockContainer) GetEffectiveAnnotation(string) (string, bool) {
+	panic("unimplemented")
+}
 func (m *mockContainer) GetAnnotations() map[string]string {
 	panic("unimplemented")
 }
@@ -480,6 +483,9 @@ func (m *mockPod) GetResmgrAnnotation(key string) (string, bool) {
 	return m.returnValue1FotGetResmgrAnnotation, m.returnValue2FotGetResmgrAnnotation
 }
 func (m *mockPod) GetResmgrAnnotationObject(string, interface{}, func([]byte, interface{}) error) (bool, error) {
+	panic("unimplemented")
+}
+func (m *mockPod) GetEffectiveAnnotation(string, string) (string, bool) {
 	panic("unimplemented")
 }
 func (m *mockPod) GetCgroupParentDir() string {

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
+	"github.com/intel/cri-resource-manager/pkg/blockio"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
@@ -355,6 +356,10 @@ func (p *policy) Introspect() *introspect.State {
 	rdtClassNames := []string{}
 	for _, rdtClass := range rdt.GetClasses() {
 		rdtClassNames = append(rdtClassNames, rdtClass.Name())
+	}
+	blkioClassNames := []string{}
+	for _, blkioClass := range blockio.GetClasses() {
+		blkioClassNames = append(blkioClassNames, blkioClass.Name)
 	}
 	p.inspsys.RDTClasses = rdtClassNames
 	p.inspsys.Policy = opt.Policy


### PR DESCRIPTION
[Update: changed annotation syntax and this description accordingly.]

This PR implements #226 .

This patch set implements initializing the default RDT and Block I/O classes of containers during container creation/discovery. The classes are initialized to the first successfully found value from the following list:
  - container-specific class annotation value
  - pod-default class annotation value 
  - pod QoS class value

The class annotations are a more consistent variant of [these kubernetes conventions](https://kubesec.io/basics/metadata-annotations-seccomp-security-alpha-kubernetes-io-pod/), using the `rdtclass` and `blockioclass` keys in the usual resource-manager-specific `.cri-resource-manager.intel.com` key 'namespace'. Hence, the full key syntaxes are:
  - `rdtclass.cri-resource-manager.intel.com/container.$container`
  - `rdtclass.cri-resource-manager.intel.com/pod`
  - `blockioclass.cri-resource-manager.intel.com/container.$container`
  - `blockioclass.cri-resource-manager.intel.com/pod`


The patch series adds generic functions to the cache Pod and Container interfaces for getting the effective container-specific value of any annotation following the above described kubernetes-inspired conventions.

Therefore additionally,
  - `rdtclass.cri-resource-manager.intel.com` is treated as`rdtclass.cri-resource-manager.intel.com/pod`, and
  - `blockioclass.cri-resource-manager.intel.com` is treated as `blockioclass.cri-resource-manager.intel.com/pod`

Once this PR is merged, we'll file additional PRs for converting our other annotations to using this same convention and functions, whenever/wherever this make sense.
