### PR TITLE
fixes: re-trigger pod cgroup parent dir and QoS class discovery, if necessary.

### DIFF
--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -212,7 +212,7 @@ func (c *container) resolveRef(path string) (string, bool, error) {
 			case "namespace":
 				obj = v.Namespace
 			case "qosclass":
-				obj = string(v.QOSClass)
+				obj = string(v.GetQOSClass())
 			}
 		case *pod:
 			switch strings.ToLower(key) {

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -754,6 +754,11 @@ func (cch *cache) UpdateContainerID(cacheID string, msg interface{}) (Container,
 	}
 
 	cch.Containers[c.ID] = c
+	if pod, ok := cch.Pods[c.PodID]; ok {
+		if pod.CgroupParent == "" {
+			pod.discoverCgroupParentDir(c.ID)
+		}
+	}
 
 	cch.Save()
 
@@ -1321,6 +1326,9 @@ func (cch *cache) Restore(data []byte) error {
 		cch.Containers[c.CacheID] = c
 		if c.ID != "" {
 			cch.Containers[c.ID] = c
+			if p, ok := c.GetPod(); ok && p.GetCgroupParentDir() == "" {
+				p.(*pod).discoverCgroupParentDir(c.ID)
+			}
 		}
 	}
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -374,7 +374,6 @@ type container struct {
 	Name          string             // container name
 	Namespace     string             // container namespace
 	State         ContainerState     // created/running/exited/unknown
-	QOSClass      v1.PodQOSClass     // QoS class, if the container had one
 	Image         string             // containers image
 	Command       []string           // command to run in container
 	Args          []string           // arguments for command

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -142,6 +142,10 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 	c.Annotations = lrc.Annotations
 	c.Tags = make(map[string]string)
 
+	if pod.CgroupParent == "" {
+		pod.discoverCgroupParentDir(c.ID)
+	}
+
 	if pod.Resources != nil {
 		if r, ok := pod.Resources.InitContainers[c.Name]; ok {
 			c.Resources = r

--- a/pkg/utils/cgroups.go
+++ b/pkg/utils/cgroups.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	cgroupTasks     = "tasks"
-	cpusetCgroupDir = "/sys/fs/cgroup/cpuset/"
+	CpusetCgroupDir = "/sys/fs/cgroup/cpuset"
 )
 
 // GetContainerCgroupDir brute-force searches for a container directory under parentDir.
@@ -88,10 +88,10 @@ func getTasksInContainer(cgroupParentDir, containerID string, onlyProcesses bool
 	// Probe known per-container directories
 	if cgroupParentDir != "" {
 		dirs := []string{
-			filepath.Join(cpusetCgroupDir, cgroupParentDir, "cri-containerd-"+containerID+".scope"),
-			filepath.Join(cpusetCgroupDir, cgroupParentDir, "crio-"+containerID+".scope"),
-			filepath.Join(cpusetCgroupDir, cgroupParentDir, "docker-"+containerID+".scope"),
-			filepath.Join(cpusetCgroupDir, cgroupParentDir, containerID),
+			filepath.Join(CpusetCgroupDir, cgroupParentDir, "cri-containerd-"+containerID+".scope"),
+			filepath.Join(CpusetCgroupDir, cgroupParentDir, "crio-"+containerID+".scope"),
+			filepath.Join(CpusetCgroupDir, cgroupParentDir, "docker-"+containerID+".scope"),
+			filepath.Join(CpusetCgroupDir, cgroupParentDir, containerID),
 		}
 		for _, d := range dirs {
 			info, err := os.Stat(d)
@@ -104,7 +104,7 @@ func getTasksInContainer(cgroupParentDir, containerID string, onlyProcesses bool
 
 	// Try generic way to search container directory under one cgroups subsytem directory
 	if containerDir == "" {
-		containerDir = GetContainerCgroupDir(cpusetCgroupDir, containerID)
+		containerDir = GetContainerCgroupDir(CpusetCgroupDir, containerID)
 		if containerDir == "" {
 			return nil, fmt.Errorf("failed to find corresponding cgroups directory for container %s", containerID)
 		}


### PR DESCRIPTION
If we had failed to discover pod cgroup parent dir and proper QoS class, re-trigger disovery of
both at suitable events (cache reload, successful pod container creation).