### PR TITLE
resource-manager: disable periodic metrics collection by default.

### DIFF
--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -63,7 +63,7 @@ func init() {
 	flag.StringVar(&opt.ForceConfigSignal, "force-config-signal", "SIGHUP",
 		"Signal used to reload forced configuration.")
 
-	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 30*time.Second,
+	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 0,
 		"Interval for polling/gathering runtime metrics data. Use 'disable' for disabling.")
 	flag.DurationVar(&opt.RebalanceTimer, "rebalance-interval", 5*time.Minute,
 		"Minimum interval between two container rebalancing attempts. Use 'disable' for disabling.")


### PR DESCRIPTION
We don't have a real rebalancing algorithm. Before we do, it does not make too much sense to collect metrics. Hence disable it by default.