### PR TITLE
build: explicitly serialize go tests in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: make format
       - run: make
       - run: make golangci-lint
-      - run: make test
+      - run: make GO_PARALLEL="-p 1" test
       - run:
           name: Codecov report
           command: bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 # Go compiler/toolchain and extra related binaries we ues/need.
-GO_CMD    := go
-GO_BUILD  := $(GO_CMD) build
-GO_GEN    := $(GO_CMD) generate -x
-GO_FMT    := gofmt
-GO_CYCLO  := gocyclo
-GO_LINT   := golint
-GO_CILINT := golangci-lint
+GO_PARALLEL :=
+GO_CMD      := go
+GO_BUILD    := $(GO_CMD) build $(GO_PARALLEL)
+GO_GEN      := $(GO_CMD) generate -x
+GO_FMT      := gofmt
+GO_CYCLO    := gocyclo
+GO_LINT     := golint
+GO_CILINT   := golangci-lint
 
 # TEST_TAGS is the set of extra build tags passed for tests.
 # We disable AVX collector for tests by default.
 TEST_TAGS := noavx,test
-GO_TEST   := $(GO_CMD) test -tags $(TEST_TAGS)
+GO_TEST   := $(GO_CMD) test $(GO_PARALLEL) -tags $(TEST_TAGS)
 GO_VET    := $(GO_CMD) vet -tags $(TEST_TAGS)
 
 # Disable some golangci_lint checkers for now until we have an more acceptable baseline...


### PR DESCRIPTION
If go test is given a bunch of module paths it tries to test all of those in parallel using one instance per module directory. In CircleCI this seems to easily cause the exhaustion of memory and the tests to get killed by a SIGKILL.

As a workaround run tests explicitly with the golang toolchain parallel flag `-p 1` in CircleCI.