### PR TITLE
resmgr: don't call the agent when force-config flag is used

### DIFF
--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -80,8 +80,10 @@ func NewResourceManager() (ResourceManager, error) {
 		return nil, err
 	}
 
-	if err := m.setupConfigAgent(); err != nil {
-		return nil, err
+	if opt.ForceConfig == "" {
+		if err := m.setupConfigAgent(); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := m.loadConfig(); err != nil {


### PR DESCRIPTION
With setups where there's no agent and force-config is used, there's
no need to setup gprc.Dial. That keeps reconnecting and writing errors
to the log output.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>