### PR TITLE
agent: add simple liveness probe to the sample deployment

### DIFF
--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core \
+    --bundles=os-core,network-basic \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/cmd/cri-resmgr-agent/agent-deployment.yaml
+++ b/cmd/cri-resmgr-agent/agent-deployment.yaml
@@ -73,6 +73,11 @@ spec:
             limits:
               cpu: 1
               memory: 512Mi
+          livenessProbe:
+            exec:
+              command: ["nc", "-U", "-z", "/var/run/cri-resmgr/cri-resmgr-agent.sock"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
       volumes:
       - name: resmgrsockets
         hostPath:


### PR DESCRIPTION
Simple nc to check if the agent socket accepts connections.