### PR TITLE
publish-docs.yml: use an access token for pushing to gh-pages.

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -39,7 +39,5 @@ jobs:
         git commit -m "publish-docs.yml: generated latest html output." .
     - name: Publish/force-push to gh-pages
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        git push -f https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages
+        git push -f https://${GITHUB_ACTOR}:${{secrets.ACCESS_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages


### PR DESCRIPTION
Use a github access token for publishing (pushing) to gh-pages.

Automatic publishing will not work until a github token created by a user with sufficient
write/push permissions and named ACCESS_TOKEN (or access-token) gets added to
settings/secrets for the main repository.