### PR TITLE
tests: add critest for CRI validation, add blockio demo test mode

### DIFF
--- a/demo/blockio/run.sh
+++ b/demo/blockio/run.sh
@@ -5,16 +5,50 @@ DEMO_TITLE="CRI Resource Manager: Block I/O Demo"
 PV='pv -qL'
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-
 LIB_DIR=$SCRIPT_DIR/../lib
+BIN_DIR=${bindir-$(realpath "$SCRIPT_DIR/../../bin")}
+OUTPUT_DIR=${outdir-$SCRIPT_DIR/output}
+COMMAND_OUTPUT_DIR=$OUTPUT_DIR/commands
 
+source $LIB_DIR/command.bash
 source $LIB_DIR/host.bash
 source $LIB_DIR/vm.bash
 
+usage() {
+    echo "$DEMO_TITLE"
+    echo "Usage: [VAR=VALUE] ./run.sh MODE"
+    echo "  MODE:     \"play\" plays the demo."
+    echo "            \"record\" plays and records the demo."
+    echo "            \"test\" runs fast, reports pass or fail."
+    echo "  VARs:"
+    echo "    vm:      govm virtual machine name."
+    echo "             The default is \"crirm-demo-blockio\"."
+    echo "    speed:   Demo play speed."
+    echo "             The default is 10 (keypresses per second)."
+    echo "    cleanup: 0: leave VM running. (\"play\" mode default)"
+    echo "             1: delete VM (\"test\" mode default)"
+    echo "             2: stop VM, but do not delete it."
+    echo "    outdir:  Save output under given directory."
+    echo "             The default is \"${SCRIPT_DIR}/output\"."
+    echo "    binsrc:  Where to get cri-resmgr to the VM."
+    echo "             \"github\": go get and build in VM (\"play\" mode default)."
+    echo "             \"local\": copy from source tree bin/ (\"test\" mode default)"
+    echo "                      (set bindir=/path/to/cri-resmgr* to override bin/)"
+}
+
+error() {
+    (echo ""; echo "error: $1" ) >&2
+    exit 1
+}
+
 out() {
-    speed=${speed-10}
-    echo "$1" | $PV $speed
-    echo | $PV $speed
+    if [ -n "$PV" ]; then
+        speed=${speed-10}
+        echo "$1" | $PV $speed
+    else
+        echo "$1"
+    fi
+    echo ""
 }
 
 record() {
@@ -23,13 +57,8 @@ record() {
     host-command "asciinema rec -t \"$DEMO_TITLE\" crirm-demo-blockio.cast -c \"./run.sh play\""
 }
 
-error() {
-    (echo ""; echo "error: $1" ) >&2
-    exit 1
-}
-
 screen-create-vm() {
-    speed=60 out '### Running the demo in a single-node cluster in a VM.'
+    speed=60 out "### Running the demo in VM \"$vm\"."
     host-create-vm $vm
     vm-networking
     if [ -z "$VM_IP" ]; then
@@ -39,21 +68,26 @@ screen-create-vm() {
 
 screen-install-k8s() {
     speed=60 out "### Installing Kubernetes to the VM."
-    vm-command "apt update && apt install -y apt-transport-https curl containerd"
-    if [ -n "$http_proxy" ] || [ -n "$https_proxy" ] || [ -n "$no_proxy" ]; then
-        speed=120 vm-command "mkdir -p /etc/systemd/system/containerd.service.d; (echo '[Service]'; echo 'Environment=HTTP_PROXY=$http_proxy'; echo 'Environment=HTTPS_PROXY=$https_proxy'; echo \"Environment=NO_PROXY=$no_proxy,$VM_IP,10.96.0.0/12,10.217.0.0/16,\$(hostname)\" ) > /etc/systemd/system/containerd.service.d/proxy.conf; systemctl daemon-reload; systemctl restart containerd"
-    fi
-    speed=60 vm-command "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -"
-    speed=60 vm-command "echo \"deb https://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list"
-    vm-command "apt update &&  apt install -y kubelet kubeadm kubectl"
+    vm-install-containerd
+    vm-install-k8s
 }
 
 screen-install-cri-resmgr() {
+    prefix=/usr/local
     speed=60 out "### Installing CRI Resource Manager to VM."
-    vm-command "apt install -y golang make"
-    vm-command "go get -d -v github.com/intel/cri-resource-manager"
-    CRI_RESMGR_SOURCE_DIR=$(awk '/package.*cri-resource-manager/{print $NF}' < command.output)
-    vm-command "cd $CRI_RESMGR_SOURCE_DIR && make install && cd -"
+    if [ "$binsrc" == "github" ]; then
+        vm-command "apt install -y golang make"
+        vm-command "go get -d -v github.com/intel/cri-resource-manager"
+        CRI_RESMGR_SOURCE_DIR=$(awk '/package.*cri-resource-manager/{print $NF}' <<< "$COMMAND_OUTPUT")
+        vm-command "cd $CRI_RESMGR_SOURCE_DIR && make install && cd -"
+    elif [ "$binsrc" == "local" ]; then
+        host-command "scp \"$BIN_DIR/cri-resmgr\" \"$BIN_DIR/cri-resmgr-agent\" $VM_SSH_USER@$VM_IP:" || {
+            command-error "copying local cri-resmgr to VM failed"
+        }
+        vm-command "mv cri-resmgr cri-resmgr-agent $prefix/bin" || {
+            command-error "installing cri-resmgr to $prefix/bin failed"
+        }
+    fi
 }
 
 screen-launch-cri-resmgr() {
@@ -67,15 +101,15 @@ screen-create-singlenode-cluster() {
     speed=60 out "### Setting up single-node Kubernetes cluster."
     speed=60 out "### CRI Resource Manager + containerd will act as the container runtime."
     vm-command "kubeadm init --pod-network-cidr=10.217.0.0/16 --cri-socket /var/run/cri-resmgr/cri-resmgr.sock"
-    if ! grep -q "initialized successfully" command.output; then
-        error "kubeadm init failed"
+    if ! grep -q "initialized successfully" <<< "$COMMAND_OUTPUT"; then
+        command-error "kubeadm init failed"
     fi
     vm-command "mkdir -p \$HOME/.kube"
     vm-command "cp -i /etc/kubernetes/admin.conf \$HOME/.kube/config"
     vm-command "kubectl taint nodes --all node-role.kubernetes.io/master-"
     vm-command "kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.6/install/kubernetes/quick-install.yaml"
     if ! vm-command "kubectl rollout status --timeout=360s -n kube-system daemonsets/cilium"; then
-        error "installing cilium CNI to Kubernetes timed out"
+        command-error "installing cilium CNI to Kubernetes timed out"
     fi
 }
 
@@ -89,8 +123,9 @@ screen-measure-io-speed() {
     process=$1
     measuretime=2
     out "### Measuring $process read speed -- twice."
-    cmd="pid=\$(ps -A | awk \"/$process/{print \\\$1}\"); echo \$(grep read_bytes /proc/\$pid/io; sleep $measuretime; grep read_bytes /proc/\$pid/io) | awk \"{print \\\"$process read speed: \\\"(\\\$4-\\\$2)/$measuretime/1024\\\" kBps\\\"}\""
+    cmd="pid=\$(ps -A | awk \"/$process/{print \\\$1}\"); [ -n \"\$pid\" ] && { echo \$(grep read_bytes /proc/\$pid/io; sleep $measuretime; grep read_bytes /proc/\$pid/io) | awk \"{print \\\"$process read speed: \\\"(\\\$4-\\\$2)/$measuretime/1024\\\" kBps\\\"}\"; }"
     speed=360 outcolor=10 vm-command "$cmd"
+    sleep 1
     speed=360 outcolor=10 vm-command "$cmd"
 }
 
@@ -109,7 +144,7 @@ demo-blockio() {
     vm-command "kubectl create -f bb-scanner.yaml"
 
     out "### Now bb-scanner is running md5sum to all mounted directories, non-stop."
-    vm-wait-process md5sum
+    vm-wait-process md5sum 60
 
     screen-measure-io-speed md5sum
 
@@ -120,6 +155,10 @@ demo-blockio() {
     vm-command "cat cri-resmgr-config.default.yaml"
     vm-command "kubectl apply -f cri-resmgr-config.default.yaml"
 
+    # Give some time for new config to become effective and process
+    # I/O to accelerate.
+    sleep 2;
+
     screen-measure-io-speed md5sum
 
     out "### Thanks for watching!"
@@ -127,52 +166,106 @@ demo-blockio() {
     vm-command "kubectl delete daemonset bb-scanner"
 }
 
-if [ "$1" == "play" ]; then
-    vm=${vm-"crirm-demo-blockio"}
+# Validate parameters
+mode=$1
+vm=${vm-"crirm-demo-blockio"}
+
+if [ "$mode" == "play" ]; then
     speed=${speed-10}
-
-    if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ] || [ -z "$VM_NAME" ]; then
-        screen-create-vm
-    fi
-
-    if ! vm-command-q "dpkg -l | grep -q kubelet"; then
-        screen-install-k8s
-    fi
-
-    if ! vm-command-q "[ -f /usr/bin/cri-resmgr ]"; then
-        screen-install-cri-resmgr
-    fi
-
-    # start cri-resmgr if not already running
-    if ! vm-command-q "pidof cri-resmgr" >/dev/null; then
-        screen-launch-cri-resmgr
-    fi
-
-    # create kubernetes cluster or wait that it is online
-    if vm-command-q "[ ! -f /var/lib/kubelet/config.yaml ]"; then
-        screen-create-singlenode-cluster
-    else
-        # wait for kube-apiserver to launch (may be down if the VM was just booted)
-        vm-wait-process kube-apiserver
-    fi
-
-    # start cri-resmgr-agent if not already running
-    if ! vm-command-q "pidof cri-resmgr-agent >/dev/null"; then
-        screen-launch-cri-resmgr-agent
-    fi
-
-    demo-blockio
-
-    speed=120 out "The VM, Kubernetes and cri-resmgr are left running. Next steps:"
-    speed=120 out "- Login VM:     ssh $VM_SSH_USER@$VM_IP"
-    speed=120 out "- Stop VM:      govm stop $VM_NAME"
-    speed=120 out "- Delete VM:    govm delete $VM_NAME"
-
-elif [ "$1" == "record" ]; then
+    cleanup=${cleanup-0}
+    binsrc=${binsrc-github}
+elif [ "$mode" == "test" ]; then
+    PV=
+    cleanup=${cleanup-1}
+    binsrc=${binsrc-local}
+elif [ "$mode" == "record" ]; then
     record
 else
-    echo "$DEMO_TITLE"
-    echo "Usage: [speed=KEYPRESSES_PER_SECOND] [vm=VM_NAME] ./run.sh <play|record>"
-    echo "    The default speed is 10."
-    echo "    The default vm is \"crirm-demo-blockio\"."
+    usage
+    error "missing valid MODE"
+    exit 1
 fi
+
+# Prepare for test/demo
+mkdir -p $OUTPUT_DIR
+mkdir -p $COMMAND_OUTPUT_DIR
+rm -f $COMMAND_OUTPUT_DIR/0*
+( echo x > $OUTPUT_DIR/x && rm -f $OUTPUT_DIR/x ) || {
+    error "output directory outdir=$OUTPUT_DIR is not writable"
+}
+
+if [ "$binsrc" == "local" ]; then
+    [ -f "${BIN_DIR}/cri-resmgr" ] || error "missing \"${BIN_DIR}/cri-resmgr\""
+    [ -f "${BIN_DIR}/cri-resmgr-agent" ] || error "missing \"${BIN_DIR}/cri-resmgr-agent\""
+fi
+
+if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ] || [ -z "$VM_NAME" ]; then
+    screen-create-vm
+fi
+
+if ! vm-command-q "dpkg -l | grep -q kubelet"; then
+    screen-install-k8s
+fi
+
+if ! vm-command-q "[ -f /usr/bin/cri-resmgr ]"; then
+    screen-install-cri-resmgr
+fi
+
+# start cri-resmgr if not already running
+if ! vm-command-q "pidof cri-resmgr" >/dev/null; then
+    screen-launch-cri-resmgr
+fi
+
+# create kubernetes cluster or wait that it is online
+if vm-command-q "[ ! -f /var/lib/kubelet/config.yaml ]"; then
+    screen-create-singlenode-cluster
+else
+    # wait for kube-apiserver to launch (may be down if the VM was just booted)
+    vm-wait-process kube-apiserver
+fi
+
+# start cri-resmgr-agent if not already running
+if ! vm-command-q "pidof cri-resmgr-agent >/dev/null"; then
+    screen-launch-cri-resmgr-agent
+fi
+
+# Run test/demo
+demo-blockio
+
+# Cleanup
+if [ "$cleanup" == "0" ]; then
+    echo "The VM, Kubernetes and cri-resmgr are left running. Next steps:"
+    vm-print-usage
+elif [ "$cleanup" == "1" ]; then
+    host-stop-vm $vm
+    host-delete-vm $vm
+elif [ "$cleanup" == "2" ]; then
+    host-stop-vm $vm
+fi
+
+# Summarize results
+SUMMARY_FILE="$OUTPUT_DIR/summary.txt"
+echo -n "" > "$SUMMARY_FILE" || error "cannot write summary to \"$SUMMARY_FILE\""
+first_speed=$(grep "^md5sum read speed:" $COMMAND_OUTPUT_DIR/0* | head -n 1 | awk '{print $4}')
+last_speed=$(grep "^md5sum read speed:" $COMMAND_OUTPUT_DIR/0* | tail -n 1 | awk '{print $4}')
+echo "First md5sum read speed (512 kBps throttling): $first_speed kBps" >> "$SUMMARY_FILE"
+echo "Last  md5sum read speed (2 MBps throttling): $last_speed kBps" >> "$SUMMARY_FILE"
+# Declare verdict in test mode
+exit_status=0
+if [ "$mode" == "test" ]; then
+    min_first=100 max_first=600 min_last=1500 max_last=2500
+    [[ "$first_speed" -gt "$min_first" ]] || exit_status=1
+    [[ "$first_speed" -lt "$max_first" ]] || exit_status=1
+    [[ "$last_speed" -gt "$min_last" ]] || exit_status=1
+    [[ "$last_speed" -lt "$max_last" ]] || exit_status=1
+    if [ "$exit_status" == "1" ]; then
+        echo "Error: speeds outside acceptable ranges ($min_first..$max_first kBps and $min_last..$max_last kBps)." >> "$SUMMARY_FILE"
+        echo "Test verdict: FAIL" >> "$SUMMARY_FILE"
+    else
+        echo "Speeds within acceptable ranges ($min_first..$max_first kBps and $min_last..$max_last kBps)." >> "$SUMMARY_FILE"
+        echo "Test verdict: PASS" >> "$SUMMARY_FILE"
+    fi
+    echo ""
+    cat "$SUMMARY_FILE"
+fi
+exit $exit_status

--- a/demo/lib/command.bash
+++ b/demo/lib/command.bash
@@ -1,0 +1,77 @@
+# Hooks for displaying and logging how shell commands (local and
+# remote) are executed, and handling their output and exit status.
+#
+# Example in a Bash script, run-on-mytargethost function:
+#   command-start mytargethost "ls -la"
+#   ssh mytargethost $COMMAND 2>&1 | command-handle-output
+#   command-end ${PIPESTATUS[0]}
+#   [ "$COMMAND_STATUS" == "0" ] || command-error "non-zero exit status"
+#
+# command-start and command-end set environment variables:
+# COMMAND, COMMAND_STATUS, COMMAND_OUTPUT
+COMMAND_COUNTER=0
+command_init_time=$EPOCHREALTIME
+
+command-start() {
+    # example: command-start vm prompt "mkdir $MYDIR"
+    COMMAND_TARGET="$1"
+    COMMAND_PROMPT="$2"
+    COMMAND="$3"
+    COMMAND_STATUS=""
+    COMMAND_OUTPUT=""
+    COMMAND_COUNTER=$(( COMMAND_COUNTER + 1 ))
+    local command_start_time=$EPOCHREALTIME
+    local time_since_start=$(echo "$command_start_time - $command_init_time" | bc)
+    COMMAND_OUT_FILE="$COMMAND_OUTPUT_DIR/$(printf %04g $COMMAND_COUNTER)-$COMMAND_TARGET"
+    echo "# start time: $time_since_start" > "$COMMAND_OUT_FILE" || {
+        echo "cannot write command output to file \"$COMMAND_OUT_FILE\""
+        exit 1
+    }
+    echo "# command: $COMMAND" >> "$COMMAND_OUT_FILE"
+    echo -e -n "${COMMAND_PROMPT}"
+    if [ -n "$PV" ]; then
+        echo "$COMMAND" | $PV $speed
+    else
+        echo "$COMMAND"
+    fi
+    if [ -n "$outcolor" ]; then
+        COMMAND_OUTSTART="\e[38;5;${outcolor}m"
+        COMMAND_OUTEND="\e[0m"
+    else
+        COMMAND_OUTSTART=""
+        COMMAND_OUTEND=""
+    fi
+}
+
+command-handle-output() {
+    # example: sh -c $command | command-handle-output
+    tee "$COMMAND_OUT_FILE.tmp" | ( echo -e -n "$COMMAND_OUTSTART"; cat; echo -e -n "$COMMAND_OUTEND" )
+    cat "$COMMAND_OUT_FILE.tmp" >> "$COMMAND_OUT_FILE"
+    if [ -n "$PV" ]; then
+        echo | $PV $speed
+    fi
+}
+
+command-runs-in-bg() {
+    echo "(runs in background)"
+    echo ""
+}
+
+command-end() {
+    # example: command-end EXIT_STATUS
+    COMMAND_STATUS=$1
+    local command_end_time=$EPOCHREALTIME
+    local time_since_start=$(echo "$command_end_time - $command_init_time" | bc)
+    ( echo "# exit status: $COMMAND_STATUS"; echo "# end time: $time_since_start" ) >> "$COMMAND_OUT_FILE"
+    COMMAND_OUTPUT=$(<"$COMMAND_OUT_FILE.tmp")
+    rm -f "$COMMAND_OUT_FILE.tmp"
+}
+
+command-error() {
+    # example: command-error "creating directory failed"
+    ( echo "command:     $COMMAND";
+      echo "output:      $COMMAND_OUTPUT";
+      echo "exit status: $COMMAND_STATUS";
+      echo "error:       $1" ) >&2
+    exit 1
+}

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -1,27 +1,22 @@
+source "$(dirname "${BASH_SOURCE[0]}")/command.bash"
+
 VM_PROMPT=${VM_PROMPT-"\e[38;5;11mroot@vm>\e[0m "}
 VM_SSH_USER=ubuntu
 VM_IMAGE_URL=https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
 VM_IMAGE=$(basename "$VM_IMAGE_URL")
 
 vm-command() {
-    speed=${speed-10}
-    if [ -n "$outcolor" ]; then
-        OUTSTART="\e[38;5;${outcolor}m"
-        OUTEND="\e[0m"
+    command-start "vm" "$VM_PROMPT" "$1"
+    if [ "$2" == "bg" ]; then
+        ( ssh -o StrictHostKeyChecking=No ${VM_SSH_USER}@${VM_IP} sudo bash <<<"$COMMAND" 2>&1 | command-handle-output ;
+          command-end ${PIPESTATUS[0]}
+        ) &
+        command-runs-in-bg
     else
-        OUTSTART=""
-        OUTEND=""
+        ssh -o StrictHostKeyChecking=No ${VM_SSH_USER}@${VM_IP} sudo bash <<<"$COMMAND" 2>&1 | command-handle-output ;
+        command-end ${PIPESTATUS[0]}
     fi
-    if [ -n "$PV" ]; then
-        echo -e -n "${VM_PROMPT}"
-        echo "$1" | $PV $speed
-    fi
-    ssh -o StrictHostKeyChecking=No ${VM_SSH_USER}@${VM_IP} sudo bash <<<"$1" 2>&1 | tee command.output | ( echo -e -n "$OUTSTART"; cat; echo -e -n "$OUTEND" )
-    command_status=${PIPESTATUS[0]}
-    if [ -n "$PV" ]; then
-        echo | $PV $speed
-    fi
-    return $command_status
+    return $COMMAND_STATUS
 }
 
 vm-command-q() {
@@ -48,4 +43,71 @@ vm-networking() {
     if [ -n "$http_proxy" ] || [ -n "$https_proxy" ] || [ -n "$no_proxy" ]; then
         vm-command-q "grep -q no_proxy /etc/environment" || vm-command "(echo http_proxy=$http_proxy; echo https_proxy=$https_proxy; echo no_proxy=$no_proxy,$VM_IP,10.96.0.0/12,10.217.0.0/16,\$(hostname) ) >> /etc/environment"
     fi
+}
+
+vm-install-containerd() {
+    vm-command-q "[ -f /usr/bin/containerd ]" || {
+        vm-command "apt install -y containerd"
+        # Set proxy environment to containers managed by containerd, if needed.
+        if [ -n "$http_proxy" ] || [ -n "$https_proxy" ] || [ -n "$no_proxy" ]; then
+            speed=120 vm-command "mkdir -p /etc/systemd/system/containerd.service.d; (echo '[Service]'; echo 'Environment=HTTP_PROXY=$http_proxy'; echo 'Environment=HTTPS_PROXY=$https_proxy'; echo \"Environment=NO_PROXY=$no_proxy,$VM_IP,10.96.0.0/12,10.217.0.0/16,\$(hostname)\" ) > /etc/systemd/system/containerd.service.d/proxy.conf; systemctl daemon-reload; systemctl restart containerd"
+        fi
+    }
+}
+
+vm-install-containernetworking() {
+    vm-command-q "command -v go >/dev/null" || vm-command "apt install -y golang"
+    vm-command "go get -d github.com/containernetworking/plugins"
+    CNI_PLUGINS_SOURCE_DIR=$(awk '/package.*plugins/{print $NF}' <<< $COMMAND_OUTPUT)
+    [ -n "$CNI_PLUGINS_SOURCE_DIR" ] || {
+        command-error "downloading containernetworking plugins failed"
+    }
+    vm-command "pushd \"$CNI_PLUGINS_SOURCE_DIR\" && ./build_linux.sh && mkdir -p /opt/cni && cp -rv bin /opt/cni && popd" || {
+        command-error "building and installing cri-tools failed"
+    }
+    vm-command 'rm -rf /etc/cni/net.d && mkdir -p /etc/cni/net.d && cat > /etc/cni/net.d/10-bridge.conf <<EOF
+{
+  "cniVersion": "0.4.0",
+  "name": "mynet",
+  "type": "bridge",
+  "bridge": "cni0",
+  "isGateway": true,
+  "ipMasq": true,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.217.0.0/16",
+    "routes": [
+      { "dst": "0.0.0.0/0" }
+    ]
+  }
+}
+EOF'
+    vm-command 'cat > /etc/cni/net.d/20-portmap.conf <<EOF
+{
+    "cniVersion": "0.4.0",
+    "type": "portmap",
+    "capabilities": {"portMappings": true},
+    "snat": true
+}
+EOF'
+    vm-command 'cat > /etc/cni/net.d/99-loopback.conf <<EOF
+{
+  "cniVersion": "0.4.0",
+  "name": "lo",
+  "type": "loopback"
+}
+EOF'
+}
+
+vm-install-k8s() {
+    vm-command "apt update && apt install -y apt-transport-https curl"
+    speed=60 vm-command "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -"
+    speed=60 vm-command "echo \"deb https://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list"
+    vm-command "apt update &&  apt install -y kubelet kubeadm kubectl"
+}
+
+vm-print-usage() {
+    echo "- Login VM:     ssh $VM_SSH_USER@$VM_IP"
+    echo "- Stop VM:      govm stop $VM_NAME"
+    echo "- Delete VM:    govm delete $VM_NAME"
 }

--- a/test/critest/README.md
+++ b/test/critest/README.md
@@ -1,0 +1,19 @@
+# CRI Resource Manager: Container Runtime Interface Validation
+
+This test runs
+[`critest`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md)
+from [cri-tools](https://github.com/kubernetes-sigs/cri-tools/) to
+make sure that various `cri-resmgr` configurations do not break CRI
+runtime conformance.
+
+## Prerequisites
+
+Install:
+- `docker`
+- `govm`
+
+## Run the test
+
+```
+./run.sh test
+```

--- a/test/critest/memtier-policy.cfg
+++ b/test/critest/memtier-policy.cfg
@@ -1,0 +1,10 @@
+policy:
+  Active: memtier
+  ReservedResources:
+    CPU: 750m
+logger:
+  Debug: cri-resmgr,resource-manager,cache,dump,instrumentation,policy
+dump:
+  Config: off:.*,full:((Create)|(Start)|(Run)|(Update)|(Stop)|(Remove)).*
+instrumentation:
+  Sampling: disabled

--- a/test/critest/run.sh
+++ b/test/critest/run.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+TEST="CRI validation tests with critest"
+
+PV='pv -qL'
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+DEMO_LIB_DIR=$(realpath "$SCRIPT_DIR/../../demo/lib")
+BIN_DIR=$(realpath "$SCRIPT_DIR/../../bin")
+OUTPUT_DIR=${outdir-$SCRIPT_DIR/output}
+COMMAND_OUTPUT_DIR=$OUTPUT_DIR/commands
+
+source $DEMO_LIB_DIR/command.bash
+source $DEMO_LIB_DIR/host.bash
+source $DEMO_LIB_DIR/vm.bash
+
+usage() {
+    echo "Usage: [VAR=VALUE] ./run.sh MODE"
+    echo "  MODE:     \"play\" plays the test as a demo."
+    echo "            \"test\" runs fast, reports pass or fail."
+    echo "  VARs:"
+    echo "    tests:   space-separated list of cri-resmgr configurations."
+    echo "             The default is all *.cfg files in $SCRIPT_DIR."
+    echo "    vm:      govm virtual machine name."
+    echo "             The default is \"crirm-test-critest\"."
+    echo "    speed:   Demo play speed."
+    echo "             The default is 10 (keypresses per second)."
+    echo "    cleanup: 0: leave VM running. (The default in the \"play\" mode.)"
+    echo "             1: delete VM (The default in the \"test\" mode.)"
+    echo "             2: stop VM, but do not delete it."
+    echo "    outdir:  Save output under given directory."
+    echo "             The default is \"${SCRIPT_DIR}/output\"."
+}
+
+error() {
+    (echo ""; echo "error: $1" ) >&2
+    exit 1
+}
+
+out() {
+    if [ -n "$PV" ]; then
+        speed=${speed-10}
+        echo "$1" | $PV $speed
+    else
+        echo "$1"
+    fi
+    echo ""
+}
+
+screen-create-vm() {
+    speed=60 out "### Running the test in VM \"$vm\"."
+    host-create-vm $vm
+    if [ -z "$VM_IP" ]; then
+        error "creating VM failed"
+    fi
+    vm-networking
+}
+
+screen-install-containerd() {
+    speed=60 out "### Installing Containerd to the VM."
+    vm-install-containerd
+    vm-install-containernetworking
+}
+
+screen-copy-cri-resmgr() {
+    prefix=/usr/local
+    host-command "scp \"$BIN_DIR/cri-resmgr\" \"$SCRIPT_DIR/tsl\" $VM_SSH_USER@$VM_IP:" || {
+        command-error "copying cri-resmgr failed"
+    }
+    vm-command "mv cri-resmgr tsl $prefix/bin/" || {
+        command-error "installing cri-resmgr to $prefix/bin failed"
+    }
+    PV= vm-command "command -v cri-resmgr" >/dev/null
+    ( echo $COMMAND_OUTPUT | grep -q $prefix/bin/cri-resmgr ) || {
+        command-error "\"cri-resmgr\" does not execute $prefix/bin/cri-resmgr on VM"
+    }
+
+}
+
+screen-install-critest() {
+    speed=60 out "### Installing critest to VM."
+    vm-command "apt install -y golang make socat"
+    vm-command "go get -d github.com/kubernetes-sigs/cri-tools"
+    CRI_TOOLS_SOURCE_DIR=$(awk '/package.*cri-tools/{print $NF}' <<< $COMMAND_OUTPUT)
+    [ -n "$CRI_TOOLS_SOURCE_DIR" ] || {
+        command-error "downloading cri-tools failed"
+    }
+    vm-command "pushd \"$CRI_TOOLS_SOURCE_DIR\" && make && make install && popd" || {
+        command-error "building and installing cri-tools failed"
+    }
+}
+
+screen-critest-crirm-config() {
+    config_file=$1
+    cri_endpoint=/var/run/containerd/containerd.sock
+    cri_resmgr_endpoint=/var/run/cri-resmgr/cri-resmgr.sock
+    host-command "scp $config_file $VM_SSH_USER@$VM_IP:"
+    vm-command "rm -rf *.tsl; killall cri-resmgr; systemctl stop containerd; sleep 1; systemctl start containerd; sleep 1; rm -rf /var/lib/cri-resmgr"
+    vm-command "cri-resmgr -force-config $config_file -runtime-socket $cri_endpoint -relay-socket $cri_resmgr_endpoint 2>&1 | tsl -uU -F \"%(ts) s cri-resmgr: %(line)s\" -o cri-resmgr.output.tsl" bg
+    sleep 5
+    vm-command "critest -runtime-endpoint unix://$cri_resmgr_endpoint 2>&1 | tsl -uU -F \"%(ts) s critest: %(line)s\" -o critest.output.tsl"
+    vm-command "killall cri-resmgr"
+    vm-command-q "cat *.tsl | sort -n | awk '{if (t_start==0) t_start=\$1; \$1=sprintf(\"%.6fs\", \$1-t_start); print;}'" > "$OUTPUT_DIR/test-$config_file.log"
+}
+
+screen-critest-containerd() {
+    config_file=$1
+    cri_endpoint=/var/run/containerd/containerd.sock
+    vm-command "rm -rf *.tsl; critest -runtime-endpoint unix://$cri_endpoint 2>&1 | tsl -uU -F \"%(ts) s critest: %(line)s\" -o critest.output.tsl"
+    vm-command-q "cat *.tsl | sort -n | awk '{if (t_start==0) t_start=\$1; \$1=sprintf(\"%.6fs\", \$1-t_start); print;}'" > "$OUTPUT_DIR/test-containerd.log"
+}
+
+require_cmd() {
+    cmd=$1
+    if ! command -v $cmd >/dev/null ; then
+        error "required command missing \"${cmd}\", make sure it is in PATH"
+    fi
+}
+
+# Validate parameters
+mode=$1
+vm=${vm-"crirm-test-critest"}
+cd "${SCRIPT_DIR}" || error "failed to cd to \"${SCRIPT_DIR}\""
+tests=${tests-*.cfg}
+
+if [ "$mode" == "test" ]; then
+    PV=
+    cleanup=${cleanup-1}
+elif [ "$mode" == "play" ] ; then
+    speed=${speed-10}
+    cleanup=${cleanup-0}
+else
+    usage
+    error "invalid MODE"
+fi
+
+# Prepare for test/demo
+mkdir -p $OUTPUT_DIR
+mkdir -p $COMMAND_OUTPUT_DIR
+rm -f $COMMAND_OUTPUT_DIR/0*
+( echo x > $OUTPUT_DIR/x && rm -f $OUTPUT_DIR/x ) || {
+    error "output directory outdir=$OUTPUT_DIR is not writable"
+}
+
+if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ] || [ -z "$VM_NAME" ]; then
+    screen-create-vm
+fi
+
+# always copy new version of the binary to VM
+screen-copy-cri-resmgr
+
+if ! vm-command-q "dpkg -l | grep -q containerd"; then
+    screen-install-containerd
+fi
+
+if ! vm-command-q "command -v critest | grep -q critest"; then
+    screen-install-critest
+fi
+
+# Run test/demo
+# 1. Run critest on cri-resmgr with each config file.
+for config_file in $tests; do
+    screen-critest-crirm-config $config_file
+done
+# 2. Run critest without cri-resmgr for reference.
+screen-critest-containerd
+
+# Cleanup
+if [ "$cleanup" == "0" ]; then
+    echo "The VM with critest, cri-resmgr and containerd is left running. Next steps:"
+    vm-print-usage
+elif [ "$cleanup" == "1" ]; then
+    host-stop-vm $vm
+    host-delete-vm $vm
+elif [ "$cleanup" == "2" ]; then
+    host-stop-vm $vm
+fi
+
+# Summarize results
+SUMMARY_FILE="$OUTPUT_DIR/summary.txt"
+echo -n "" > "$SUMMARY_FILE" || error "cannot write summary to \"$SUMMARY_FILE\""
+for testlog in $OUTPUT_DIR/test-*.log; do
+    echo -n "$(basename "$testlog") " >> "$SUMMARY_FILE"
+    awk 'BEGIN{s=0;e=0}/critest: /{if(s==0)s=$1;e=$1}END{printf "(runtime %.2f s): ",e-s}' < "$testlog" >> "$SUMMARY_FILE"
+    # remove ansi colors from critest output in the summary
+    grep Pending "$testlog" | grep critest: | tail -n 1 | sed -r -e "s/[[:cntrl:]]\[[0-9]+m//g" -e "s/^.* -- //g" >> "$SUMMARY_FILE"
+done
+exit_status=0
+# Declare verdict in test mode
+if [ "$mode" == "test" ]; then
+    echo "" >> "$SUMMARY_FILE"
+    # Test is passed if all critest executions had the same passrate,
+    # no matter which cri-resmgr configuration was used.
+    if [ "$(awk -F: '{print $2}' < $SUMMARY_FILE | sort -u | wc -l)" == "1" ]; then
+        echo "All critest results are the same." >> "$SUMMARY_FILE"
+        echo "Test verdict: PASS" >> "$SUMMARY_FILE"
+    else
+        echo "Error: critest results are not the same in all configurations." >> "$SUMMARY_FILE"
+        echo "Test verdict: FAIL" >> "$SUMMARY_FILE"
+        exit_status=1
+    fi
+fi
+echo ""
+echo "Summary:"
+cat $SUMMARY_FILE
+exit $exit_status

--- a/test/critest/tsl
+++ b/test/critest/tsl
@@ -1,0 +1,101 @@
+#!/usr/bin/python3
+#
+# Copyright 2020 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tsl - timestamp lines
+
+Usage: tsl [options]
+
+Options:
+  -h, --help      print help.
+  -f TIMEFORMAT   use TIMEFORMAT as output timeformat (man strftime).
+                  The default format is "%s.%f".
+  -F LINEFORMAT   use LINEFORMAT as line output format:
+                  - %(ts)s: timestamp
+                  - %(line)s: original line
+                  The default is "%(ts)s %(line)s".
+  -o OUTFILE      write output lines to OUTFILE. Supports many -o's.
+                  Special outfiles:
+                  - stdout: standard output
+                  - stderr: standard error
+  -u              unbuffered input: more accurate timestamps, slower throughput.
+  -U              unbuffered output: flush after every line, slower throughput.
+
+Examples:
+  cmd1 | tsl -u -F "%(ts)s cmd1: %(line)s" > cmd1.tsl &
+  cmd2 | tsl -u -F "%(ts)s cmd2: %(line)s" > cmd2.tsl &
+  wait
+  cat cmd1.tsl cmd2.tsl | sort -n > cmd1_cmd2.output
+"""
+
+import getopt
+import sys
+import datetime
+
+def unbuffered_xreadlines(fileobj):
+    """like fileobj.xreadlines() but unbuffered"""
+    ln = []
+    while True:
+        c = fileobj.read(1)
+        if not c:
+            if ln:
+                yield "".join(ln)
+            break
+        ln.append(c)
+        if c == "\n":
+            yield "".join(ln)
+            ln = []
+
+if __name__ == "__main__":
+    opt_timeformat = "%s.%f" #"%Y-%m-%d %H:%M:%S"
+    opt_lineformat = "%(ts)s %(line)s"
+    opt_unbuffered_in = False
+    opt_unbuffered_out = False
+    opt_outfiles = []
+    opts, remainder = getopt.gnu_getopt(
+        sys.argv[1:], 'hf:F:o:uU',
+        ['help', 'format='])
+    for opt, arg in opts:
+        if opt in ["-h", "--help"]:
+            print(__doc__)
+            sys.exit(0)
+        elif opt in ["-f", "--format"]:
+            opt_timeformat = arg
+        elif opt in ["-F"]:
+            opt_lineformat = arg
+        elif opt in ["-o"]:
+            if arg == "stdout":
+                opt_outfiles.append(sys.stdout)
+            elif arg == "stderr":
+                opt_outfiles.append(sys.stderr)
+            else:
+                opt_outfiles.append(open(arg, "w"))
+        elif opt in ["-u"]:
+            opt_unbuffered_in = True
+        elif opt in ["-U"]:
+            opt_unbuffered_out = True
+    if not opt_outfiles:
+        opt_outfiles.append(sys.stdout)
+    if opt_unbuffered_in:
+        line_iter = unbuffered_xreadlines(sys.stdin)
+    else:
+        line_iter = sys.stdin
+    for line in line_iter:
+        ts = datetime.datetime.now().strftime(opt_timeformat)
+        out_line = opt_lineformat % {'ts': ts, 'line': line}
+        for outfile in opt_outfiles:
+            outfile.write(out_line)
+            if opt_unbuffered_out:
+                outfile.flush()


### PR DESCRIPTION
- critest validates CRI without full Kubernetes stack,
  requires a container runtime with containernetworking.
- All cri-resmgr *.cfg files in tests/critest are tested
  to produce the same result as critest without cri-resmgr.
- Refactor demo/lib to reuse procedures in tests.
- Harmonize usage of test/critest and demo/blockio run.sh.