### PR TITLE
instrumentation: disable Prometheus exporter, endpoint by default.

### DIFF
--- a/pkg/instrumentation/flags.go
+++ b/pkg/instrumentation/flags.go
@@ -47,9 +47,9 @@ const (
 	// defaultJaegerAgent is the default Jaeger agent endpoint.
 	defaultJaegerAgent = ""
 	// defaultHTTPEndpoint is the default HTTP endpoint serving Prometheus /metrics.
-	defaultHTTPEndpoint = ":8888"
+	defaultHTTPEndpoint = ""
 	// defaultPrometheusExport is the default state for Prometheus exporting.
-	defaultPrometheusExport = "true"
+	defaultPrometheusExport = "false"
 )
 
 // options encapsulates our configurable instrumentation parameters.


### PR DESCRIPTION
Since we don't collect metrics by default, these should be disabled as well.