### PR TITLE
resource-manager: implement support for limiting the amount of DRAM/top tier memory a container can use.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -42,6 +42,8 @@ const (
 	RDT = "rdt"
 	// BlockIO marks changes that can be applied by the BlockIO controller.
 	BlockIO = "blockio"
+	// Memory marks changes that can be applied by the Memory controller.
+	Memory = "memory"
 
 	// TagAVX512 tags containers that use AVX512 instructions.
 	TagAVX512 = "AVX512"
@@ -50,6 +52,11 @@ const (
 	RDTClassKey = "rdtclass" + "." + kubernetes.ResmgrKeyNamespace
 	// BlockIOClassKey is the pod annotation key for specifying a container Block I/O class.
 	BlockIOClassKey = "blockioclass" + "." + kubernetes.ResmgrKeyNamespace
+	// ToptierLimitKey is the pod annotation key for specifying container top tier memory limits.
+	ToptierLimitKey = "toptierlimit" + "." + kubernetes.ResmgrKeyNamespace
+
+	// ToptierLimitUnset is the reserved value for indicating unset top tier limits.
+	ToptierLimitUnset int64 = -1
 )
 
 // PodState is the pod state in the runtime.
@@ -324,6 +331,11 @@ type Container interface {
 	// GetBlockIOClass returns the BlockIO class for this container.
 	GetBlockIOClass() string
 
+	// SetToptierLimit sets the tier memory limit for the container.
+	SetToptierLimit(int64)
+	// GetToptierLimit returns the top tier memory limit for the container.
+	GetToptierLimit() int64
+
 	// SetCRIRequest sets the current pending CRI request of the container.
 	SetCRIRequest(req interface{}) error
 	// GetCRIRequest returns the current pending CRI request of the container.
@@ -378,9 +390,11 @@ type container struct {
 	LinuxReq  *cri.LinuxContainerResources // used to estimate Resources if we lack annotations
 	req       *interface{}                 // pending CRI request
 
-	RDTClass     string              // RDT class this container is assigned to.
-	BlockIOClass string              // Block I/O class this container is assigned to.
-	pending      map[string]struct{} // controllers with pending changes for this container
+	RDTClass     string // RDT class this container is assigned to.
+	BlockIOClass string // Block I/O class this container is assigned to.
+	ToptierLimit int64  // Top tier memory limit.
+
+	pending map[string]struct{} // controllers with pending changes for this container
 
 	prettyName string // cached PrettyName()
 }

--- a/pkg/cri/resource-manager/control/memory/memory.go
+++ b/pkg/cri/resource-manager/control/memory/memory.go
@@ -1,0 +1,173 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/client"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/utils"
+)
+
+const (
+	// MemoryController is the name of the memory controller.
+	MemoryController = cache.Memory
+
+	// memoryCgroupPath is the path to the root of the memory cgroup.
+	memoryCgroupPath = "/sys/fs/cgroup/memory"
+	// toptierSoftLimitControl is the memory cgroup entry to set top tier soft limit.
+	toptierSoftLimitControl = "memory.toptier_soft_limit_in_bytes"
+)
+
+// memctl encapsulates the runtime state of our memory enforcement/controller.
+type memctl struct {
+	cache    cache.Cache // resource manager cache
+	disabled bool        // true, if kernel lacks the necessary cgroup controls
+}
+
+// Our logger instance.
+var log logger.Logger = logger.NewLogger(MemoryController)
+
+// Our singleton memory controller instance.
+var singleton *memctl
+
+// getMemoryController returns our singleton memory controller instance.
+func getMemoryController() *memctl {
+	if singleton == nil {
+		singleton = &memctl{}
+	}
+	return singleton
+}
+
+// Start initializes the controller for enforcing decisions.
+func (ctl *memctl) Start(cache cache.Cache, client client.Client) error {
+	// Let's keep this off for now so we can exercise this without a patched kernel...
+	/*if !ctl.checkToptierLimitSupport() {
+		return memctlError("cgroup top tier memory limit control not available")
+	}*/
+	ctl.cache = cache
+	return nil
+}
+
+// Stop shuts down the controller.
+func (ctl *memctl) Stop() {
+}
+
+// PreCreateHook is the memory controller pre-create hook.
+func (ctl *memctl) PreCreateHook(c cache.Container) error {
+	return nil
+}
+
+// PreStartHook is the memory controller pre-start hook.
+func (ctl *memctl) PreStartHook(c cache.Container) error {
+	return nil
+}
+
+// PostStartHook is the memory controller post-start hook.
+func (ctl *memctl) PostStartHook(c cache.Container) error {
+	if !c.HasPending(MemoryController) {
+		return nil
+	}
+
+	if err := ctl.setToptierLimit(c); err != nil {
+		return err
+	}
+
+	c.ClearPending(MemoryController)
+
+	return nil
+}
+
+// PostUpdateHook is the memory controller post-update hook.
+func (ctl *memctl) PostUpdateHook(c cache.Container) error {
+	if !c.HasPending(MemoryController) {
+		return nil
+	}
+
+	if err := ctl.setToptierLimit(c); err != nil {
+		return err
+	}
+
+	c.ClearPending(MemoryController)
+
+	return nil
+}
+
+// PostStop is the memory controller post-stop hook.
+func (ctl *memctl) PostStopHook(c cache.Container) error {
+	return nil
+}
+
+// Check if memory cgroup controller supports top tier soft limits.
+func (ctl *memctl) checkToptierLimitSupport() bool {
+	_, err := os.Stat(memoryCgroupPath + "/" + toptierSoftLimitControl)
+	if err != nil && os.IsNotExist(err) {
+		log.Warn("cgroup top tier memory limit control not available")
+		ctl.disabled = true
+	}
+	return !ctl.disabled
+}
+
+// setToptierLimit sets the top tier memory (soft) limit for the container.
+func (ctl *memctl) setToptierLimit(c cache.Container) error {
+	pod, ok := c.GetPod()
+	if !ok {
+		return memctlError("%s: failed to get Pod", c.PrettyName())
+	}
+
+	limit := c.GetToptierLimit()
+
+	podDir := memoryCgroupPath + "/" + pod.GetCgroupParentDir()
+	containerDir := utils.GetContainerCgroupDir(podDir, c.GetID())
+	if containerDir == "" {
+		return memctlError("%s: failed to find memory controller cgroup directory",
+			c.PrettyName())
+	}
+
+	path := containerDir + "/" + toptierSoftLimitControl
+
+	log.Debug("%q: setting %s to %v", c.PrettyName(), path, limit)
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0644)
+	if err != nil {
+		return memctlError("%s: failed to open cgroup entry %s: %v",
+			c.PrettyName(), path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(strconv.FormatInt(limit, 10) + "\n"); err != nil {
+		return memctlError("%s: failed to update top tier memory soft limit: %v",
+			c.PrettyName(), err)
+	}
+
+	log.Info("%q: memory limit set to %v", c.PrettyName(), limit)
+
+	return nil
+}
+
+// memctlError creates a memory I/O-controller-specific formatted error message.
+func memctlError(format string, args ...interface{}) error {
+	return fmt.Errorf("memory: "+format, args...)
+}
+
+// init registers this controller.
+func init() {
+	control.Register(MemoryController, "memory toptier controller", getMemoryController())
+}

--- a/pkg/cri/resource-manager/controllers.go
+++ b/pkg/cri/resource-manager/controllers.go
@@ -18,5 +18,6 @@ import (
 	// List of controllers to pull in.
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/blockio"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/cri"
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/memory"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/rdt"
 )

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -437,6 +437,12 @@ func (m *mockContainer) SetBlockIOClass(string) {
 func (m *mockContainer) GetBlockIOClass() string {
 	panic("unimplemented")
 }
+func (m *mockContainer) SetToptierLimit(int64) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetToptierLimit() int64 {
+	panic("unimplemented")
+}
 func (m *mockContainer) SetCRIRequest(req interface{}) error {
 	panic("unimplemented")
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -384,6 +384,12 @@ func (m *mockContainer) SetBlockIOClass(string) {
 func (m *mockContainer) GetBlockIOClass() string {
 	panic("unimplemented")
 }
+func (m *mockContainer) SetToptierLimit(int64) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetToptierLimit() int64 {
+	panic("unimplemented")
+}
 func (m *mockContainer) SetCRIRequest(req interface{}) error {
 	panic("unimplemented")
 }

--- a/pkg/utils/cgroups.go
+++ b/pkg/utils/cgroups.go
@@ -28,24 +28,26 @@ const (
 	cpusetCgroupDir = "/sys/fs/cgroup/cpuset/"
 )
 
-// GetContainerCgroupDir finds container path in one specified subsystem directory
-func GetContainerCgroupDir(subsystemDir, containerID string) string {
+// GetContainerCgroupDir brute-force searches for a container directory under parentDir.
+func GetContainerCgroupDir(parentDir, containerID string) string {
 	var containerDir string
 
-	filepath.Walk(subsystemDir, func(path string, info os.FileInfo, err error) error {
+	filepath.Walk(parentDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 		if !info.IsDir() {
 			return nil
 		}
-		// Assume directory name contains containerID is what we want
+		if containerDir != "" {
+			return filepath.SkipDir
+		}
+		// Assume any directory that contains containerID is the one we look for.
 		if strings.Contains(filepath.Base(path), containerID) {
 			containerDir = path
 		}
 		return nil
 	})
-
 	return containerDir
 }
 


### PR DESCRIPTION
This patch set implements limiting the amount of DRAM/top tier memory a container can use with memory tiering.
In particular, it adds
  - support for per container DRAM limits,
  - support for setting per container DRAM limits using annotations, and
  - a controller for enforcing DRAM limits using the memory cgroup controller
