### PR TITLE
devel: add support for policy events, add/generate container startup event.

### DIFF
--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -92,7 +92,7 @@ func (m *resmgr) stopEventProcessing() {
 	}
 }
 
-// SendEvent injects the given event to the resource manaager's event processing loop.
+// SendEvent injects the given event to the resource manager's event processing loop.
 func (m *resmgr) SendEvent(event interface{}) error {
 	if m.events == nil {
 		return resmgrError("can't send event, no event channel")

--- a/pkg/cri/resource-manager/events/events.go
+++ b/pkg/cri/resource-manager/events/events.go
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+// Metrics is a set of metrics-related events we might need to act upon.
+type Metrics struct {
+	// Avx describes changes in container AVX512 instruction usage.
+	Avx *Avx
+}
+
+// AVX contains data related to container AVX512 instruction usage.
+type Avx struct {
+	// Updates contains containers with a change in their AVX512 instruction usage.
+	Updates map[string]bool
+}
+
+// Policy is a policy-specific event to be handled by the active policy.
+type Policy struct {
+	// Event is the policy-specific type of this event.
+	Type string
+	// Source describes where this event is originated from.
+	Source string
+	// Data is any optional arbitrary data associated with this event.
+	Data interface{}
+}

--- a/pkg/cri/resource-manager/events/events.go
+++ b/pkg/cri/resource-manager/events/events.go
@@ -35,3 +35,8 @@ type Policy struct {
 	// Data is any optional arbitrary data associated with this event.
 	Data interface{}
 }
+
+const (
+	// ContainerStarted is delivered to policies when a StartContainer request succeeds.
+	ContainerStarted = "container-started"
+)

--- a/pkg/cri/resource-manager/metrics/avx.go
+++ b/pkg/cri/resource-manager/metrics/avx.go
@@ -19,15 +19,10 @@ import (
 	"path/filepath"
 
 	"github.com/intel/cri-resource-manager/pkg/cgroups"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 )
 
-// AvxEvent describes cgroup/container AVX512 instruction usage.
-type AvxEvent struct {
-	// Updates contains updates to cgroup/container AVX512 instruction usage.
-	Updates map[string]bool
-}
-
-func (m *Metrics) collectAvxEvents(raw map[string]*model.MetricFamily) *AvxEvent {
+func (m *Metrics) collectAvxEvents(raw map[string]*model.MetricFamily) *events.Avx {
 	all, ok := raw["all_switch_count_per_cgroup"]
 	if !ok {
 		return nil
@@ -63,5 +58,5 @@ func (m *Metrics) collectAvxEvents(raw map[string]*model.MetricFamily) *AvxEvent
 		usage["/"+cgroup] = active
 	}
 
-	return &AvxEvent{Updates: usage}
+	return &events.Avx{Updates: usage}
 }

--- a/pkg/cri/resource-manager/metrics/metrics.go
+++ b/pkg/cri/resource-manager/metrics/metrics.go
@@ -27,6 +27,7 @@ import (
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/instrumentation"
 	"github.com/intel/cri-resource-manager/pkg/metrics"
 	// pull in all metrics collectors
@@ -37,11 +38,6 @@ const (
 	// DefaultAvxThreshold is the cutoff below which a cgroup/container is not an AVX user.
 	DefaultAvxThreshold = float64(0.1)
 )
-
-// Event is a set of metrics events we deliver to be acted upon.
-type Event struct {
-	Avx *AvxEvent // AVX512 container usage changes
-}
 
 // Options describes options for metrics collection and processing.
 type Options struct {
@@ -164,7 +160,7 @@ func (m *Metrics) process() error {
 		raw[*f.Name] = f
 	}
 
-	event := &Event{
+	event := &events.Metrics{
 		Avx: m.collectAvxEvents(raw),
 	}
 
@@ -172,7 +168,7 @@ func (m *Metrics) process() error {
 }
 
 // sendEvent sends a metrics-based event for processing.
-func (m *Metrics) sendEvent(e *Event) error {
+func (m *Metrics) sendEvent(e *events.Metrics) error {
 	select {
 	case m.opts.Events <- e:
 		return nil

--- a/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 
 	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
@@ -207,6 +208,12 @@ func (p *policy) Rebalance() (bool, error) {
 	}
 
 	return true, errors
+}
+
+// HandleEvent handles policy-specific events.
+func (p *policy) HandleEvent(*events.Policy) (bool, error) {
+	log.Debug("should handle policy event %v...")
+	return false, nil
 }
 
 // Introspect provides data for external introspection.

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -16,6 +16,7 @@ package none
 
 import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
@@ -85,6 +86,12 @@ func (n *none) UpdateResources(c cache.Container) error {
 // Rebalance tries to find an optimal allocation of resources for the current containers.
 func (n *none) Rebalance() (bool, error) {
 	n.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
+// HandleEvent handles policy-specific events.
+func (n *none) HandleEvent(*events.Policy) (bool, error) {
+	n.Debug("(not) handling event...")
 	return false, nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
@@ -171,6 +172,12 @@ func (p *staticplus) UpdateResources(c cache.Container) error {
 // Rebalance tries to find an optimal allocation of resources for the current containers.
 func (p *staticplus) Rebalance() (bool, error) {
 	p.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
+// HandleEvent handles policy-specific events.
+func (p *staticplus) HandleEvent(*events.Policy) (bool, error) {
+	p.Debug("(not) handling event...")
 	return false, nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/agent"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
@@ -241,6 +242,12 @@ func (stp *stp) UpdateResources(c cache.Container) error {
 // Rebalance tries to find an optimal allocation of resources for the current containers.
 func (stp *stp) Rebalance() (bool, error) {
 	stp.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
+// HandleEvent handles policy-specific events.
+func (stp *stp) HandleEvent(*events.Policy) (bool, error) {
+	stp.Debug("(not) handling event...")
 	return false, nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
@@ -166,6 +167,12 @@ func (s *static) UpdateResources(c cache.Container) error {
 // Rebalance tries to find an optimal allocation of resources for the current containers.
 func (s *static) Rebalance() (bool, error) {
 	s.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
+// HandleEvent handles policy-specific events.
+func (s *static) HandleEvent(*events.Policy) (bool, error) {
+	s.Debug("(not) handling event...")
 	return false, nil
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
@@ -207,6 +208,12 @@ func (p *policy) Rebalance() (bool, error) {
 	}
 
 	return true, errors
+}
+
+// HandleEvent handles policy-specific events.
+func (p *policy) HandleEvent(*events.Policy) (bool, error) {
+	log.Debug("(not) handling event...")
+	return false, nil
 }
 
 // ExportResourceData provides resource data to export for the container.

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -325,6 +325,15 @@ func (m *resmgr) StartContainer(ctx context.Context, method string, request inte
 
 	container.UpdateState(cache.ContainerStateRunning)
 
+	e := &events.Policy{
+		Type:   events.ContainerStarted,
+		Source: "resource-manager",
+		Data:   container,
+	}
+	if _, err := m.policy.HandleEvent(e); err != nil {
+		m.Error("%s: policy failed to handle event %s: %v", method, e.Type, err)
+	}
+
 	if err := m.runPostStartHooks(ctx, method, container); err != nil {
 		m.Error("%s: failed to run post-start hooks for %s: %v",
 			method, container.PrettyName(), err)

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -20,6 +20,7 @@ import (
 	criapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/cri/server"
 )
@@ -472,6 +473,36 @@ func (m *resmgr) RebalanceContainers() error {
 
 	if changes {
 		if err := m.runPostUpdateHooks(context.Background(), method); err != nil {
+			m.Error("%s: failed to run post-update hooks: %v", method, err)
+			return resmgrError("%s: failed to run post-update hooks: %v", method, err)
+		}
+	}
+
+	m.cache.Save()
+	return nil
+}
+
+// DeliverPolicyEvent delivers a policy-specific event to the active policy.
+func (m *resmgr) DeliverPolicyEvent(e *events.Policy) error {
+	m.Lock()
+	defer m.Unlock()
+
+	if e.Source == "" {
+		e.Source = "unspecified"
+	}
+
+	m.Info("delivering policy event %s.%s...", e.Source, e.Type)
+
+	method := "DeliverPolicyEvent"
+	changes, err := m.policy.HandleEvent(e)
+
+	if err != nil {
+		m.Error("%s: handling event %s.%s failed: %v", method, e.Source, e.Type, err)
+		return err
+	}
+
+	if changes {
+		if err = m.runPostUpdateHooks(context.Background(), method); err != nil {
 			m.Error("%s: failed to run post-update hooks: %v", method, err)
 			return resmgrError("%s: failed to run post-update hooks: %v", method, err)
 		}

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -396,7 +396,7 @@ func (m *resmgr) setupPolicy() error {
 		m.cache.SetActivePolicy(active)
 	}
 
-	options := &policy.Options{AgentCli: m.agent}
+	options := &policy.Options{AgentCli: m.agent, SendEvent: m.SendEvent}
 	if m.policy, err = policy.NewPolicy(m.cache, options); err != nil {
 		return resmgrError("failed to create policy %s: %v", active, err)
 	}


### PR DESCRIPTION
This patch set extends the current resource manager event functionality in preparation for the memtier policy coldstart feature. The patch set
  - adds support for handling events in policies
  - adds support for generating events in policies
  - generates an event on successful container startup