### PR TITLE
resource-manager: disable periodic rebalancing by default.

### DIFF
--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -54,14 +54,25 @@ func (m *resmgr) startEventProcessing() error {
 
 	stop := m.stop
 	go func() {
-		rebalanceTimer := time.NewTicker(opt.RebalanceTimer)
+		var rebalanceTimer *time.Ticker
+		var rebalanceChan <-chan time.Time
+
+		if opt.RebalanceTimer > 0 {
+			rebalanceTimer = time.NewTicker(opt.RebalanceTimer)
+			rebalanceChan = rebalanceTimer.C
+		} else {
+			m.Info("periodic rebalancing is disabled")
+		}
 		for {
 			select {
 			case _ = <-stop:
+				if rebalanceTimer != nil {
+					rebalanceTimer.Stop()
+				}
 				return
 			case event := <-m.events:
 				m.processEvent(event)
-			case _ = <-rebalanceTimer.C:
+			case _ = <-rebalanceChan:
 				if err := m.RebalanceContainers(); err != nil {
 					evtlog.Error("rebalancing failed: %v", err)
 				}

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -65,7 +65,7 @@ func init() {
 
 	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 30*time.Second,
 		"Interval for polling/gathering runtime metrics data. Use 'disable' for disabling.")
-	flag.DurationVar(&opt.RebalanceTimer, "rebalance-interval", 5*time.Minute,
+	flag.DurationVar(&opt.RebalanceTimer, "rebalance-interval", 0,
 		"Minimum interval between two container rebalancing attempts. Use 'disable' for disabling.")
 
 	flag.BoolVar(&opt.DisableUI, "disable-ui", false,


### PR DESCRIPTION
We don't have a real rebalancing algorithm at the moment. Before we do, it does not make sense to periodically trigger rebalancing. Hence disable it by default.