### PR TITLE
RFC: metrics: per container metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.1-0.20191218042359-6151c48ac7fa
+	github.com/VividCortex/ewma v1.1.1
 	github.com/cilium/ebpf v0.0.0-20200317182658-6f632cc9ee38
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1
@@ -20,6 +21,7 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
+	gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 	google.golang.org/grpc v1.26.0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkF
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
+github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -17,6 +17,8 @@ package resmgr
 import (
 	"time"
 
+	criapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/metrics"
@@ -113,6 +115,8 @@ func (m *resmgr) processEvent(e interface{}) {
 	switch event := e.(type) {
 	case string:
 		evtlog.Debug("'%s'...", event)
+	case []*criapi.ContainerStats:
+		m.processContainerStats(event)
 	case *events.Metrics:
 		m.processAvx(event.Avx)
 	case *events.Policy:
@@ -150,6 +154,19 @@ func (m *resmgr) processAvx(e *events.Avx) bool {
 		}
 	}
 	return changes
+}
+
+// processContainerStats processes collected CRI container statistics.
+func (m *resmgr) processContainerStats(e []*criapi.ContainerStats) bool {
+	if e == nil {
+		return false
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	evtlog.Info("* got CRI container statistics: %v", e)
+	return false
 }
 
 // resolveCgroupPath resolves a cgroup path to a container.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -650,3 +650,9 @@ func (m *mockCache) OpenFile(string, string, os.FileMode) (*os.File, error) {
 func (m *mockCache) WriteFile(string, string, os.FileMode, []byte) error {
 	panic("unimplemented")
 }
+func (m *mockCache) GetMetrics() *cache.Metricsdata {
+	panic("unimplemented")
+}
+func (m *mockCache) SetMetrics(*cache.Metricsdata) {
+	panic("unimplemented")
+}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -592,3 +592,9 @@ func (m *mockCache) OpenFile(string, string, os.FileMode) (*os.File, error) {
 func (m *mockCache) WriteFile(string, string, os.FileMode, []byte) error {
 	panic("unimplemented")
 }
+func (m *mockCache) GetMetrics() *cache.Metricsdata {
+	panic("unimplemented")
+}
+func (m *mockCache) SetMetrics(*cache.Metricsdata) {
+	panic("unimplemented")
+}

--- a/pkg/metricsring/metricsring.go
+++ b/pkg/metricsring/metricsring.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsring
+
+import (
+	"container/ring"
+	"github.com/VividCortex/ewma"
+	"time"
+)
+
+type SampleBuffer interface {
+	Push(d float64)
+	EWMA() float64
+	GetTime() time.Duration
+	GetSize() int
+	GetLastNSamples(count int) []float64
+}
+
+// MetricsRing implements SampleBufer interface
+type MetricsRing struct {
+	r  *ring.Ring
+	s  int // the count of elements in the ring
+	ma ewma.MovingAverage
+}
+
+type sample struct {
+	s         float64
+	timestamp time.Time
+}
+
+func NewMetricsRing(ringlen int) SampleBuffer {
+	// Note: ewma has warm-up period of 10 samples. with ringlen < 10
+	// EWMA() returns 0.0 always.
+
+	return &MetricsRing{
+		r:  ring.New(ringlen),
+		ma: ewma.NewMovingAverage(float64(ringlen)),
+	}
+}
+
+func (mr *MetricsRing) GetTime() time.Duration {
+	t1 := mr.r.Prev().Value.(sample).timestamp
+
+	return t1.Sub(mr.r.Move(-1 * mr.s).Value.(sample).timestamp)
+}
+
+func (mr *MetricsRing) EWMA() float64 {
+	return mr.ma.Value()
+}
+
+func (mr *MetricsRing) Push(d float64) {
+
+	mr.r.Value = sample{
+		s:         d,
+		timestamp: time.Now(),
+	}
+
+	// Add to MovingAverage
+	mr.ma.Add(d)
+
+	mr.r = mr.r.Next()
+
+	if mr.s+1 <= mr.r.Len() {
+		mr.s++
+	}
+}
+
+func (mr *MetricsRing) GetSize() int {
+	return mr.r.Len()
+}
+
+func (mr *MetricsRing) GetLastNSamples(count int) []float64 {
+
+	sliceLen := count
+	if sliceLen > mr.r.Len() {
+		sliceLen = mr.r.Len()
+	}
+	if sliceLen > mr.s {
+		// ring does not have enough elements yet
+		sliceLen = mr.s
+	}
+
+	s := make([]float64, sliceLen)
+
+	// Move backwards in the ring
+	mr.r = mr.r.Move(-1 * sliceLen)
+
+	for i := 0; i < sliceLen; i++ {
+		s[i] = mr.r.Value.(sample).s
+		mr.r = mr.r.Next()
+	}
+
+	return s
+}

--- a/pkg/metricsring/metricsring_test.go
+++ b/pkg/metricsring/metricsring_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsring
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMetricsRing(t *testing.T) {
+
+	cases := []struct {
+		name     string
+		input    []float64
+		output   []float64
+		inputlen int
+		count    int
+	}{
+		{
+			name:     "get all samples",
+			input:    []float64{1.1, 2.2, 3.3, 4.4},
+			output:   []float64{1.1, 2.2, 3.3, 4.4},
+			inputlen: 4,
+			count:    4,
+		},
+		{
+			name:     "get less samples",
+			input:    []float64{1.1, 2.2, 3.3, 4.4},
+			output:   []float64{3.3, 4.4},
+			inputlen: 4,
+			count:    2,
+		},
+		{
+			name:     "get excess samples (ask more than ring size)",
+			input:    []float64{1.1, 2.2, 3.3, 4.4},
+			output:   []float64{1.1, 2.2, 3.3, 4.4},
+			inputlen: 4,
+			count:    8,
+		},
+		{
+			name:     "get excess samples (ring not yet full)",
+			input:    []float64{3.3, 4.4},
+			output:   []float64{3.3, 4.4},
+			inputlen: 4,
+			count:    4,
+		},
+	}
+	for _, tc := range cases {
+		test := tc
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mr := NewMetricsRing(test.inputlen)
+			for _, v := range test.input {
+				mr.Push(v)
+			}
+			output := mr.GetLastNSamples(test.count)
+			if !reflect.DeepEqual(output, test.output) {
+				t.Fatalf("GetLastNSamples: expected output: %+v got: %+v", test.output, output)
+			}
+			all := mr.GetLastNSamples(mr.GetSize())
+			if !reflect.DeepEqual(all, test.input) {
+				t.Fatalf("GetAllSamples: expected output: %+v got: %+v", test.input, all)
+			}
+		})
+	}
+}


### PR DESCRIPTION
RFC to how to pull in metrics in "native" format (however, I've kept AVX coming from Prometheus but moved numa stats collection hooked to `ListContainerStats`).

The metrics storage is per container flat/map structure and the sliding window buffer can be easily fed to numerical analysis, such as Gonum's stat. A flat storage is what we'd get from cAdvisor too so consuming/adding cAdvisor data should be easy.

TODO:
- "pub&sub" or policy based filtering which metrics to collect
- configurable avx thresholds
- configurable sliding window size
- ...