### PR TITLE
resource-manager: add command line option for resetting cached configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ configuration using the `--fallback-config <config-file>`. This file will be
 use before the very first configuration is successfully acquired from the
 agent.
 
+Whenever a new configuration is acquired from the agent and successfully
+taken into use, this configuration is stored in the cache and will become
+the default configuration to take into use the next time CRI Resource
+Manager is restarted (unless that time the --force-config option is used).
+While CRI Resource Manager is shut down, any cached configuration can be
+cleared from the cache using the --reset-config command line option.
+
 See the [later chapter](#cri-resource-manager-node-agent) about how to set
 up and configure the agent.
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -492,6 +492,8 @@ type Cache interface {
 	SetConfig(*config.RawConfig) error
 	// GetConfig returns the current/cached configuration.
 	GetConfig() *config.RawConfig
+	// ResetConfig clears any stored configuration from the cache.
+	ResetConfig() error
 
 	// Save requests a cache save.
 	Save() error
@@ -625,6 +627,19 @@ func (cch *cache) SetConfig(cfg *config.RawConfig) error {
 // GetConfig returns the current/cached configuration.
 func (cch *cache) GetConfig() *config.RawConfig {
 	return cch.Cfg
+}
+
+// ResetConfig clears any stored configuration from the cache.
+func (cch *cache) ResetConfig() error {
+	old := cch.Cfg
+	cch.Cfg = nil
+
+	if err := cch.Save(); err != nil {
+		cch.Cfg = old
+		return err
+	}
+
+	return nil
 }
 
 // Derive cache id using pod uid, or allocate a new unused local cache id.

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -35,6 +35,7 @@ type options struct {
 	ForceConfigSignal string
 	AllowPolicySwitch bool
 	ResetPolicy       bool
+	ResetConfig       bool
 	MetricsTimer      time.Duration
 	RebalanceTimer    time.Duration
 	DisableUI         bool
@@ -64,6 +65,9 @@ func init() {
 		"Configuration used to override the one stored in the cache. Does not override the agent.")
 	flag.StringVar(&opt.ForceConfigSignal, "force-config-signal", "SIGHUP",
 		"Signal used to reload forced configuration.")
+	flag.BoolVar(&opt.ResetConfig, "reset-config", false,
+		"Remove configuration (from the agent) stored in the cache, then exit.")
+
 	flag.BoolVar(&opt.ResetPolicy, "reset-policy", false,
 		"Reset policy data stored in the cache, then exit.")
 	flag.BoolVar(&opt.AllowPolicySwitch, "allow-policy-switch", false,

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -635,6 +635,9 @@ func (m *mockCache) SetConfig(*config.RawConfig) error {
 func (m *mockCache) GetConfig() *config.RawConfig {
 	panic("unimplemented")
 }
+func (m *mockCache) ResetConfig() error {
+	panic("unimplemented")
+}
 func (m *mockCache) Save() error {
 	return nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -577,6 +577,9 @@ func (m *mockCache) SetConfig(*config.RawConfig) error {
 func (m *mockCache) GetConfig() *config.RawConfig {
 	panic("unimplemented")
 }
+func (m *mockCache) ResetConfig() error {
+	panic("unimplemented")
+}
 func (m *mockCache) Save() error {
 	panic("unimplemented")
 }


### PR DESCRIPTION
Add command line option `--reset-cached-config` to reset any configuration data stored in the cache.