### PR TITLE
memtier: add cold start feature.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -179,7 +179,7 @@ const (
 type Container interface {
 	// PrettyName returns the user-friendly <podname>:<containername> for the container.
 	PrettyName() string
-	// GetPod returns the pod of the container.
+	// GetPod returns the pod of the container and a boolean indicating if there was one.
 	GetPod() (Pod, bool)
 	// GetID returns the ID of the container.
 	GetID() string

--- a/pkg/cri/resource-manager/policy/builtin/memtier/README.md
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/README.md
@@ -55,6 +55,28 @@ metadata:
 The `memtier` policy will then aim to allocate resources from a topology
 node which can satisfy the memory requirements.
 
+The `memtier` policy supports "cold start" functionality. When cold start is
+enabled and the workload is allocated to a topology node with both DRAM and
+PMEM memory, the initial memory controller is only the PMEM controller. DRAM
+controller is added to the workload only after the cold start timeout is
+done. The effect of this is that allocated large unused memory areas of
+memory don't need to be migrated to PMEM, because it was allocated there to
+begin with. Cold start is configured like this in the pod metadata:
+
+```
+metadata:
+  annotations:
+    cri-resource-manager.intel.com/memory-type: |
+      container1: dram,pmem
+    cri-resource-manager.intel.com/cold-start: |
+      container1:
+        duration: 60s
+```
+
+In the above example, `container1` would be initially granted only PMEM
+memory controller, but after 60 seconds the DRAM controller would be
+added to the container memset.
+
 ## Container memory requests and limits
 
 Due to inaccuracies in how `cri-resmgr` calculates memory requests for

--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
@@ -91,6 +91,7 @@ type cachedGrant struct {
 	MemType     memoryType
 	Memset      system.IDSet
 	MemoryLimit memoryMap
+	ColdStart   int
 }
 
 func newCachedGrant(cg Grant) *cachedGrant {
@@ -107,6 +108,8 @@ func newCachedGrant(cg Grant) *cachedGrant {
 	for key, value := range cg.MemLimit() {
 		ccg.MemoryLimit[key] = value
 	}
+
+	ccg.ColdStart = cg.ColdStart()
 
 	return ccg
 }
@@ -129,6 +132,7 @@ func (ccg *cachedGrant) ToGrant(policy *policy) (Grant, error) {
 		ccg.MemType,
 		ccg.MemType,
 		ccg.MemoryLimit,
+		ccg.ColdStart,
 	)
 
 	if g.Memset().String() != ccg.Memset.String() {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
@@ -127,6 +127,7 @@ func (ccg *cachedGrant) ToGrant(policy *policy) (Grant, error) {
 		cpuset.MustParse(ccg.Exclusive),
 		ccg.Part,
 		ccg.MemType,
+		ccg.MemType,
 		ccg.MemoryLimit,
 	)
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
@@ -16,6 +16,7 @@ package memtier
 
 import (
 	"encoding/json"
+	"time"
 
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
@@ -91,7 +92,7 @@ type cachedGrant struct {
 	MemType     memoryType
 	Memset      system.IDSet
 	MemoryLimit memoryMap
-	ColdStart   int
+	ColdStart   time.Duration
 }
 
 func newCachedGrant(cg Grant) *cachedGrant {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache_test.go
@@ -88,11 +88,11 @@ func TestAllocationMarshalling(t *testing.T) {
 	}{
 		{
 			name: "non-zero Exclusive",
-			data: []byte(`{"key1":{"Exclusive":"1","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{}}}`),
+			data: []byte(`{"key1":{"Exclusive":"1","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{},"ColdStart":0}}`),
 		},
 		{
 			name: "zero Exclusive",
-			data: []byte(`{"key1":{"Exclusive":"","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{}}}`),
+			data: []byte(`{"key1":{"Exclusive":"","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{},"ColdStart":0}}`),
 		},
 	}
 	for _, tc := range tcases {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/coldstart.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/coldstart.go
@@ -1,0 +1,70 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memtier
+
+import (
+	"time"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
+)
+
+// trigger cold start for the container if necessary.
+func (p *policy) triggerColdStart(c cache.Container) error {
+	log.Info("coldstart: triggering coldstart for %s...", c.PrettyName())
+	g, ok := p.allocations.grants[c.GetCacheID()]
+	if !ok {
+		log.Warn("coldstart: no grant found, nothing to do...")
+		return nil
+	}
+
+	coldStart := g.ColdStart()
+	if coldStart <= 0 {
+		log.Info("coldstart: no coldstart, nothing to do...")
+		return nil
+	}
+
+	// start a timer to restore the grant memset to full.
+	duration := time.Duration(int64(coldStart) * int64(time.Millisecond))
+	// TODO: store the timer so that we can release it if the grant is destroyed before the timer elapses
+	timer := time.AfterFunc(duration, func() {
+		e := &events.Policy{
+			Type:   ColdStartDone,
+			Source: PolicyName,
+			Data:   c.GetID(),
+		}
+		if err := p.options.SendEvent(e); err != nil {
+			// we should retry this later, the channel is probably full...
+			log.Error("Ouch... we'should retry this later.")
+		}
+	})
+	g.AddTimer(timer)
+	return nil
+}
+
+// finish an ongoing coldstart for the container.
+func (p *policy) finishColdStart(c cache.Container) (bool, error) {
+	g, ok := p.allocations.grants[c.GetCacheID()]
+	if !ok {
+		log.Warn("coldstart: no grant found, nothing to do...")
+		return false, policyError("coldstart: no grant found for %s", c.PrettyName())
+	}
+
+	log.Info("restoring memset to grant %v", g)
+	g.RestoreMemset()
+	g.ClearTimer()
+
+	return true, nil
+}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/coldstart.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/coldstart.go
@@ -36,9 +36,10 @@ func (p *policy) triggerColdStart(c cache.Container) error {
 		return nil
 	}
 
-	// start a timer to restore the grant memset to full.
-	duration := time.Duration(int64(coldStart) * int64(time.Millisecond))
-	// TODO: store the timer so that we can release it if the grant is destroyed before the timer elapses
+	// Start a timer to restore the grant memset to full. Store the
+	// timer so that we can release it if the grant is destroyed before
+	// the timer elapses.
+	duration := coldStart
 	timer := time.AfterFunc(duration, func() {
 		e := &events.Policy{
 			Type:   ColdStartDone,

--- a/pkg/cri/resource-manager/policy/builtin/memtier/coldstart_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/coldstart_test.go
@@ -1,0 +1,226 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memtier
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
+	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+var globalPolicy *policy
+var mutex sync.Mutex
+
+func sendEvent(param interface{}) error {
+	// Simulate event synchronization in the upper levels.
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	fmt.Printf("Event received: %v", param)
+	event := param.(*events.Policy)
+	globalPolicy.HandleEvent(event)
+	return nil
+}
+
+func TestColdStart(t *testing.T) {
+
+	// Idea with cold start is that the workload is first allocated only PMEM node. Only when timer expires
+	// (or some other event is triggered) is the DRAM node added to the memset. This causes the initial
+	// memory allocations to be made from PMEM only.
+
+	tcases := []struct {
+		name                     string
+		nodes                    []Node
+		numaNodes                []system.Node
+		req                      Request
+		affinities               map[int]int32
+		tree                     map[int][]int
+		container                cache.Container
+		expectedColdStartTimeout time.Duration
+		expectedDRAMNodeID       int
+		expectedPMEMNodeID       int
+		expectedDRAMSystemNodeID system.ID
+		expectedPMEMSystemNodeID system.ID
+	}{
+		{
+			name: "three node cold start",
+			nodes: []Node{
+				&socketnode{
+					node: node{
+						id:      100,
+						name:    "testnode-root",
+						kind:    UnknownNode,
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10000, 50000, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10000, 50000, 0), createMemoryMap(0, 0, 0)),
+					},
+				},
+				&numanode{
+					node: node{
+						id:      101,
+						name:    "testnode-dram",
+						kind:    UnknownNode,
+						mem:     system.NewIDSet(11),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10000, 0, 0), createMemoryMap(0, 0, 0)),
+					},
+					id: 1, // system node id
+				},
+				&numanode{
+					node: node{
+						id:      102,
+						name:    "testnode-pmem",
+						kind:    UnknownNode,
+						pMem:    system.NewIDSet(12),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(0, 50000, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(0, 50000, 0), createMemoryMap(0, 0, 0)),
+					},
+					id: 2, // system node id
+				},
+			},
+			numaNodes: []system.Node{
+				&mockSystemNode{id: 1, memFree: 10000, memTotal: 10000, memType: system.MemoryTypeDRAM, distance: []int{5, 5, 1}},
+				&mockSystemNode{id: 2, memFree: 50000, memTotal: 50000, memType: system.MemoryTypePMEM, distance: []int{5, 1, 5}},
+			},
+			container: &mockContainer{
+				name:                     "demo-coldstart-container",
+				returnValueForGetCacheID: "1234",
+				pod: &mockPod{
+					coldStartTimeout:                   1000 * time.Millisecond,
+					returnValue1FotGetResmgrAnnotation: "demo-coldstart-container: pmem,dram",
+					returnValue2FotGetResmgrAnnotation: true,
+					coldStartContainerName:             "demo-coldstart-container",
+				},
+			},
+			tree:                     map[int][]int{100: {101, 102}, 101: {}, 102: {}},
+			expectedColdStartTimeout: 1000 * time.Millisecond,
+			expectedDRAMNodeID:       101,
+			expectedDRAMSystemNodeID: system.ID(1),
+			expectedPMEMSystemNodeID: system.ID(2),
+			expectedPMEMNodeID:       102,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			setLinks(tc.nodes, tc.tree)
+			policy := &policy{
+				sys: &mockSystem{
+					nodes: tc.numaNodes,
+				},
+				pools: tc.nodes,
+				cache: &mockCache{
+					returnValue1ForLookupContainer: tc.container,
+					returnValue2ForLookupContainer: true,
+				},
+				root:    tc.nodes[0],
+				nodeCnt: len(tc.nodes),
+				allocations: allocations{
+					grants: make(map[string]Grant, 0),
+				},
+				options: policyapi.BackendOptions{},
+			}
+			// back pointers
+			for _, node := range tc.nodes {
+				switch node.(type) {
+				case *numanode:
+					numaNode := node.(*numanode)
+					numaNode.self.node = numaNode
+					noderes := numaNode.noderes.(*supply)
+					noderes.node = node
+					freeres := numaNode.freeres.(*supply)
+					freeres.node = node
+					numaNode.policy = policy
+					if node.NodeID() == tc.expectedPMEMNodeID {
+						for _, sysnode := range tc.numaNodes {
+							if sysnode.ID() == tc.expectedPMEMSystemNodeID {
+								numaNode.sysnode = sysnode
+							}
+						}
+					} else if node.NodeID() == tc.expectedDRAMNodeID {
+						for _, sysnode := range tc.numaNodes {
+							if sysnode.ID() == tc.expectedDRAMSystemNodeID {
+								numaNode.sysnode = sysnode
+							}
+						}
+					}
+				case *virtualnode:
+					virtualNode := node.(*virtualnode)
+					virtualNode.self.node = virtualNode
+					noderes := virtualNode.noderes.(*supply)
+					noderes.node = node
+					freeres := virtualNode.freeres.(*supply)
+					freeres.node = node
+					virtualNode.policy = policy
+				case *socketnode:
+					socketNode := node.(*socketnode)
+					socketNode.self.node = socketNode
+					noderes := socketNode.noderes.(*supply)
+					noderes.node = node
+					freeres := socketNode.freeres.(*supply)
+					freeres.node = node
+					socketNode.policy = policy
+				}
+			}
+			policy.allocations.policy = policy
+			policy.options.SendEvent = sendEvent
+			tc.nodes[1].DiscoverMemset()
+			tc.nodes[2].DiscoverMemset()
+
+			grant, err := policy.allocatePool(tc.container)
+			if err != nil {
+				panic(err)
+			}
+			if grant.ColdStart() != tc.expectedColdStartTimeout {
+				t.Errorf("Expected coldstart value '%v', but got '%v'", tc.expectedColdStartTimeout, grant.ColdStart())
+			}
+
+			policy.allocations.grants[tc.container.GetCacheID()] = grant
+
+			mems := grant.Memset()
+			if len(mems) != 1 || mems.Members()[0] != tc.expectedPMEMSystemNodeID {
+				t.Errorf("Expected one memory controller %v, got: %v", tc.expectedPMEMSystemNodeID, mems)
+			}
+
+			if grant.MemoryType()&memoryDRAM != 0 {
+				// FIXME: should we report only the limited memory types or the granted types
+				// while the cold start is going on?
+				// t.Errorf("No DRAM was expected before coldstart timer: %v", grant.MemoryType())
+			}
+
+			globalPolicy = policy
+
+			policy.options.SendEvent(&events.Policy{
+				Type: events.ContainerStarted,
+				Data: tc.container,
+			})
+
+			time.Sleep(tc.expectedColdStartTimeout * 2)
+
+			newMems := grant.Memset()
+			if len(newMems) != 2 {
+				t.Errorf("Expected two memory controllers, got %d: %v", len(newMems), newMems)
+			}
+			if !newMems.Has(tc.expectedPMEMSystemNodeID) || !newMems.Has(tc.expectedDRAMSystemNodeID) {
+				t.Errorf("Didn't get all expected system nodes in mems, got: %v", newMems)
+			}
+		})
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
@@ -27,6 +27,8 @@ import (
 
 	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+
+	"sync"
 )
 
 const (
@@ -60,6 +62,7 @@ type policy struct {
 	depth        int                       // tree depth
 	allocations  allocations               // container pool assignments
 	cpuAllocator cpuallocator.CPUAllocator // CPU allocator used by the policy
+	updateLock   sync.Mutex
 }
 
 // Make sure policy implements the policy.Backend interface.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences.go
@@ -16,8 +16,10 @@ package memtier
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -145,26 +147,54 @@ func podSharedCPUPreference(pod cache.Pod, container cache.Container) (bool, int
 	return true, int(elevate)
 }
 
+// ColdStartPreference lists the various ways the container can be configured to trigger
+// cold start. Currently, only timer is supported. If the "duration" is set to a duration
+// greater than 0, cold start is enabled and the DRAM controller is added to the container
+// after the duration has passed.
+type ColdStartPreference struct {
+	duration time.Duration
+}
+
+type coldStartPreferenceYaml struct {
+	Duration string // `yaml:"duration,omitempty"`
+}
+
 // coldStartPreference figures out if the container memory should be first allocated from PMEM.
 // It returns the time (in milliseconds) after which DRAM controller should be added to the mix.
-func coldStartPreference(pod cache.Pod, container cache.Container) (int, error) {
+func coldStartPreference(pod cache.Pod, container cache.Container) (ColdStartPreference, error) {
 	value, ok := pod.GetResmgrAnnotation(keyColdStartPreference)
 	if !ok {
-		return 0, nil
+		return ColdStartPreference{}, nil
 	}
-	preferences := map[string]int{}
+	preferences := map[string]coldStartPreferenceYaml{}
 	if err := yaml.Unmarshal([]byte(value), &preferences); err != nil {
 		log.Error("failed to parse cold start preference %s = '%s': %v",
 			keyColdStartPreference, value, err)
-		return 0, err
+		return ColdStartPreference{}, err
 	}
 	name := container.GetName()
-	coldStartTimeout, ok := preferences[name]
+	coldStartPreference, ok := preferences[name]
 	if !ok {
 		log.Debug("container %s has no entry among cold start preferences", container.PrettyName())
-		return 0, nil
+		return ColdStartPreference{}, nil
 	}
-	return coldStartTimeout, nil
+
+	// Parse the cold start data.
+	duration, err := time.ParseDuration(coldStartPreference.Duration)
+	if err != nil {
+		log.Error("failed to parse cold start timeout %s: %v",
+			coldStartPreference.Duration, err)
+		return ColdStartPreference{}, err
+	}
+
+	if duration < 0 || duration > time.Hour {
+		// Duration can't be negative. We also reject durations which are longer than one hour.
+		return ColdStartPreference{}, fmt.Errorf("failed to validate cold start timeout %s: value out of scope", duration.String())
+	}
+
+	return ColdStartPreference{
+		duration: duration,
+	}, nil
 }
 
 // cpuAllocationPreferences figures out the amount and kind of CPU to allocate.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -319,9 +319,6 @@ func (p *policy) allocatePool(container cache.Container) (Grant, error) {
 
 // Apply the result of allocation to the requesting container.
 func (p *policy) applyGrant(grant Grant) error {
-	p.updateLock.Lock()
-	defer p.updateLock.Unlock()
-
 	log.Debug("* applying grant %s", grant)
 
 	container := grant.GetContainer()

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -17,6 +17,7 @@ package memtier
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
@@ -91,6 +92,8 @@ type Request interface {
 	MemoryType() memoryType
 	// MemAmountToAllocate retuns how much memory we need to reserve for a request.
 	MemAmountToAllocate() uint64
+	// ColdStart returns the cold start timeout in milliseconds.
+	ColdStart() int
 }
 
 // Grant represents CPU and memory capacity allocated to a container from a node.
@@ -129,6 +132,13 @@ type Grant interface {
 	// UpdateExtraMemoryReservation() updates the reservations in the subtree
 	// of nodes under the node from which the memory was granted.
 	UpdateExtraMemoryReservation()
+	// RestoreMemset restores the granted memory set to node maximum
+	// and reapplies the grant.
+	RestoreMemset()
+	// AddTimer adds a cold start timer.
+	AddTimer(*time.Timer)
+	// StopTimer stops a cold start timer.
+	StopTimer()
 }
 
 // Score represents how well a supply can satisfy a request.
@@ -179,20 +189,29 @@ type request struct {
 	// go up in the tree starting at the best fitting pool, before assigning
 	// the container to an actual pool. Currently ignored.
 	elevate int
+
+	// coldStart tells the timeout (in milliseconds) how long to wait until
+	// a DRAM memory controller should be added to a container asking for a
+	// mixed DRAM/PMEM memory allocation. This allows for a "cold start" where
+	// initial memory requests are made to the PMEM memory. A value of -1
+	// indicates that cold start is not explicitly requested.
+	coldStart int
 }
 
 var _ Request = &request{}
 
 // grant implements our Grant interface.
 type grant struct {
-	container    cache.Container // container CPU is granted to
-	node         Node            // node CPU is supplied from
-	memoryNode   Node            // node memory is supplied from
-	exclusive    cpuset.CPUSet   // exclusive CPUs
-	portion      int             // milliCPUs granted from shared set
-	memType      memoryType      // requested types of memory
-	memset       system.IDSet    // assigned memory nodes
-	allocatedMem memoryMap       // memory limit
+	container      cache.Container // container CPU is granted to
+	node           Node            // node CPU is supplied from
+	memoryNode     Node            // node memory is supplied from
+	exclusive      cpuset.CPUSet   // exclusive CPUs
+	portion        int             // milliCPUs granted from shared set
+	memType        memoryType      // requested types of memory
+	fullMemType    memoryType      // after a cold start, restore
+	memset         system.IDSet    // assigned memory nodes
+	allocatedMem   memoryMap       // memory limit
+	coldStartTimer *time.Timer
 }
 
 var _ Grant = &grant{}
@@ -352,6 +371,10 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 		}
 	}
 
+	if remaining > 0 && cr.ColdStart() > 0 {
+		return nil, policyError("internal error: not enough memory at %s, short circuit due to cold start", cs.node.Name())
+	}
+
 	if remaining > 0 && memType&memoryDRAM != 0 {
 		available := cs.mem[memoryDRAM] - cs.grantedMem[memoryDRAM]
 		if remaining < available {
@@ -434,7 +457,25 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 		return nil, err
 	}
 
-	grant := newGrant(cs.node, cr.GetContainer(), exclusive, cr.fraction, cr.memType, allocatedMem)
+	// allocate only limited memory set due to cold start
+	memType := memoryPMEM
+	coldStart := cr.ColdStart()
+	if coldStart <= 0 {
+		memType = cr.memType
+	}
+
+	grant := newGrant(cs.node, cr.GetContainer(), exclusive, cr.fraction, memType, cr.memType, allocatedMem)
+
+	if coldStart > 0 {
+		// start a timer to restore the grant memset to full.
+		duration := time.Duration(int64(coldStart) * int64(time.Millisecond))
+		// TODO: store the timer so that we can release it if the grant is destroyed before the timer elapses
+		timer := time.AfterFunc(duration, func() {
+			log.Info("restoring memset to grant %v", grant)
+			grant.RestoreMemset()
+		})
+		grant.AddTimer(timer)
+	}
 
 	cs.node.DepthFirst(func(n Node) error {
 		n.FreeSupply().AccountAllocate(grant)
@@ -600,14 +641,24 @@ func (cs *supply) String() string {
 	return "<" + cs.node.Name() + " CPU: " + none + isolated + sharable + ", Mem: " + mem + ">"
 }
 
-// newRequest creates a new CPU request for the given container.
+// newRequest creates a new request for the given container.
 func newRequest(container cache.Container) Request {
 	pod, _ := container.GetPod()
 	full, fraction, isolate, elevate := cpuAllocationPreferences(pod, container)
-
 	req, lim, mtype := memoryAllocationPreference(pod, container)
+	coldStart := -1
+
 	if mtype == memoryUnspec {
 		mtype = defaultMemoryType
+	}
+
+	if mtype&memoryPMEM == memoryPMEM && mtype&memoryDRAM == memoryDRAM {
+		parsedColdStart, err := coldStartPreference(pod, container)
+		if err != nil {
+			log.Error("Failed to parse cold start preference")
+		} else {
+			coldStart = parsedColdStart
+		}
 	}
 
 	return &request{
@@ -619,6 +670,7 @@ func newRequest(container cache.Container) Request {
 		memLim:    lim,
 		memType:   mtype,
 		elevate:   elevate,
+		coldStart: coldStart,
 	}
 }
 
@@ -696,6 +748,11 @@ func (cr *request) MemAmountToAllocate() uint64 {
 // MemoryType returns the requested type of memory for the grant.
 func (cr *request) MemoryType() memoryType {
 	return cr.memType
+}
+
+// ColdStart returns the cold start timeout (in milliseconds).
+func (cr *request) ColdStart() int {
+	return cr.coldStart
 }
 
 // Score collects data for scoring this supply wrt. the given request.
@@ -797,8 +854,8 @@ func (score *score) String() string {
 }
 
 // newGrant creates a CPU grant from the given node for the container.
-func newGrant(n Node, c cache.Container, exclusive cpuset.CPUSet, portion int, mt memoryType, allocatedMem memoryMap) Grant {
-	mems := n.GetMemset(mt)
+func newGrant(n Node, c cache.Container, exclusive cpuset.CPUSet, portion int, initialMt, mt memoryType, allocatedMem memoryMap) Grant {
+	mems := n.GetMemset(initialMt)
 	if mems.Size() == 0 {
 		mems = n.GetMemset(memoryDRAM)
 		if mems.Size() == 0 {
@@ -899,6 +956,13 @@ func (cg *grant) String() string {
 func (cg *grant) Release() {
 	cg.GetCPUNode().FreeSupply().ReleaseCPU(cg)
 	cg.GetMemoryNode().FreeSupply().ReleaseMemory(cg)
+	cg.StopTimer()
+}
+
+func (cg *grant) RestoreMemset() {
+	mems := cg.GetMemoryNode().GetMemset(cg.memType)
+	cg.memset = mems
+	cg.GetMemoryNode().Policy().applyGrant(cg)
 }
 
 func (cg *grant) ExpandMemset() (bool, error) {
@@ -961,4 +1025,14 @@ func (cg *grant) UpdateExtraMemoryReservation() {
 		}
 		return nil
 	})
+}
+
+func (cg *grant) AddTimer(timer *time.Timer) {
+	cg.coldStartTimer = timer
+}
+
+func (cg *grant) StopTimer() {
+	if cg.coldStartTimer != nil {
+		cg.coldStartTimer.Stop()
+	}
 }


### PR DESCRIPTION
Add "cold start" functionality to the `memtier` policy. When cold start is enabled and the workload is allocated to a topology node with both DRAM and PMEM memory, the initial memory controller is only the PMEM controller. DRAM controller is added to the workload only after the cold start timeout is done. The effect of this is that allocated large unused memory areas of memory don't need to be migrated to PMEM, because it was allocated there to begin with. Cold start is configured like this in the pod metadata:

```
metadata:
  annotations:
    cri-resource-manager.intel.com/memory-type: |
      container1: dram,pmem
    cri-resource-manager.intel.com/cold-start: |
      container1: 
        duration: 60s
```

In the above example, `container1` would be initially granted only PMEM memory controller, but after 60000 milliseconds the DRAM controller would be added to the container memset.