### PR TITLE
fixes: allow policy switch by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ See the [later chapter](#cri-resource-manager-node-agent) about how to set
 up and configure the agent.
 
 
+### Changing the Active Policy
+
+Currently CRI Resource Manager will disable changing the active policy using
+the agent. That is, once the active policy is recorded in the cache, any
+configuration received through the agent that requests a different policy
+will be rejected. This limitation will be removed in a future version of
+CRI Resource Manager.
+
+However, by default CRI Resource Manager will allow changing policies during
+its startup phase. If you want to disable this you can pass the command line
+option `--disable-policy-switch` to CRI Resource Manager.
+
+If you run CRI Resource Manager with disabled policy switching, you can still
+switch policies by clearing any policy-specific data stored in the cache while
+CRI Resource Manager is shut down. You can do this by using the command line
+option `--reset-policy`. The whole sequence of switching policies this way is
+
+  - stop cri-resmgr (`systemctl stop cri-resource-manager`)
+  - reset policy data (`cri-resmgr --reset-policy`)
+  - change policy (`$EDITOR /etc/cri-resource-manager/fallback.cfg`)
+  - start cri-resmgr (`systemctl start cri-resource-manager`)
+
 ## CRI Resource Manager Mutating Webhook
 
 By default CRI Resource Manager does not see the original container *resource

--- a/cmd/cri-resmgr/cri-resource-manager.sysconf
+++ b/cmd/cri-resmgr/cri-resource-manager.sysconf
@@ -3,5 +3,5 @@
 # Use a fallback file for configuration if/when we can't acquire one from the agent.
 CONFIG_OPTIONS="--fallback-config /etc/cri-resmgr/fallback.cfg"
 
-# Enable this for allowing the active policy to be changed during startup.
-#POLICY_OPTIONS="--allow-policy-switch"
+# Enable this for preventing the active policy to be changed during startup.
+#POLICY_OPTIONS="--disable-policy-switch"

--- a/cmd/cri-resmgr/fallback.cfg.sample
+++ b/cmd/cri-resmgr/fallback.cfg.sample
@@ -5,24 +5,24 @@
 # stored in the cache).
 #
 # Switching Policies:
-#     Normally cri-resmgr will refuse to change the active policy
-#     once it has been stored in the cache. This restriction can
-#     be relaxed, for now to allow the policy to be changed during
-#     startup, by passing cri-resmgr the --allow-policy-switch
-#     option on the command line.
+#     Recent versions of cri-resmgr will allow changing the active
+#     policy during startup. If you want to prevent this from hap-
+#     pening you can pass the --disable-policy-switch option to
+#     cri-resmgr on the command line.
 #
 #     With the stock packaging you can control whether startup-
 #     phase policy switching is allowed using the POLICY_OPTIONS
 #     variable in the sysconf file.
 #
-#     If switching policies is disabled, you can manually reset
-#     the active policy to allow cri-resmgr to start up withe a
-#     new one. You do this by passing the --reset-policy command
-#     line option to cri-resmgr. To switch policies this way you
-#     need to
-#         - stop cri-resmgr,
+#     If switching policies is disabled, you can still reset the
+#     active policy manually when cri-resmgr is not running. This
+#     allows cri-resmgr to start up next with a new policy. You
+#     do this by passing the --reset-policy command line option
+#     to cri-resmgr. The full sequence of switching policies this
+#     way is
+#         - stop cri-resmgr (systemctl stop cri-resource-manager),
 #         - reset the active policy (cri-resmgr --reset-policy),
-#         - restart cri-resmgr again
+#         - start cri-resmgr (systemctl start cri-resource-manager)
 #
 
 policy:

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -23,22 +23,22 @@ import (
 
 // Options captures our command line parameters.
 type options struct {
-	ImageSocket       string
-	RuntimeSocket     string
-	RelaySocket       string
-	RelayDir          string
-	AgentSocket       string
-	ConfigSocket      string
-	ResctrlPath       string
-	FallbackConfig    string
-	ForceConfig       string
-	ForceConfigSignal string
-	AllowPolicySwitch bool
-	ResetPolicy       bool
-	ResetConfig       bool
-	MetricsTimer      time.Duration
-	RebalanceTimer    time.Duration
-	DisableUI         bool
+	ImageSocket         string
+	RuntimeSocket       string
+	RelaySocket         string
+	RelayDir            string
+	AgentSocket         string
+	ConfigSocket        string
+	ResctrlPath         string
+	FallbackConfig      string
+	ForceConfig         string
+	ForceConfigSignal   string
+	DisablePolicySwitch bool
+	ResetPolicy         bool
+	ResetConfig         bool
+	MetricsTimer        time.Duration
+	RebalanceTimer      time.Duration
+	DisableUI           bool
 }
 
 // Relay command line options.
@@ -70,8 +70,8 @@ func init() {
 
 	flag.BoolVar(&opt.ResetPolicy, "reset-policy", false,
 		"Reset policy data stored in the cache, then exit.")
-	flag.BoolVar(&opt.AllowPolicySwitch, "allow-policy-switch", false,
-		"Allow switching policies (only during startup for now)")
+	flag.BoolVar(&opt.DisablePolicySwitch, "disable-policy-switch", false,
+		"Disable switching policies during startup.")
 
 	flag.DurationVar(&opt.MetricsTimer, "metrics-interval", 0,
 		"Interval for polling/gathering runtime metrics data. Use 'disable' for disabling.")

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -439,7 +439,9 @@ func (m *resmgr) setupPolicy() error {
 
 	if active != cached {
 		if cached != "" {
-			if !opt.AllowPolicySwitch {
+			if opt.DisablePolicySwitch {
+				m.Error("can't switch policy from %q to %q: policy switching disabled",
+					cached, active)
 				return resmgrError("cannot load cache with policy %s for active policy %s",
 					cached, active)
 			}


### PR DESCRIPTION
Change the default configuration to allow switching policies by default.
Add a brief chapter to README.md describing the current state of switching policies. 