### PR TITLE
cgroupstats: fix hugetlb size parsing

### DIFF
--- a/pkg/cgroups/cgroupstats.go
+++ b/pkg/cgroups/cgroupstats.go
@@ -307,7 +307,7 @@ func GetHugetlbUsage(cgroupPath string) ([]HugetlbUsage, error) {
 	result := make([]HugetlbUsage, 0, len(usageFiles))
 
 	for _, file := range usageFiles {
-		size := strings.TrimSuffix(strings.TrimPrefix(file, prefix), usageSuffix)
+		size := strings.SplitN(filepath.Base(file), ".", 3)[1]
 		bytes, err := readCgroupSingleNumber(file)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
file is a full cgroup path so the trimming does not give the expected
result.

Fix the size parsing by first taking the base of the path and then
splitting hugetlb.<size>.bar.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>