### PR TITLE
Convert HBMEM -> HBM everywhere.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/README.md
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/README.md
@@ -32,12 +32,12 @@ cri-resmgr --policy memtier --reserved-resources cpu=750m
 ## Configuration
 
 The `memtier` policy knows of three kinds of memory: `DRAM`, `PMEM`, and
-`HBMEM`. The various memory types are accessed via separate memory controllers.
+`HBM`. The various memory types are accessed via separate memory controllers.
 
   * DRAM (dynamic random-access memory) is regular system main memory.
   * PMEM (persistent memory) is large-capacity memory, such as
     Intel® Optane™ memory.
-  * HBMEM (high-bandwidth memory) is high speed memory, typically found
+  * HBM (high-bandwidth memory) is high speed memory, typically found
     on some special-purpose computing systems.
 
 In order to configure a pod to use a certain memory type, use

--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache_test.go
@@ -88,11 +88,11 @@ func TestAllocationMarshalling(t *testing.T) {
 	}{
 		{
 			name: "non-zero Exclusive",
-			data: []byte(`{"key1":{"Exclusive":"1","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBMEM","Memset":"","MemoryLimit":{}}}`),
+			data: []byte(`{"key1":{"Exclusive":"1","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{}}}`),
 		},
 		{
 			name: "zero Exclusive",
-			data: []byte(`{"key1":{"Exclusive":"","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBMEM","Memset":"","MemoryLimit":{}}}`),
+			data: []byte(`{"key1":{"Exclusive":"","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{}}}`),
 		},
 	}
 	for _, tc := range tcases {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
@@ -273,7 +273,7 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 	mems := grant.Memset()
 	dram := system.NewIDSet()
 	pmem := system.NewIDSet()
-	hbmem := system.NewIDSet()
+	hbm := system.NewIDSet()
 	for _, id := range mems.SortedMembers() {
 		node := p.sys.Node(id)
 		switch node.GetMemoryType() {
@@ -282,8 +282,8 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 		case system.MemoryTypePMEM:
 			pmem.Add(id)
 			/*
-			   case system.MemoryTypeHBMEM:
-			       hbmem.Add(id)
+				case system.MemoryTypeHBM:
+					hbm.Add(id)
 			*/
 		}
 	}
@@ -294,8 +294,8 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 	if pmem.Size() > 0 {
 		data["PMEM_MEMS"] = pmem.String()
 	}
-	if hbmem.Size() > 0 {
-		data["HBMEM_MEMS"] = hbmem.String()
+	if hbm.Size() > 0 {
+		data["HBM_MEMS"] = hbm.String()
 	}
 
 	return data

--- a/pkg/cri/resource-manager/policy/builtin/memtier/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/node.go
@@ -128,7 +128,7 @@ type node struct {
 	freeres  Supply       // CPU and memory allocatable at this node
 	mem      system.IDSet // controllers with normal DRAM attached
 	pMem     system.IDSet // controllers with PMEM attached
-	hbMem    system.IDSet // controllers with HBM attached
+	hbm      system.IDSet // controllers with HBM attached
 }
 
 // nodeself is used to 'upcast' a generic Node interface to a type-specific one.
@@ -280,7 +280,7 @@ func (n *node) Dump(prefix string, level ...int) {
 	log.Debug("%s  - node CPU: %v", idt, n.noderes)
 	log.Debug("%s  - free CPU: %v", idt, n.freeres)
 	log.Debug("%s  - normal memory: %v", idt, n.mem)
-	log.Debug("%s  - HBM memory: %v", idt, n.hbMem)
+	log.Debug("%s  - HBM memory: %v", idt, n.hbm)
 	log.Debug("%s  - PMEM memory: %v", idt, n.pMem)
 	for _, grant := range n.policy.allocations.grants {
 		if grant.GetCPUNode().NodeID() == n.id {
@@ -398,8 +398,8 @@ func (n *node) GetMemoryType() memoryType {
 	if n.mem.Size() > 0 {
 		memoryMask |= memoryDRAM
 	}
-	if n.hbMem.Size() > 0 {
-		memoryMask |= memoryHBMEM
+	if n.hbm.Size() > 0 {
+		memoryMask |= memoryHBM
 	}
 	return memoryMask
 }
@@ -451,7 +451,7 @@ func (n *numanode) DiscoverSupply() Supply {
 		mem = createMemoryMap(meminfo.MemTotal, 0, 0)
 	case memoryPMEM:
 		mem = createMemoryMap(0, meminfo.MemTotal, 0)
-	case memoryHBMEM:
+	case memoryHBM:
 		mem = createMemoryMap(0, 0, meminfo.MemTotal)
 	case memoryUnspec:
 		mem = createMemoryMap(meminfo.MemTotal, 0, 0)
@@ -482,8 +482,8 @@ func (n *numanode) GetMemset(mtype memoryType) system.IDSet {
 	if mtype&memoryDRAM != 0 {
 		mset.Add(n.mem.Members()...)
 	}
-	if mtype&memoryHBMEM != 0 {
-		mset.Add(n.hbMem.Members()...)
+	if mtype&memoryHBM != 0 {
+		mset.Add(n.hbm.Members()...)
 	}
 	if mtype&memoryPMEM != 0 {
 		mset.Add(n.pMem.Members()...)
@@ -496,7 +496,7 @@ func (n *numanode) GetMemset(mtype memoryType) system.IDSet {
 func (n *numanode) DiscoverMemset() {
 	nID := n.sysnode.ID()
 	n.mem = system.NewIDSet(nID)
-	n.hbMem = system.NewIDSet()
+	n.hbm = system.NewIDSet()
 	n.pMem = system.NewIDSet()
 
 	if !n.IsLeafNode() {
@@ -601,7 +601,7 @@ func (n *socketnode) DiscoverSupply() Supply {
 				mem = createMemoryMap(meminfo.MemTotal, 0, 0)
 			case memoryPMEM:
 				mem = createMemoryMap(0, meminfo.MemTotal, 0)
-			case memoryHBMEM:
+			case memoryHBM:
 				mem = createMemoryMap(0, 0, meminfo.MemTotal)
 			case memoryUnspec:
 				mem = createMemoryMap(meminfo.MemTotal, 0, 0)
@@ -631,8 +631,8 @@ func (n *socketnode) GetMemset(mtype memoryType) system.IDSet {
 	if mtype&memoryDRAM != 0 {
 		mset.Add(n.mem.Members()...)
 	}
-	if mtype&memoryHBMEM != 0 {
-		mset.Add(n.hbMem.Members()...)
+	if mtype&memoryHBM != 0 {
+		mset.Add(n.hbm.Members()...)
 	}
 	if mtype&memoryPMEM != 0 {
 		mset.Add(n.pMem.Members()...)
@@ -644,11 +644,11 @@ func (n *socketnode) GetMemset(mtype memoryType) system.IDSet {
 // DiscoverMemset discovers the set of memory attached to this socket.
 func (n *socketnode) DiscoverMemset() {
 	n.mem = system.NewIDSet()
-	n.hbMem = system.NewIDSet()
+	n.hbm = system.NewIDSet()
 	n.pMem = system.NewIDSet()
 	for _, c := range n.children {
 		n.mem.Add(c.GetMemset(memoryDRAM).Members()...)
-		n.hbMem.Add(c.GetMemset(memoryHBMEM).Members()...)
+		n.hbm.Add(c.GetMemset(memoryHBM).Members()...)
 		n.pMem.Add(c.GetMemset(memoryPMEM).Members()...)
 	}
 }
@@ -708,8 +708,8 @@ func (n *virtualnode) GetMemset(mtype memoryType) system.IDSet {
 	if mtype&memoryDRAM != 0 {
 		mset.Add(n.mem.Members()...)
 	}
-	if mtype&memoryHBMEM != 0 {
-		mset.Add(n.hbMem.Members()...)
+	if mtype&memoryHBM != 0 {
+		mset.Add(n.hbm.Members()...)
 	}
 	if mtype&memoryPMEM != 0 {
 		mset.Add(n.pMem.Members()...)
@@ -721,11 +721,11 @@ func (n *virtualnode) GetMemset(mtype memoryType) system.IDSet {
 // DiscoverMemset discovers the set of memory attached to this socket.
 func (n *virtualnode) DiscoverMemset() {
 	n.mem = system.NewIDSet()
-	n.hbMem = system.NewIDSet()
+	n.hbm = system.NewIDSet()
 	n.pMem = system.NewIDSet()
 	for _, c := range n.children {
 		n.mem.Add(c.GetMemset(memoryDRAM).Members()...)
-		n.hbMem.Add(c.GetMemset(memoryHBMEM).Members()...)
+		n.hbm.Add(c.GetMemset(memoryHBM).Members()...)
 		n.pMem.Add(c.GetMemset(memoryPMEM).Members()...)
 	}
 }

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences.go
@@ -40,15 +40,15 @@ const (
 var memoryNamedTypes = map[string]memoryType{
 	"dram":  memoryDRAM,
 	"pmem":  memoryPMEM,
-	"hbmem": memoryHBMEM,
+	"hbm":   memoryHBM,
 	"mixed": memoryAll,
 }
 
 // names by memory type
 var memoryTypeNames = map[memoryType]string{
-	memoryDRAM:  "DRAM",
-	memoryPMEM:  "PMEM",
-	memoryHBMEM: "HBMEM",
+	memoryDRAM: "DRAM",
+	memoryPMEM: "PMEM",
+	memoryHBM:  "HBM",
 }
 
 // memoryType is bitmask of types of memory to allocate
@@ -59,7 +59,7 @@ const (
 	memoryUnspec memoryType = (0x1 << iota) >> 1
 	memoryDRAM
 	memoryPMEM
-	memoryHBMEM
+	memoryHBM
 	memoryFirstUnusedBit
 	memoryAll = memoryFirstUnusedBit - 1
 
@@ -239,7 +239,7 @@ func memoryAllocationPreference(pod cache.Pod, c cache.Container) (uint64, uint6
 func (t memoryType) String() string {
 	str := ""
 	sep := ""
-	for _, bit := range []memoryType{memoryDRAM, memoryPMEM, memoryHBMEM} {
+	for _, bit := range []memoryType{memoryDRAM, memoryPMEM, memoryHBM} {
 		if int(t)&int(bit) != 0 {
 			str += sep + memoryTypeNames[bit]
 			sep = ","

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -511,8 +511,8 @@ func (p *policy) filterInsufficientResources(req Request, originals []Node) []No
 				bitsToFit -= supply.MemoryLimit()[memoryDRAM] - supply.ExtraMemoryReservation(memoryDRAM)
 			}
 		}
-		if memType&memoryHBMEM != 0 {
-			if supply.MemoryLimit()[memoryHBMEM]-supply.ExtraMemoryReservation(memoryHBMEM) >= bitsToFit {
+		if memType&memoryHBM != 0 {
+			if supply.MemoryLimit()[memoryHBM]-supply.ExtraMemoryReservation(memoryHBM) >= bitsToFit {
 				filtered = append(filtered, node)
 			}
 		}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -227,7 +227,7 @@ func createMemoryMap(normalMemory, persistentMemory, hbMemory uint64) memoryMap 
 	return memoryMap{
 		memoryDRAM:   normalMemory,
 		memoryPMEM:   persistentMemory,
-		memoryHBMEM:  hbMemory,
+		memoryHBM:    hbMemory,
 		memoryAll:    normalMemory + persistentMemory + hbMemory,
 		memoryUnspec: 0,
 	}
@@ -333,7 +333,7 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 	amount := cr.MemAmountToAllocate()
 	remaining := amount
 
-	// First allocate from PMEM, then DRAM, finally HBMEM. No need to care about
+	// First allocate from PMEM, then DRAM, finally HBM. No need to care about
 	// extra memory reservations since the nodes into which the request won't
 	// fit have already been filtered out.
 
@@ -367,17 +367,17 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 		}
 	}
 
-	if remaining > 0 && memType&memoryHBMEM != 0 {
-		available := cs.mem[memoryHBMEM] - cs.grantedMem[memoryHBMEM]
+	if remaining > 0 && memType&memoryHBM != 0 {
+		available := cs.mem[memoryHBM] - cs.grantedMem[memoryHBM]
 		if remaining < available {
-			cs.grantedMem[memoryHBMEM] += remaining
-			cs.mem[memoryHBMEM] -= remaining
-			allocatedMem[memoryHBMEM] = remaining
+			cs.grantedMem[memoryHBM] += remaining
+			cs.mem[memoryHBM] -= remaining
+			allocatedMem[memoryHBM] = remaining
 			remaining = 0
 		} else {
-			cs.grantedMem[memoryHBMEM] += available
-			cs.mem[memoryHBMEM] = 0
-			allocatedMem[memoryHBMEM] = available
+			cs.grantedMem[memoryHBM] += available
+			cs.mem[memoryHBM] = 0
+			allocatedMem[memoryHBM] = available
 			remaining -= available
 		}
 	}


### PR DESCRIPTION
Based on comment https://github.com/intel/cri-resource-manager/pull/264#commitcomment-38987172, it seems that it would be better to use HBM instead of HBMEM in memtier. Do a project-wide string replacement. This breaks HBM annotation API (memory type was `hbmem` but is now `hbm`).