### PR TITLE
documentation: reorganise README.md, minor fixes.

### DIFF
--- a/sample-configs/memtier-policy.cfg
+++ b/sample-configs/memtier-policy.cfg
@@ -1,0 +1,8 @@
+policy:
+  Active: memtier
+  ReservedResources:
+    CPU: 750m
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy
+dump:
+  Config: off:.*,full:((Create)|(Start)|(Run)|(Update)|(Stop)|(Remove)).*


### PR DESCRIPTION
Reorganise README.md, adding a quick start section to the beginning. Minor fixes to the most ancient/outdated pieces. Add referenced memtier policy sample configuration.