### PR TITLE
cache: limit annotated affinity weights to [-1000,1000].

### DIFF
--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -66,6 +66,10 @@ const (
 	NotExist Operator = "NotExist"
 	// AlwaysTrue always evaluates to true.
 	AlwaysTrue = "AlwaysTrue"
+	// UserWeightCutoff is the cutoff we clamp user-provided weights to.
+	UserWeightCutoff = 1000
+	// DefaultWeight is the default assigned weight if omitted in annotations.
+	DefaultWeight int32 = 1
 )
 
 // ImplicitAffinity is an affinity that gets implicitly added to all eligible containers.
@@ -82,6 +86,13 @@ func (a *Affinity) Validate() error {
 
 	if err := a.Match.Validate(); err != nil {
 		return cacheError("invalid affinity match: %v", err)
+	}
+
+	switch {
+	case a.Weight > UserWeightCutoff:
+		a.Weight = UserWeightCutoff
+	case a.Weight < -UserWeightCutoff:
+		a.Weight = -UserWeightCutoff
 	}
 
 	return nil

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -339,7 +339,7 @@ func (p *pod) GetContainerAffinity(name string) []*Affinity {
 
 	value, ok := p.GetResmgrAnnotation(keyAffinity)
 	if ok {
-		weight := int32(1)
+		weight := DefaultWeight
 		if !p.Affinity.parseSimple(p, value, weight) {
 			if err := p.Affinity.parseFull(p, value, weight); err != nil {
 				p.cache.Error("%v", err)
@@ -348,7 +348,7 @@ func (p *pod) GetContainerAffinity(name string) []*Affinity {
 	}
 	value, ok = p.GetResmgrAnnotation(keyAntiAffinity)
 	if ok {
-		weight := int32(-1)
+		weight := -DefaultWeight
 		if !p.Affinity.parseSimple(p, value, weight) {
 			if err := p.Affinity.parseFull(p, value, weight); err != nil {
 				p.cache.Error("%v", err)


### PR DESCRIPTION
Limiting the range of externally provided weights helps
internally generated affinities assign weights to their
desired effect, without having to use the min or max of
the expressible integer range. 

Additionally, we now use an explicitly defined const to
spell out default weights.
