### PR TITLE
agent: call log.Flush() to disable log buffering

### DIFF
--- a/cmd/cri-resmgr-agent/main.go
+++ b/cmd/cri-resmgr-agent/main.go
@@ -24,7 +24,10 @@ import (
 )
 
 func main() {
+	// Disable buffering and make sure that all messages have been emitted at
+	// program exit
 	log.Flush()
+	defer log.Flush()
 
 	flag.Parse()
 

--- a/cmd/cri-resmgr-agent/main.go
+++ b/cmd/cri-resmgr-agent/main.go
@@ -24,16 +24,16 @@ import (
 )
 
 func main() {
-	logger := log.Default()
+	log.Flush()
 
 	flag.Parse()
 
 	a, err := agent.NewResourceManagerAgent()
 	if err != nil {
-		logger.Fatal("failed to create resource manager agent instance: %v", err)
+		log.Fatal("failed to create resource manager agent instance: %v", err)
 	}
 
 	if err := a.Run(); err != nil {
-		logger.Fatal("%v", err)
+		log.Fatal("%v", err)
 	}
 }


### PR DESCRIPTION
Call log.Flush() once in the beginning of main() in order to disable log
buffering (and thus, get rid of delayed log messages). Also, instead of
explicitly getting the default logger instance, use convenience logging
functions of the log package in main().