### PR TITLE
build: add noavx tags to build without AVX-512 BPF collector

### DIFF
--- a/pkg/metrics/register/register_metrics.go
+++ b/pkg/metrics/register/register_metrics.go
@@ -1,8 +1,6 @@
 package register
 
 import (
-	// Pull in avx collector.
-	_ "github.com/intel/cri-resource-manager/pkg/avx"
 	// Pull in cgroup-based metric collector.
 	_ "github.com/intel/cri-resource-manager/pkg/cgroupstats"
 )

--- a/pkg/metrics/register/register_metrics_avx.go
+++ b/pkg/metrics/register/register_metrics_avx.go
@@ -1,0 +1,8 @@
+// +build !noavx
+
+package register
+
+import (
+	// Pull in avx collector.
+	_ "github.com/intel/cri-resource-manager/pkg/avx"
+)


### PR DESCRIPTION
Previously, noavx tag was only used to skip AVX-512 collector
registration during testing. A user may also want to build completely
without the avx package (and its dependencies).

We add more noavx tags to be able to make completely avx code free
build when using: make BUILD_TAGS="-tags noavx"

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>