### PR TITLE
fixes: don't consider assignment to a default class an error if no classes are defined. 

### DIFF
--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -28,6 +28,15 @@ import (
 
 var memoryCapacity int64
 
+// IsPodQOSClassName returns true if the given class is one of the Pod QOS classes.
+func IsPodQOSClassName(class string) bool {
+	switch corev1.PodQOSClass(class) {
+	case corev1.PodQOSBestEffort, corev1.PodQOSBurstable, corev1.PodQOSGuaranteed:
+		return true
+	}
+	return false
+}
+
 // estimateComputeResources calculates resource requests/limits from a CRI request.
 func estimateComputeResources(lnx *cri.LinuxContainerResources, cgroupParent string) corev1.ResourceRequirements {
 	var qos corev1.PodQOSClass

--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -971,5 +971,5 @@ func defaultOptions() interface{} {
 
 // Register us for configuration handling.
 func init() {
-	pkgcfg.Register("rdt", "RDT control", opt, defaultOptions)
+	pkgcfg.Register(ConfigModuleName, "RDT control", opt, defaultOptions)
 }

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -33,6 +33,9 @@ import (
 )
 
 const (
+	// ConfigModuleName is the configuration section of blockio class definitions
+	ConfigModuleName = "rdt"
+
 	resctrlGroupPrefix = "cri-resmgr."
 	// RootClassName is the name we use in our config for the special class
 	// that configures the "root" resctrl group of the system


### PR DESCRIPTION
When running without any `RDT` / `BlockIO` classes configured, do not consider failed assignments to `BestEffort`, `Burstable`, or `Guaranteed` an error. These are the default classes inherited from the container's `Pod QoS class`. Also, for both controllers give a warning the first time the controller realizes it is running without any classes configured.