### PR TITLE
resource-manager: disable periodic rebalancing by default.

### DIFF
--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -65,7 +65,7 @@ func init() {
 
 	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 30*time.Second,
 		"Interval for polling/gathering runtime metrics data. Use 'disable' for disabling.")
-	flag.DurationVar(&opt.RebalanceTimer, "rebalance-interval", 5*time.Minute,
+	flag.DurationVar(&opt.RebalanceTimer, "rebalance-interval", 0,
 		"Minimum interval between two container rebalancing attempts. Use 'disable' for disabling.")
 
 	flag.BoolVar(&opt.DisableUI, "disable-ui", false,


### PR DESCRIPTION
We don't have a real rebalancing algorithm. Before we do, it does not make sense to periodically trigger rebalancing. Hence disable it by default.