### PR TITLE
memtier: dynamic demotion support.

### DIFF
--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -120,7 +120,7 @@ func (ctl *rdtctl) assign(c cache.Container) error {
 		return rdtError("failed to get pod of container %s", c.PrettyName())
 	}
 
-	pids, err := utils.GetProcessInContainer(pod.GetCgroupParentDir(), c.GetID())
+	pids, err := utils.GetTasksInContainer(pod.GetCgroupParentDir(), c.GetID())
 	if err != nil {
 		return rdtError("failed to get process list for container %s: %v", c.PrettyName(), err)
 	}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/dynamic_demotion.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/dynamic_demotion.go
@@ -1,0 +1,526 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memtier
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/utils"
+)
+
+// Support dynamic pushing of unused pages from DRAM to PMEM.
+//
+// The algorithm is be (roughly) this:
+//
+// Find out which processes belong to the container. For every process in the
+// container, find out which pages the process uses. Using move_pages(), push a
+// number of pages not in the working set, which are present in DRAM, from DRAM
+// to PMEM. This may need to be done for many times with a delay in between,
+// because the process will be "stuck" when the pages are moved. Repeat this
+// process.
+//
+// How to figure out which pages are not part of the working set:
+//
+// 1. Clear soft-dirty bits on the PTEs:
+//    https://www.kernel.org/doc/html/latest/admin-guide/mm/soft-dirty.html
+// 2. Wait for a while.
+// 3. Read out the process page maps:
+//    https://www.kernel.org/doc/html/latest/admin-guide/mm/pagemap.html The pages
+//    which don't have the soft-dirty bit are considered to be outside of the
+//    working set.
+
+type page struct {
+	pid  int
+	addr uint64
+}
+
+type addrRange struct {
+	addr   uint64
+	length uint64
+}
+
+type demoter struct {
+	policy *policy // Policy backpointer, needed for sending events
+
+	// Finding pages
+	dirtyBitReset    time.Ticker      // Ticker for resetting the dirty bits.
+	dirtyBitStop     chan interface{} // Channel for stopping the ticker.
+	dirtyBitDuration time.Duration    // How often should we analyze the working set size.
+
+	// Moving pages
+	pageMover         PageMover
+	containerDemoters map[string]chan interface{} // Channel for sending pagemap updates to demoters.
+	pageMoveDuration  time.Duration               // How often should we move pages for a container.
+	pageMoveCount     uint                        // How many pages to move at once.
+}
+
+// Demoter dynamically demotes pages from DRAM to PMEM.
+type Demoter interface {
+	// StartDirtyBitResetTimer starts the timer for getting memory moving events.
+	StartDirtyBitResetTimer(policy *policy, timeout time.Duration)
+	// StopDirtyBitResetTimer stops the memory moving.
+	StopDirtyBitResetTimer()
+	// ResetDirtyBit resets soft-dirty bits for all processes in container c.
+	ResetDirtyBit(c cache.Container) error
+	// GetPagesForContainer gets pages which could be potentially moved from container c.
+	GetPagesForContainer(c cache.Container, sourceNodes system.IDSet) (pagePool, error)
+	// MovePages moves at most 'count' pages in page pool to a memory node.
+	MovePages(p pagePool, count uint, targetNodes system.IDSet) error
+
+	UpdateDemoter(cid string, p pagePool, targetNodes system.IDSet)
+	StopDemoter(cid string)
+	UnusedDemoters(cs []cache.Container) []string
+}
+
+type pagePool struct {
+	pages        map[int][]page
+	longestRange uint
+}
+
+type demotion struct {
+	pagePool    pagePool
+	targetNodes system.IDSet
+}
+
+func copyPagePool(p pagePool) pagePool {
+	c := pagePool{
+		longestRange: p.longestRange,
+		pages:        make(map[int][]page, 0),
+	}
+	for pid, pages := range p.pages {
+		c.pages[pid] = make([]page, len(pages))
+		copy(c.pages[pid], pages)
+	}
+	return c
+}
+
+func (d *demoter) UpdateDemoter(cid string, p pagePool, targetNodes system.IDSet) {
+	channel, found := d.containerDemoters[cid]
+	if !found {
+		channel := make(chan interface{})
+		go func() {
+			moveTimer := time.NewTicker(d.pageMoveDuration)
+			moveTimerChan := moveTimer.C
+			pagePool := p
+			nodes := targetNodes
+			count := d.pageMoveCount
+			for {
+				select {
+				case msg := <-channel:
+					demotion, ok := msg.(demotion)
+					if ok {
+						pagePool = demotion.pagePool
+						targetNodes = demotion.targetNodes
+						if p.longestRange > d.pageMoveCount {
+							// The number of pages moved needs to be at least as large as a range in numa_maps
+							// file so that we know that all pages will be moved (even if some of them were
+							// already on the PMEM node).
+
+							// TODO: adjust the timer if we have a larger-than-usual range of pages to move.
+							count = p.longestRange
+						} else {
+							count = d.pageMoveCount
+						}
+					} else {
+						// A stop request.
+						if moveTimer != nil {
+							moveTimer.Stop()
+						}
+						return
+					}
+				case _ = <-moveTimerChan:
+					err := d.MovePages(pagePool, count, nodes)
+					if err != nil {
+						log.Error("Error demoting pages: %s", err)
+					}
+				}
+			}
+		}()
+		d.containerDemoters[cid] = channel
+		// TODO: trigger instant update when run the first time?
+	} else {
+		channel <- demotion{pagePool: p, targetNodes: targetNodes}
+	}
+}
+
+func (d *demoter) StopDemoter(cid string) {
+	channel, found := d.containerDemoters[cid]
+	if found {
+		channel <- "stop"
+		delete(d.containerDemoters, cid)
+	}
+}
+
+func (d *demoter) UnusedDemoters(cs []cache.Container) []string {
+	unused := make([]string, 0)
+	for key := range d.containerDemoters {
+		found := false
+		for _, c := range cs {
+			if c.GetCacheID() == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			unused = append(unused, key)
+		}
+	}
+	return unused
+}
+
+func (d *demoter) StopDirtyBitResetTimer() {
+	if d.dirtyBitStop != nil {
+		close(d.dirtyBitStop)
+		d.dirtyBitStop = nil
+	}
+}
+
+func (d *demoter) StartDirtyBitResetTimer(policy *policy, timeout time.Duration) {
+	if d.dirtyBitStop != nil {
+		return
+	}
+
+	d.policy = policy
+
+	stop := make(chan interface{})
+	go func() {
+		dirtyBitResetTimer := time.NewTicker(timeout)
+		dirtyBitResetChan := dirtyBitResetTimer.C
+		for {
+			select {
+			case _ = <-stop:
+				if dirtyBitResetTimer != nil {
+					dirtyBitResetTimer.Stop()
+				}
+				return
+			case _ = <-dirtyBitResetChan:
+				e := &events.Policy{
+					Type:   DirtyBitReset,
+					Source: PolicyName,
+					Data:   "tick",
+				}
+				if err := d.policy.options.SendEvent(e); err != nil {
+					log.Error("Failed to send event.")
+				}
+			}
+		}
+	}()
+	d.dirtyBitStop = stop
+}
+
+func resetDirtyBit(pid string) error {
+	// Write magic value "4" to the clear_refs file. This resets the dirty bit.
+	path := "/proc/" + pid + "/clear_refs"
+	err := ioutil.WriteFile(path, []byte("4"), 0600)
+	return err
+}
+
+// ResetDirtyBit unsets soft-dirty bits for all processes in a container.
+func (d *demoter) ResetDirtyBit(c cache.Container) error {
+	parentDir := ""
+	pod, isPod := c.GetPod()
+	if isPod {
+		parentDir = pod.GetCgroupParentDir()
+	}
+
+	pids, err := utils.GetProcessesInContainer(parentDir, c.GetID())
+	if err != nil {
+		return err
+	}
+
+	for _, pid := range pids {
+		err = resetDirtyBit(pid)
+		if err != nil {
+			log.Error("Failed to reset dirty bit for process %s: %v", pid, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *demoter) GetPagesForContainer(c cache.Container, sourceNodes system.IDSet) (pagePool, error) {
+	pool := pagePool{
+		pages:        make(map[int][]page, 0),
+		longestRange: 0,
+	}
+	parentDir := ""
+	pod, isPod := c.GetPod()
+	if isPod {
+		parentDir = pod.GetCgroupParentDir()
+	}
+
+	pids, err := utils.GetProcessesInContainer(parentDir, c.GetID())
+	if err != nil {
+		return pagePool{}, err
+	}
+
+	for _, pid := range pids {
+		addressRanges := make([]addrRange, 0)
+		pidNumber64, err := strconv.ParseInt(pid, 10, 32)
+		if err != nil {
+			log.Error("Failed to parse addr to int: %v", err)
+			continue
+		}
+		pidNumber := int(pidNumber64)
+		// Read /proc/pid/numa_maps and /proc/pid/maps
+		numaMapsPath := "/proc/" + pid + "/numa_maps"
+		numaMapsBytes, err := ioutil.ReadFile(numaMapsPath)
+		if err != nil {
+			log.Error("Could not read numa_maps: %v", err)
+			continue
+		}
+		mapsPath := "/proc/" + pid + "/maps"
+		mapsBytes, err := ioutil.ReadFile(mapsPath)
+		if err != nil {
+			log.Error("Could not read maps: %v\n", err)
+			os.Exit(1)
+		}
+		mapsLines := strings.Split(string(mapsBytes), "\n")
+
+		for _, line := range strings.Split(string(numaMapsBytes), "\n") {
+			tokens := strings.Split(line, " ")
+			if len(tokens) < 3 {
+				continue
+			}
+			attrs := strings.Join(tokens[2:], " ")
+			// Filter out lines which don't have "anonymous", since we are not
+			// interested in file-mapped or shared pages. Save the interesting ranges.
+			// TODO: consider dropping the "heap" requirement. There are often ranges
+			// in the file which don't have any attributes indicating the memory
+			// location.
+			if !strings.Contains(attrs, "heap") || !strings.Contains(attrs, "anon=") {
+				continue
+			}
+			// We only find out if *any* pages in the range are in a DRAM node. The
+			// more fine-grained analysis is done later by running the move_pages()
+			// system call twice.
+			locatedOnDRAMNode := false
+			for node := range sourceNodes {
+				number := strconv.FormatInt(int64(node), 10)
+				str := "N" + number + "="
+				if strings.Contains(attrs, str) {
+					locatedOnDRAMNode = true
+					break
+				}
+			}
+			if !locatedOnDRAMNode {
+				continue
+			}
+
+			for _, mapLine := range mapsLines {
+				if strings.HasPrefix(mapLine, tokens[0]+"-") {
+					spaceIndex := strings.Index(mapLine, " ")
+					if spaceIndex > len(tokens[0]+"-") {
+						endAddrStr := mapLine[len(tokens[0]+"-"):spaceIndex]
+						startAddr, err := strconv.ParseInt(tokens[0], 16, 64)
+						if err != nil {
+							log.Error("Failed to parse addr to int: %v\n", err)
+							break
+						}
+						endAddr, err := strconv.ParseInt(endAddrStr, 16, 64)
+						if err != nil {
+							log.Error("Failed to parse addr to int: %v\n", err)
+							break
+						}
+						rangeLength := endAddr - startAddr
+						addressRanges = append(addressRanges, addrRange{uint64(startAddr), uint64(rangeLength / int64(os.Getpagesize()))})
+						// log.Debug("found interesting page range for pid %s: %v", pid, addressRanges[len(addressRanges)-1])
+						break
+					}
+				}
+			}
+		}
+
+		// Read /proc/pid/pagemap and process only interesting page ranges. For
+		// every read-only page and for every page with the soft-dirty bit on, mark
+		// them as candidates to be moved by adding them to pagePool.
+
+		if len(addressRanges) > 0 {
+			// log.Debug("Getting pages for PID %s for ranges %v", pid, addressRanges)
+			pages := make([]page, 0)
+			path := "/proc/" + pid + "/pagemap"
+			pageMap, err := os.OpenFile(path, os.O_RDONLY, 0)
+			if err != nil {
+				// Probably the process just died?
+				fmt.Printf("Could not read pagemaps: %v\n", err)
+				break
+			}
+			for _, addressRange := range addressRanges {
+				idx := int64(addressRange.addr / uint64(os.Getpagesize()) * 8)
+				offset, err := pageMap.Seek(idx, io.SeekStart)
+				if err != nil {
+					// Maybe there was a race condition and the maps changed?
+					log.Error("Failed to seek: %v\n", err)
+					continue
+				}
+				for i := uint64(0); i < addressRange.length; i++ {
+					bytes := make([]byte, 8)
+					// Read exactly 8 bytes (because the file interface breaks otherwise).
+					_, err = io.ReadAtLeast(pageMap, bytes, 8)
+					if err != nil {
+						// Possibly the maps changed.
+						log.Error("Could not read data from pagemaps(%v)(page size: %d, seek offset: %d): %v\n", idx, os.Getpagesize(), offset, err)
+						break
+					}
+					data := binary.LittleEndian.Uint64(bytes)
+
+					// Check that the page is present (not swapped), exclusively
+					// mapped (not used by any other process), and it has the
+					// soft-dirty bit off.
+
+					// Note: there appears to be no way to see from the pagemap entry what the NUMA node is.
+					// We could map this back to the physical address ranges if needed. Currently this is handled
+					// in MovePages() by calling move_pages() first with an empty node array.
+
+					softDirtyBit := uint64(0x1) << 55
+					exclusiveBit := uint64(0x1) << 56
+					presentBit := uint64(0x1) << 63
+					present := (data&presentBit == presentBit)
+					exclusive := (data&exclusiveBit == exclusiveBit)
+					softDirty := (data&softDirtyBit == softDirtyBit)
+
+					if present && exclusive && !softDirty {
+						// log.Debug("page a candidate for moving: 0x%08x", addressRange.addr+i*uint64(os.Getpagesize()))
+						pages = append(pages, page{addr: addressRange.addr + i*uint64(os.Getpagesize()), pid: pidNumber})
+					}
+				}
+			}
+			if _, found := pool.pages[pidNumber]; found {
+				pool.pages[pidNumber] = append(pool.pages[pidNumber], pages...)
+			} else {
+				pool.pages[pidNumber] = pages
+			}
+			if uint(len(addressRanges)) > pool.longestRange {
+				pool.longestRange = uint(len(addressRanges))
+			}
+		}
+	}
+
+	return pool, nil
+}
+
+func pickClosestPMEMNode(currentNode system.ID, targetNodes system.IDSet) system.ID {
+	// TODO: analyze the topology information (and possibly the amount of free memory) and choose the "best"
+	// PMEM node to demote the page to. The array targetNodes already contains only the subset of PMEM nodes
+	// available in this topology subtree. Right now just pick a random controller.
+	nodes := targetNodes.Members()
+	return nodes[rand.Intn(len(nodes))]
+}
+
+func (d *demoter) movePagesForPid(p []page, count uint, pid int, targetNodes system.IDSet) (uint, error) {
+	// We move at max count pages, but there might not be that much.
+	nPages := count
+	if uint(len(p)) < count {
+		nPages = uint(len(p))
+	}
+
+	// Gather memory page pointers.
+	pages := make([]uintptr, nPages)
+	var i uint
+	for i = 0; i < nPages; i++ {
+		pages[i] = uintptr(p[i].addr)
+	}
+
+	// MPOL_MF_MOVE - only move pages exclusive to this process. There will be
+	// permission denied errors for pages which couldn't be moved. FIXME: find
+	// out if the whole move_pages() syscall failed or if just the non-exclusive
+	// pages were not moved.
+	flags := 1 << 1
+
+	// Call move_pages() first with nil nodes array to find out the current controllers.
+	_, currentStatus, err := d.pageMover.MovePagesSyscall(pid, nPages, pages, nil, flags)
+	if err != nil {
+		log.Error("Failed to find out the current status of the pages: %v.", err)
+		return 0, err
+	}
+
+	dramPages := make([]uintptr, 0)
+	nodes := make([]int, 0)
+	// Choose a target node for every page. Drop the pages which already are on the right controller from the list.
+	for i, pageStatus := range currentStatus {
+		if pageStatus < 0 {
+			// There was an error regarding this page.
+			continue
+		}
+		// log.Debug("page 0x%08X: old status %d", pages[i], pageStatus)
+		if !targetNodes.Has(system.ID(pageStatus)) {
+			// In case of many PMEM controllers choose the one that is the closest.
+			dramPages = append(dramPages, pages[i])
+			nodes = append(nodes, int(pickClosestPMEMNode(system.ID(pageStatus), targetNodes)))
+		} // else no need to move.
+	}
+
+	// Call move_pages() to actually move the pages.
+	_, _, err = d.pageMover.MovePagesSyscall(pid, uint(len(dramPages)), dramPages, nodes, flags)
+
+	// We processed (moved or ignored) at least nPages.
+	return nPages, err
+}
+
+func (d *demoter) MovePages(p pagePool, count uint, targetNodes system.IDSet) error {
+	// Select pid for moving the pages so that the process with the largest number
+	// of non-dirty pages gets the pages moved first.
+	processedPids := make(map[int]bool, 0)
+
+	for count > 0 {
+		mostPagesPid := 0
+		nPagesForPid := uint(0)
+		for pid, pages := range p.pages {
+			_, alreadyProcessed := processedPids[pid]
+			if alreadyProcessed {
+				continue
+			}
+			if uint(len(pages)) > nPagesForPid {
+				mostPagesPid = pid
+				nPagesForPid = uint(len(pages))
+			}
+		}
+
+		if nPagesForPid == 0 {
+			return nil
+		}
+
+		processedPids[mostPagesPid] = true
+
+		nMovePages := nPagesForPid
+		if count < nPagesForPid {
+			nMovePages = count
+			count = 0
+		} else {
+			count -= nPagesForPid
+		}
+
+		log.Debug("moving %d pages for pid %d", nMovePages, mostPagesPid)
+		nPages, err := d.movePagesForPid(p.pages[mostPagesPid], nMovePages, mostPagesPid, targetNodes)
+		if err != nil {
+			log.Error("Failed to move pages: %v", err)
+			return err
+		}
+		// Remove processed pages from the pagemap.
+		p.pages[mostPagesPid] = p.pages[mostPagesPid][nPages:]
+	}
+	return nil
+}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/dynamic_demotion_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/dynamic_demotion_test.go
@@ -1,0 +1,259 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memtier
+
+import (
+	"fmt"
+	"testing"
+
+	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+)
+
+type mockPageMover struct {
+	firstSuccess               bool
+	secondSuccess              bool
+	expectedPagesForSecondCall uint
+	firstStatus                []int
+}
+
+func (m *mockPageMover) MovePagesSyscall(pid int, count uint, pages []uintptr, nodes []int, flags int) (uint, []int, error) {
+
+	status := make([]int, len(pages))
+
+	fmt.Printf("move_pages(): pid %d, count %d, pages %v, nodes %v, flags %d\n",
+		pid, count, pages, nodes, flags)
+
+	if nodes == nil {
+		// First call is made without nodes
+		if m.firstSuccess == false {
+			return 0, m.firstStatus, fmt.Errorf("Fake error")
+		}
+		return 0, m.firstStatus, nil
+	}
+
+	// Second call
+	if m.secondSuccess == false {
+		return 0, status, fmt.Errorf("Fake error")
+	}
+	if uint(len(pages)) != m.expectedPagesForSecondCall {
+		return 0, status, fmt.Errorf("Real error")
+	}
+
+	return 0, status, nil
+}
+
+func TestMovePages(t *testing.T) {
+	tcases := []struct {
+		name                       string
+		pool                       pagePool
+		targetNodes                system.IDSet
+		pageCount                  uint
+		expectedRemainingPageCount uint
+		expectedError              bool
+		pageMover                  PageMover
+		pid                        int
+	}{
+		{
+			name: "move pages (both)",
+			pool: pagePool{
+				pages: map[int][]page{
+					500: {
+						{
+							pid:  500,
+							addr: 0xdeadbeef,
+						},
+						{
+							pid:  500,
+							addr: 0xc0ffee,
+						},
+					},
+				},
+			},
+			pid:       500,
+			pageCount: 2,
+			pageMover: &mockPageMover{
+				firstSuccess:               true,
+				secondSuccess:              true,
+				firstStatus:                []int{0, 0},
+				expectedPagesForSecondCall: 2,
+			},
+			targetNodes:                system.NewIDSet(1, 2),
+			expectedError:              false,
+			expectedRemainingPageCount: 0,
+		},
+		{
+			name: "move pages (only one)",
+			pool: pagePool{
+				pages: map[int][]page{
+					500: {
+						{
+							pid:  500,
+							addr: 0xdeadbeef,
+						},
+						{
+							pid:  500,
+							addr: 0xc0ffee,
+						},
+					},
+				},
+			},
+			pid:       500,
+			pageCount: 2,
+			pageMover: &mockPageMover{
+				firstSuccess:               true,
+				secondSuccess:              true,
+				firstStatus:                []int{0, 2},
+				expectedPagesForSecondCall: 1,
+			},
+			targetNodes:                system.NewIDSet(1, 2),
+			expectedError:              false,
+			expectedRemainingPageCount: 0,
+		},
+		{
+			name: "move pages (none)",
+			pool: pagePool{
+				pages: map[int][]page{
+					500: {
+						{
+							pid:  500,
+							addr: 0xdeadbeef,
+						},
+						{
+							pid:  500,
+							addr: 0xc0ffee,
+						},
+					},
+				},
+			},
+			pid:       500,
+			pageCount: 2,
+			pageMover: &mockPageMover{
+				firstSuccess:               true,
+				secondSuccess:              true,
+				firstStatus:                []int{2, 1},
+				expectedPagesForSecondCall: 0,
+			},
+			targetNodes:                system.NewIDSet(1, 2),
+			expectedError:              false,
+			expectedRemainingPageCount: 0,
+		},
+		{
+			name: "move pages (count 1)",
+			pool: pagePool{
+				pages: map[int][]page{
+					500: {
+						{
+							pid:  500,
+							addr: 0xdeadbeef,
+						},
+						{
+							pid:  500,
+							addr: 0xc0ffee,
+						},
+					},
+				},
+			},
+			pid:       500,
+			pageCount: 1,
+			pageMover: &mockPageMover{
+				firstSuccess:               true,
+				secondSuccess:              true,
+				firstStatus:                []int{0},
+				expectedPagesForSecondCall: 1,
+			},
+			targetNodes:                system.NewIDSet(1, 2),
+			expectedError:              false,
+			expectedRemainingPageCount: 1,
+		},
+		{
+			name: "move pages (first call error)",
+			pool: pagePool{
+				pages: map[int][]page{
+					500: {
+						{
+							pid:  500,
+							addr: 0xdeadbeef,
+						},
+						{
+							pid:  500,
+							addr: 0xc0ffee,
+						},
+					},
+				},
+			},
+			pid:       500,
+			pageCount: 2,
+			pageMover: &mockPageMover{
+				firstSuccess:               false,
+				secondSuccess:              true,
+				firstStatus:                []int{0, 0},
+				expectedPagesForSecondCall: 0,
+			},
+			targetNodes:                system.NewIDSet(1, 2),
+			expectedError:              true,
+			expectedRemainingPageCount: 2,
+		},
+		{
+			name: "move pages (second call error)",
+			pool: pagePool{
+				pages: map[int][]page{
+					500: {
+						{
+							pid:  500,
+							addr: 0xdeadbeef,
+						},
+						{
+							pid:  500,
+							addr: 0xc0ffee,
+						},
+					},
+				},
+			},
+			pid:       500,
+			pageCount: 2,
+			pageMover: &mockPageMover{
+				firstSuccess:               true,
+				secondSuccess:              false,
+				firstStatus:                []int{0, 0},
+				expectedPagesForSecondCall: 0,
+			},
+			targetNodes:                system.NewIDSet(1, 2),
+			expectedError:              true,
+			expectedRemainingPageCount: 2,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dynamicDemoter := &demoter{
+				pageMoveCount: tc.pageCount,
+				pageMover:     tc.pageMover,
+			}
+
+			err := dynamicDemoter.MovePages(tc.pool, tc.pageCount, tc.targetNodes)
+			if err != nil {
+				if err.Error() != "Fake error" {
+					t.Errorf("Non-fake error: %v", err)
+				}
+			}
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Unexpected error value")
+			}
+
+			if uint(len(tc.pool.pages[tc.pid])) != tc.expectedRemainingPageCount {
+				t.Errorf("Wrong number of remaining pages: %d", len(tc.pool.pages[tc.pid]))
+			}
+		})
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
@@ -15,6 +15,8 @@
 package memtier
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
@@ -24,6 +26,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 
 	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
@@ -39,6 +42,8 @@ const (
 
 	// ColdStartDone is the event generated for the end of a container cold start period.
 	ColdStartDone = "cold-start-done"
+	// DirtyBitReset is the event generated for the reseting of the soft-dirty bits for all processes in the containers.
+	DirtyBitReset = "dirty-bit-reset"
 )
 
 // allocations is our cache.Cachable for saving resource allocations in the cache.
@@ -49,20 +54,21 @@ type allocations struct {
 
 // policy is our runtime state for the memtier policy.
 type policy struct {
-	options      policyapi.BackendOptions  // options we were created or reconfigured with
-	cache        cache.Cache               // pod/container cache
-	sys          system.System             // system/HW topology info
-	allowed      cpuset.CPUSet             // bounding set of CPUs we're allowed to use
-	reserved     cpuset.CPUSet             // system-/kube-reserved CPUs
-	reserveCnt   int                       // number of CPUs to reserve if given as resource.Quantity
-	isolated     cpuset.CPUSet             // (our allowed set of) isolated CPUs
-	nodes        map[string]Node           // pool nodes by name
-	pools        []Node                    // pre-populated node slice for scoring, etc...
-	root         Node                      // root of our pool/partition tree
-	nodeCnt      int                       // number of pools
-	depth        int                       // tree depth
-	allocations  allocations               // container pool assignments
-	cpuAllocator cpuallocator.CPUAllocator // CPU allocator used by the policy
+	options        policyapi.BackendOptions  // options we were created or reconfigured with
+	cache          cache.Cache               // pod/container cache
+	sys            system.System             // system/HW topology info
+	allowed        cpuset.CPUSet             // bounding set of CPUs we're allowed to use
+	reserved       cpuset.CPUSet             // system-/kube-reserved CPUs
+	reserveCnt     int                       // number of CPUs to reserve if given as resource.Quantity
+	isolated       cpuset.CPUSet             // (our allowed set of) isolated CPUs
+	nodes          map[string]Node           // pool nodes by name
+	pools          []Node                    // pre-populated node slice for scoring, etc...
+	root           Node                      // root of our pool/partition tree
+	nodeCnt        int                       // number of pools
+	depth          int                       // tree depth
+	allocations    allocations               // container pool assignments
+	cpuAllocator   cpuallocator.CPUAllocator // CPU allocator used by the policy
+	dynamicDemoter Demoter                   // Dynamic demoter for moving memory pages
 }
 
 // Make sure policy implements the policy.Backend interface.
@@ -92,6 +98,12 @@ func CreateMemtierPolicy(opts *policyapi.BackendOptions) policyapi.Backend {
 
 	config.GetModule(PolicyPath).AddNotify(p.configNotify)
 
+	p.dynamicDemoter = &demoter{
+		containerDemoters: make(map[string]chan interface{}, 0),
+		pageMoveDuration:  time.Duration(opt.PageMovePeriod),
+		pageMoveCount:     opt.PageMoveCount,
+		pageMover:         &linuxPageMover{},
+	}
 	p.root.Dump("<pre-start>")
 
 	return p
@@ -111,6 +123,17 @@ func (p *policy) Description() string {
 func (p *policy) Start(add []cache.Container, del []cache.Container) error {
 	if err := p.restoreCache(); err != nil {
 		return policyError("failed to start: %v", err)
+	}
+
+	// TODO: the dirty bit reset timer should only be started if there is a container
+	// for which there is a demotion possiblity.
+	if opt.DirtyBitScanPeriod > 0 && opt.PageMovePeriod > 0 && opt.PageMoveCount > 0 {
+		log.Debug("staring dirty bit -based page demotion: scan period %v, page move period %v, page move count %d",
+			opt.DirtyBitScanPeriod.String(), opt.PageMovePeriod.String(), opt.PageMoveCount)
+		p.dynamicDemoter.StartDirtyBitResetTimer(p, time.Duration(opt.DirtyBitScanPeriod))
+	} else {
+		log.Debug("not staring dirty bit -based page demotion due to missing or empty parameters: scan period %v, page move period %v, page move count %d",
+			opt.DirtyBitScanPeriod.String(), opt.PageMovePeriod.String(), opt.PageMoveCount)
 	}
 
 	p.root.Dump("<post-start>")
@@ -239,6 +262,50 @@ func (p *policy) HandleEvent(e *events.Policy) (bool, error) {
 		}
 		log.Info("finishing coldstart period for %s", c.PrettyName())
 		return p.finishColdStart(c)
+	case DirtyBitReset:
+		for _, container := range p.cache.GetContainers() {
+			if container.GetNamespace() == kubernetes.NamespaceSystem {
+				// The system containers should not be moved.
+				continue
+			}
+			grant, ok := p.allocations.grants[container.GetCacheID()]
+			if !ok {
+				log.Info("%s event: no grant found for container %s", e.Type, container.GetCacheID())
+				continue
+			}
+			memType := grant.GetMemoryNode().GetMemoryType()
+			if memType&memoryDRAM == 0 || memType&memoryPMEM == 0 {
+				log.Info("%s event: not demoting pages, memory type %v for container %v", e.Type, memType, container.GetCacheID())
+				// No demotion possibility.
+				continue
+			}
+			pmemNodes := grant.GetMemoryNode().GetMemset(memoryPMEM)
+			dramNodes := grant.GetMemoryNode().GetMemset(memoryDRAM)
+
+			// Gather the known pages which need to be moved.
+			pagePool, err := p.dynamicDemoter.GetPagesForContainer(container, dramNodes)
+			if err != nil {
+				log.Error("%s event: failed to get pages for container %v", e.Type, container.GetCacheID())
+				continue
+			}
+
+			count := 0
+			for _, pages := range pagePool.pages {
+				count += len(pages)
+			}
+			log.Debug("%s event: %d pages for (maybe) demoting for %v", e.Type, count, container.GetCacheID())
+
+			// Reset the dirty bit from all pages.
+			p.dynamicDemoter.ResetDirtyBit(container)
+
+			// Give the pages to the page moving goroutine. Copy the page pool so that there's no race.
+			p.dynamicDemoter.UpdateDemoter(container.GetCacheID(), copyPagePool(pagePool), pmemNodes.Clone())
+		}
+		cids := p.dynamicDemoter.UnusedDemoters(p.cache.GetContainers())
+		for _, cid := range cids {
+			p.dynamicDemoter.StopDemoter(cid)
+		}
+		return false, nil
 	}
 	return false, nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/memtier/syscall_linux.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/syscall_linux.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memtier
+
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+type linuxPageMover struct{}
+
+// PageMover implements the way to move pages in a given HW/SW platform.
+type PageMover interface {
+	MovePagesSyscall(pid int, count uint, pages []uintptr, nodes []int, flags int) (uint, []int, error)
+}
+
+func (m *linuxPageMover) MovePagesSyscall(pid int, count uint, pages []uintptr, nodes []int, flags int) (uint, []int, error) {
+
+	// syscall:
+	// long move_pages(int pid, unsigned long count, void **pages,
+	//                 const int *nodes, int *status, int flags);
+
+	var err error
+
+	if count == 0 {
+		return 0, []int{}, nil
+	}
+
+	// Go int is 64 bits on a 64-bit system, but C int is only guaranteed to be at least 16 bits, typically 32.
+	cNodes := make([]C.int, len(nodes))
+	for i := 0; i < len(nodes); i++ {
+		if nodes[i] < 0 || nodes[i] > 32767 {
+			return 0, []int{}, fmt.Errorf("int value error: %d", nodes[i])
+		}
+		cNodes[i] = C.int(nodes[i]) // safe downcast
+	}
+
+	cStatus := make([]C.int, len(pages))
+
+	nodesPtr := unsafe.Pointer(nil)
+	if nodes != nil {
+		nodesPtr = unsafe.Pointer(&cNodes[0])
+	}
+
+	ret, _, en := unix.Syscall6(unix.SYS_MOVE_PAGES, uintptr(pid), uintptr(count), uintptr(unsafe.Pointer(&pages[0])), uintptr(nodesPtr), uintptr(unsafe.Pointer(&cStatus[0])), uintptr(flags))
+	if en != 0 {
+		err = unix.Errno(en)
+	}
+
+	// log.Debug("move_pages(): pid %d, count %d, pages %v, nodes %v, flags %d: return value %d, status %d, errno %v",
+	// 	pid, count, pages, nodes, flags, uint(ret), cStatus, err)
+
+	status := make([]int, count)
+	for i := uint(0); i < count; i++ {
+		status[i] = int(cStatus[i])
+	}
+
+	return uint(ret), status, err
+}


### PR DESCRIPTION
"Dynamic demotion" means that non-used pages are demoted from DRAM to PMEM (if possible). See issue https://github.com/intel/cri-resource-manager/issues/244 for better description of the feature and some discussion about the implementation.

The code could use some work still (there's a number of TODOs still), but I would like to have feedback regarding the overall design and especially the heuristics for page selection.