### PR TITLE
memtier: don't crash if no suitable pools are found.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -117,6 +117,11 @@ func (p *policy) allocatePool(container cache.Container) (Grant, error) {
 			}
 		}
 
+		if len(pools) == 0 {
+			return nil, policyError("no suitable pool found for container %s",
+				container.PrettyName())
+		}
+
 		pool = pools[0]
 	}
 


### PR DESCRIPTION
Fail gracefully instead of crashing if filtering out pools with insufficient memory results in an empty set.