### PR TITLE
webhook: drop containerPort from the sample deployment spec

### DIFF
--- a/cmd/cri-resmgr-webhook/webhook-deployment.yaml
+++ b/cmd/cri-resmgr-webhook/webhook-deployment.yaml
@@ -27,8 +27,6 @@ spec:
         image: IMAGE_PLACEHOLDER
         # Convenience pull policy for development
         imagePullPolicy: Always
-        ports:
-        - containerPort: 443
         # Mount the tls cert/key in the default location
         volumeMounts:
         - name: certs


### PR DESCRIPTION
Not needed. Points to incorrect port and we use the service, anyway.