### PR TITLE
tests: add NUMA node testing infra and memtier CPU isolation test

### DIFF
--- a/demo/lib/numajson2qemuopts.py
+++ b/demo/lib/numajson2qemuopts.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+"""numajson2qemuopts - convert NUMA node list from JSON to Qemu options
+
+Example: Each of the two first groups contain two NUMA nodes. Nodes in
+the first group include two CPUs and 2G RAM, nodes in the second group
+single CPU and 1G RAM. The only NUMA node defined in the third group
+has 8G of NVRAM, and no CPU.
+
+$ ( cat << EOF
+[
+    {
+        "cpu": 2,
+        "mem": "2G",
+        "nodes": 2
+    },
+    {
+        "cpu": 1,
+        "mem": "1G",
+        "nodes": 2
+    },
+    {
+        "nvmem": "8G",
+        "dist": 20,
+        "dist-group-0": 80,
+        "dist-group-1": 80
+    }
+]
+EOF
+) | numajson2qemuopts
+
+NUMA node group definitions:
+"cpu"                 number of CPUs on every NUMA node in this group.
+                      The default is 0.
+"mem"                 mem (RAM) size on every NUMA node in this group.
+                      The default is 0G.
+"nvmem"               nvmem (non-volatile RAM) size on every NUMA node
+                      in this group. The default is 0G.
+"nodes"               number of NUMA nodes in this group. The default is 1.
+
+NUMA node distances are defined with following keys:
+"dist-group-X": N     symmetrical distance between nodes in this group and
+                      nodes in group X. The first group in the list is group 0.
+"dist-to-group-X": N  unidirectional distance from nodes in this group to
+                      nodes in group X.
+"dist-node-X": N      symmetrical distance between nodes in this group and
+                      node X. The first node in the first group is node 0,
+                      the second node in the first group is node 1, and so on.
+"dist-to-node-X": N   unidirectional distance from nodes in this group to
+                      node X.
+"dist": N             the default distance on all node links within and between
+                      all groups.
+
+Note that the distance from a node to itself is always 10 (otherwise Qemu
+would give an error).
+"""
+
+import sys
+import json
+
+def error(msg, exitstatus=1):
+    sys.stderr.write("numajson2qemuopts: %s\n" % (msg,))
+    if not exitstatus is None:
+        sys.exit(exitstatus)
+
+def siadd(s1, s2):
+    if s1.lower().endswith("g") and s2.lower().endswith("g"):
+        return str(int(s1[:-1]) + int(s2[:-1])) + "G"
+    raise ValueError('supports only sizes in gigabytes, example: 2G')
+
+def validate(numalist):
+    valid_keys = set(("cpu", "mem", "nvmem", "nodes", "dist"))
+    valid_key_prefixes = set(("dist-group-", "dist-to-group-",
+                              "dist-node-", "dist-to-node-"))
+    for numalistindex, numaspec in enumerate(numalist):
+        for key in numaspec:
+            if key in valid_keys:
+                continue
+            for prefix in valid_key_prefixes:
+                if key.startswith(prefix):
+                    try:
+                        v = int(key[len(prefix):])
+                    except:
+                        raise ValueError('integer expected in property %r after prefix %r' % (key, prefix))
+                    break
+            else:
+                raise ValueError('invalid property name in numalist: %r' % (key,))
+
+def qemuopts(numalist):
+    machineparam = "-machine pc"
+    numaparams = []
+    objectparams = []
+    lastnode = -1
+    lastcpu = -1
+    lastmem = -1
+    lastnvmem = -1
+    totalmem = "0G"
+    totalnvmem = "0G"
+    groupnodes = {} # groupnodes[NUMALISTINDEX] = (NODEID, ...)
+    validate(numalist)
+
+    # Read  "cpu" counts, and "mem" and "nvmem" sizes for all nodes.
+    for numalistindex, numaspec in enumerate(numalist):
+        nodecount = int(numaspec.get("nodes", 1))
+        groupnodes[numalistindex] = tuple(range(lastnode + 1, lastnode + 1 + nodecount))
+        cpucount = int(numaspec.get("cpu", 0))
+        memsize = numaspec.get("mem", "0")
+        if memsize != "0":
+            memcount = 1
+        else:
+            memcount = 0
+        nvmemsize = numaspec.get("nvmem", "0")
+        if nvmemsize != "0":
+            nvmemcount = 1
+        else:
+            nvmemcount = 0
+        for node in range(nodecount):
+            lastnode += 1
+            for mem in range(memcount):
+                lastmem += 1
+                objectparams.append("-object memory-backend-ram,size=%s,id=mem%s" % (memsize, lastmem))
+                numaparams.append("-numa node,nodeid=%s,memdev=mem%s" % (lastnode, lastmem))
+                totalmem = siadd(totalmem, memsize)
+            for nvmem in range(nvmemcount):
+                lastnvmem += 1
+                if lastnvmem == 0:
+                    machineparam += ",nvdimm=on"
+                # Don't use file-backed nvdimms because the file would
+                # need to be accessible from the govm VM
+                # container. Everything is ram-backed on host for now.
+                objectparams.append("-object memory-backend-ram,size=%s,id=nvmem%s" % (nvmemsize, lastnvmem))
+                # Currently nvdimm is not backed up by -device pair.
+                numaparams.append("-numa node,nodeid=%s,memdev=nvmem%s" % (lastnode, lastnvmem))
+                totalnvmem = siadd(totalnvmem, nvmemsize)
+            if cpucount > 0:
+                numaparams[-1] = numaparams[-1] + (",cpus=%s-%s" % (lastcpu + 1, lastcpu + cpucount))
+                lastcpu += cpucount
+
+    # Calculate distances in the order of precedence: nodes, groups and the default.
+    found_dests = {src: set() for src in range(lastnode + 1)}
+    # First, "dist-to-node" and "dist-node" override more general distances.
+    sourcenode = -1
+    for numalistindex, numaspec in enumerate(numalist):
+        nodecount = int(numaspec.get("nodes", 1))
+        for node in range(nodecount):
+            sourcenode += 1
+            if sourcenode not in found_dests[sourcenode]:
+                # Mark all node-to-self-distances already defined, but
+                # let Qemu use its default (10) for them instead of specifying
+                # it explicitly (-numa dist,src=N,dst=N,val=10).
+                # Qemu would give an error, if val != 10.
+                found_dests[sourcenode].add(sourcenode)
+            for destnode in range(lastnode + 1):
+                destnodedist = numaspec.get("dist-to-node-%s" % (destnode,), None)
+                symdestnodedist = numaspec.get("dist-node-%s" % (destnode,), None)
+                if not destnodedist is None and destnode not in found_dests[sourcenode]:
+                    numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, destnodedist))
+                    found_dests[sourcenode].add(destnode)
+                if not symdestnodedist is None:
+                    if destnode not in found_dests[sourcenode]:
+                        numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, symdestnodedist))
+                        found_dests[sourcenode].add(destnode)
+                    if sourcenode not in found_dests[destnode]:
+                        numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (destnode, sourcenode, symdestnodedist))
+                        found_dests[destnode].add(sourcenode)
+    # Second, "dist-to-group" and "dist-group" override the default
+    sourcenode = -1
+    for numalistindex, numaspec in enumerate(numalist):
+        nodecount = int(numaspec.get("nodes", 1))
+        for node in range(nodecount):
+            sourcenode += 1
+            for destgroup in range(len(numalist)):
+                groupdist = numaspec.get("dist-to-group-%s" % (destgroup,), None)
+                symgroupdist = numaspec.get("dist-group-%s" % (destgroup,), None)
+                if not groupdist is None:
+                    for destnode in groupnodes[destgroup]:
+                        if not destnode in found_dests[sourcenode]:
+                            numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, groupdist))
+                            found_dests[sourcenode].add(destnode)
+                if not symgroupdist is None:
+                    for destnode in groupnodes[destgroup]:
+                        if not destnode in found_dests[sourcenode]:
+                            numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, symgroupdist))
+                            found_dests[sourcenode].add(destnode)
+                        if not sourcenode in found_dests[destnode]:
+                            numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (destnode, sourcenode, symgroupdist))
+                            found_dests[destnode].add(sourcenode)
+    # Finally, use the first found default distance for all other node links
+    for numalistindex, numaspec in enumerate(numalist):
+        defaultdist = numaspec.get("dist", None)
+        if defaultdist is None:
+            continue
+        for sourcenode in range(lastnode + 1):
+            for destnode in range(lastnode + 1):
+                if not destnode in found_dests[sourcenode]:
+                    numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, defaultdist))
+                if not sourcenode in found_dests[destnode]:
+                    numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (destnode, sourcenode, defaultdist))
+    # Combine all parameters
+    cpuparam = "-smp %s" % (lastcpu + 1,)
+    memparam = "-m %s" % (siadd(totalmem, totalnvmem),)
+    return (machineparam + " " +
+            cpuparam + " " +
+            memparam + " " +
+            " ".join(numaparams) + " " +
+            " ".join(objectparams))
+
+def main():
+    try:
+        numalist = json.loads(sys.stdin.read())
+    except Exception as e:
+        error("error reading JSON from stdin: %s" % (e,))
+    try:
+        print(qemuopts(numalist))
+    except Exception as e:
+        error("error converting JSON to Qemu opts: %s" % (e,))
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        print(__doc__)
+        sys.exit(0)
+    main()

--- a/test/numa/README.md
+++ b/test/numa/README.md
@@ -1,0 +1,129 @@
+# CRI Resource Manager - NUMA node tests
+
+## Prerequisites
+
+Install:
+- `docker`
+- `govm`
+- `jq`
+
+## Usage
+
+```
+[VAR=VALUE...] ./run.sh MODE
+```
+
+Get help on available `VAR=VALUE`'s with `./run.sh`.
+
+## Two modes: `test` and `play`
+
+`test` mode runs fast and, by default, cleans up everything after test
+run. The virtual machine with the contents will be lost. The output
+will include `Test verdict:`, and the exit status is zero if and only
+if the test passed.
+
+`play` mode runs slower and, by default, leaves the virtual machine
+running.
+
+Print help to see clean up, execution speed and other options for both
+modes.
+
+## Running from scratch and quick rerun in existing virtual machine
+
+The test will use `govm` virtual machine named in the `vm` environment
+variable. The default is `crirm-test-numa`. If a virtual machine with
+that name exists, the test will be run on it. Otherwise the test will
+create a virtual machine with that name from scratch. You can delete a
+virtual machine with `govm delete NAME`.
+
+If you want rerun the test many times, possibly with different test
+inputs or against different versions of `cri-resmgr`, either use the
+`play` mode or set `cleanup=0` in order to keep the virtual machine
+after each run. Then tests will run in the same single node cluster,
+and the test script will only delete running pods before launching new
+ones.
+
+## Testing locally built cri-resmgr and cri-resmgr from github
+
+If you make changes to `cri-resmgr` sources and rebuild it, you can
+force the test script to reinstall newly built `cri-resmgr` to
+existing virtual machine before rerunning the test:
+
+```
+cri-resource-manager$ make
+cri-resource-manager$ cd test/numa
+numa$ reinstall_cri_resmgr=1 speed=1000 ./run.sh play
+```
+
+You can also let the test script build `cri-resmgr` from the github
+master branch. This takes place inside the virtual machine, so your
+local git sources will not be affected:
+
+```
+numa$ reinstall_cri_resmgr=1 binsrc=github ./run.sh play
+```
+
+## Testing different Pods
+
+The test will instantiate Pods listed in the `pods` variable in
+JSON. You can print the default `pods` with `./run.sh help defaults`.
+
+The JSON list contains pod groups. Each group specifies template file,
+number of pods to be created with these specifications, and contents
+to the fields in template files (`CPU`, `CPULIM`, `MEM`, ... depends
+on the template).
+
+```
+{
+  "q": "guaranteed", // specifies the QoS class, or more precisely,
+                     // the Pod template file (here guaranteed.yaml.in)
+                     // from which pods will be instantiated.
+  "pods": 3,         // how many pods like this will be created.
+                     // The default is 1.
+  "CPU": 2,          // how many CPUs each pod will require. Field ${CPU}
+                     // in the template will be replaced with this value.
+                     // The defaults of template field values is printed by
+                     // ./run.sh help defaults.
+  "MEM": "3G",       // how much memory each pod will require.
+}
+```
+
+You can create `mycustom.yaml.in` Pod templates and use those in the
+same way as `guaranteed`, `burstable` and `besteffort` templates.
+
+## Testing different NUMA node configurations
+
+If you change NUMA node topology of an existing virtual machine, you
+must delete the virtual machine first. Otherwise `numanodes` variable
+is ignored and the test will run in the existing NUMA
+configuration. Example:
+
+```
+numa$ govm delete my2x4
+```
+
+Run the test in a VM with two NUMA nodes, 4 CPUs and 4G RAM in each node
+```
+numa$ govm delete my2x4 ; vm=my2x4 numanodes='[{"cpu":4,"mem":"4G","nodes":2}]' ./run.sh play
+```
+
+Run the test in a VM with two NUMA nodes, 8 CPUs and 4G of memory in
+one, no CPUs and 16G of non-volatile memory (NVRAM) in the other
+
+```
+numa$ vm=mynvram numanodes='[{"cpu":8,"mem":"4G"},{"nvmem":"16G"}]' ./run.sh play
+```
+
+## Test output
+
+All test output is saved under the directory in the environment
+variable `outdir`. The default is `./output`.
+
+Executed commands with their output, exit status and timestamps are
+saved under the `output/commands` directory.
+
+You can find Qemu output from Docker logs. For instance, output of the
+most recent Qemu launced by `govm`:
+```
+$ docker logs $(docker ps | awk '/govm/{print $1; exit}')
+```

--- a/test/numa/besteffort.yaml.in
+++ b/test/numa/besteffort.yaml.in
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME} \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  terminationGracePeriodSeconds: 1

--- a/test/numa/burstable.yaml.in
+++ b/test/numa/burstable.yaml.in
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+  annotations:
+    cri-resource-manager.intel.com/prefer-isolated-cpus: '${ISO}'
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME} \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    name: busybox
+    resources:
+      requests:
+        cpu: ${CPUREQ}
+        memory: ${MEMREQ}
+      limits:
+        cpu: ${CPULIM}
+        memory: ${MEMLIM}
+  terminationGracePeriodSeconds: 1

--- a/test/numa/cri-resmgr-memtier.cfg
+++ b/test/numa/cri-resmgr-memtier.cfg
@@ -1,0 +1,6 @@
+policy:
+  Active: memtier
+  ReservedResources:
+    CPU: 750m
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy

--- a/test/numa/guaranteed.yaml.in
+++ b/test/numa/guaranteed.yaml.in
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+  annotations:
+    cri-resource-manager.intel.com/prefer-isolated-cpus: '${ISO}'
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME} \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    name: busybox
+    resources:
+      requests:
+        cpu: ${CPU}
+        memory: '${MEM}'
+      limits:
+        cpu: ${CPU}
+        memory: '${MEM}'
+  terminationGracePeriodSeconds: 1

--- a/test/numa/run.sh
+++ b/test/numa/run.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+
+DEMO_TITLE="CRI Resource Manager: Numa test"
+
+PV='pv -qL'
+
+binsrc=${binsrc-local}
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+DEMO_LIB_DIR=$(realpath "$SCRIPT_DIR/../../demo/lib")
+BIN_DIR=${bindir-$(realpath "$SCRIPT_DIR/../../bin")}
+OUTPUT_DIR=${outdir-$SCRIPT_DIR/output}
+COMMAND_OUTPUT_DIR=$OUTPUT_DIR/commands
+
+source $DEMO_LIB_DIR/command.bash
+source $DEMO_LIB_DIR/host.bash
+source $DEMO_LIB_DIR/vm.bash
+
+usage() {
+    echo "$DEMO_TITLE"
+    echo "Usage: [VAR=VALUE] ./run.sh MODE"
+    echo "  MODE:     \"play\" plays the test as a demo."
+    echo "            \"record\" plays and records the demo."
+    echo "            \"test\" runs fast, reports pass or fail."
+    echo "  VARs:"
+    echo "    vm:      govm virtual machine name."
+    echo "             The default is \"crirm-test-numa\"."
+    echo "    speed:   Demo play speed."
+    echo "             The default is 10 (keypresses per second)."
+    echo "    cleanup: Level of cleanup after test run:"
+    echo "             0: leave VM running. (\"play\" mode default)"
+    echo "             1: delete VM (\"test\" mode default)"
+    echo "             2: stop VM, but do not delete it."
+    echo "    outdir:  Save output under given directory."
+    echo "             The default is \"${SCRIPT_DIR}/output\"."
+    echo "    binsrc:  Where to get cri-resmgr to the VM."
+    echo "             \"github\": go get from master and build inside VM."
+    echo "             \"local\": copy from source tree bin/ (the default)."
+    echo "                      (set bindir=/path/to/cri-resmgr* to override bin/)"
+    echo "    reinstall_cri_resmgr: If 1, stop running cri-resmgr, reinstall,"
+    echo "             and restart it on the VM before starting test run."
+    echo ""
+    echo "  Test input VARs:"
+    echo "    numanodes: JSON to override NUMA node list used in tests."
+    echo "             Effective only if \"vm\" does not exist."
+    echo "    cri_resmgr_cfg: configuration file forced to cri-resmgr."
+    echo "    pods:    JSON to override the default Pods to be created."
+    echo "             The array specifies the order, and objects the"
+    echo "             QoS class (guaranteed, besteffort or burstable)"
+    echo "             and non-default values for variables in"
+    echo "             QOSCLASS.yaml.in templates."
+    echo ""
+    echo "Default test input VARs: ./run.sh help defaults"
+    echo ""
+    echo "Development cycle example:"
+    echo "pushd ../..; make; popd; reinstall_cri_resmgr=1 speed=120 ./run.sh play"
+}
+
+error() {
+    (echo ""; echo "error: $1" ) >&2
+    exit 1
+}
+
+out() {
+    if [ -n "$PV" ]; then
+        speed=${speed-10}
+        echo "$1" | $PV $speed
+    else
+        echo "$1"
+    fi
+    echo ""
+}
+
+record() {
+    clear
+    out "Recording this screencast..."
+    host-command "asciinema rec -t \"$DEMO_TITLE\" crirm-demo-blockio.cast -c \"./run.sh play\""
+}
+
+screen-create-vm() {
+    speed=60 out "### Running the test in VM \"$vm\"."
+    # Create a machine with 5 NUMA nodes.
+    # Qemu default NUMA node self-distance is 10.
+    # Define distance 22 between all 4 nodes with CPU(s).
+    # The distance from nodes with CPU(s) and the node with NVRAM is 88.
+    host-create-vm $vm "$numanodes"
+    vm-networking
+    if [ -z "$VM_IP" ]; then
+        error "creating VM failed"
+    fi
+}
+
+screen-install-k8s() {
+    speed=60 out "### Installing Kubernetes to the VM."
+    vm-install-containerd
+    vm-install-k8s
+}
+
+screen-install-cri-resmgr() {
+    speed=60 out "### Installing CRI Resource Manager to VM."
+    vm-install-cri-resmgr
+}
+
+screen-launch-cri-resmgr() {
+    speed=120 out "### Launching cri-resmgr with config $cri_resmgr_cfg."
+    host-command "scp $cri_resmgr_cfg $VM_SSH_USER@$VM_IP:" || {
+        command-error "copying $cri_resmgr_cfg to VM failed"
+    }
+    vm-command "cat $(basename $cri_resmgr_cfg)"
+    vm-command "cri-resmgr -relay-socket /var/run/cri-resmgr/cri-resmgr.sock -runtime-socket /var/run/containerd/containerd.sock -force-config $(basename $cri_resmgr_cfg) >cri-resmgr.output.txt 2>&1 &"
+}
+
+screen-create-singlenode-cluster() {
+    speed=60 out "### Setting up single-node Kubernetes cluster."
+    speed=60 out "### CRI Resource Manager + containerd will act as the container runtime."
+    vm-create-singlenode-cluster-cilium
+}
+
+screen-launch-cri-resmgr-agent() {
+    speed=60 out "### Launching cri-resmgr-agent."
+    speed=60 out "### The agent will make cri-resmgr configurable with ConfigMaps."
+    vm-command "NODE_NAME=\$(hostname) cri-resmgr-agent -kubeconfig \$HOME/.kube/config >cri-resmgr-agent.output.txt 2>&1 &"
+}
+
+create-wait() {
+    # Copy NAME.yaml from host to vm, kubectl create -f it,
+    # and wait for it becoming Ready.
+    local NAME=$1
+    local YAML_KIND=$(awk '/kind/{print $2}' < $NAME.yaml)
+    host-command "scp $NAME.yaml $VM_SSH_USER@$VM_IP:" || {
+        command-error "copying $NAME.yaml to VM failed"
+    }
+    vm-command "cat $NAME.yaml"
+    vm-command "kubectl create -f $NAME.yaml"
+    vm-command-q "kubectl wait --timeout=60s --for=condition=Ready ${YAML_KIND}/$NAME" >/dev/null 2>&1 || {
+        command-error "waiting for ${YAML_KIND} \"$NAME\" to become ready timed out"
+    }
+}
+
+get-cpus-allowed-mask() {
+    local PROCESS_CMD_CONTAINS=$1
+    vm-command "grep Cpus_allowed: /proc/\$(pgrep -f ${PROCESS_CMD_CONTAINS})/status | awk '{print \$2}'"
+    local mask=$COMMAND_OUTPUT
+    if [ "$(echo $mask | wc -c)" -gt "3" ] || [ "$(echo $mask | wc -c)" -lt "2" ]; then
+        command-error "expected Cpus_allowed mask value, got \"$mask\""
+    fi
+    CPUS_ALLOWED_MASK=$(python3 -c "print(bin(0x$mask))")
+}
+
+test-exclusive-cpus() {
+    vm-command-q "kubectl get pods 2>&1 | grep -q NAME" && vm-command "kubectl delete pods --all --now"
+
+    # Instantiate QOSCLASS.yaml.in with parameters in pods JSON
+    local last_pod_index=-1
+    local pod_descr=()
+    local pod_names=()
+    local cpu_masks=()
+    out "### Creating pods..."
+    for pod_group_index in $(seq 0 $(jq length-1 <<<$pods)); do
+        local pod_qos_class=$(jq -r ".[$pod_group_index].q" <<<$pods)
+        local pod_count=$(jq -r ".[$pod_group_index].pods" <<<$pods)
+        if [ "$pod_count" == "null" ]; then
+            pod_count=1
+        fi
+        local pod_yaml_in=${pod_qos_class}.yaml.in
+        if ! [ -f "$pod_yaml_in" ]; then
+            error "cannot find pod yaml template $pod_yaml_in"
+        fi
+        local pod_env=$(jq -r ".[$pod_group_index]|to_entries|.[]|select(.key != \"q\" and .key != \"pods\")|\"\(.key)=\(.value)\"" <<<$pods)
+        for pod_in_group in $(seq 1 $pod_count); do
+            pod_index=$(( last_pod_index + 1 ))
+            pod_descr[$pod_index]="$pod_qos_class $(echo $pod_env)"
+            pod_env_defaults="NAME=pod${pod_index} ${yaml_in_defaults}"
+            eval $pod_env_defaults
+            eval $pod_env
+            echo "### Creating Pod $NAME: ${pod_descr[$pod_index]}"
+            eval "echo -e \"$(<${pod_yaml_in})\"" > $NAME.yaml
+            create-wait $NAME || {
+                error "failed to create pod $NAME from YAML: $(<$NAME.yaml)"
+            }
+            last_pod_index=$pod_index
+            pod_names[$pod_index]=$NAME
+        done
+    done
+    out "### All pods are now running."
+
+    out "### Reading which CPUs each pod is allowed to run on."
+    for pod_index in $(seq 0 $last_pod_index); do
+        get-cpus-allowed-mask ${pod_names[$pod_index]}; cpu_masks[$pod_index]=$CPUS_ALLOWED_MASK
+    done
+
+    out "### Cpus_allowed masks:"
+    out "$(printf "%-8s %15s  %s" "Pod" "Cpus_allowed" "Description")"
+    for pod_index in $(seq 0 $last_pod_index); do
+        out "$(printf "%-8s %15s  %s" ${pod_names[$pod_index]} ${cpu_masks[$pod_index]} "${pod_descr[$pod_index]}")"
+    done
+}
+
+# Validate parameters
+mode=$1
+vm=${vm-"crirm-test-numa"}
+cri_resmgr_cfg=${cri_resmgr_cfg-"cri-resmgr-memtier.cfg"}
+numanodes=${numanodes-'[
+    {"cpu": 1, "mem": "1G", "nodes": 2},
+    {"cpu": 2, "mem": "2G"},
+    {"cpu": 4, "mem": "4G"},
+    {"nvmem": "8G",
+     "dist": 22,
+     "dist-group-0": 88,
+     "dist-group-1": 88,
+     "dist-group-2": 88
+    }]'}
+pods=${pods-'[
+    {"q": "guaranteed", "CPU": 1},
+    {"q": "besteffort", "pods": 2},
+    {"q": "burstable", "CPULIM": 4, "CPUREQ": 2},
+    {"q": "guaranteed", "CPU": 3}
+    ]'}
+yaml_in_defaults="CPU=1 MEM=100M ISO=true CPUREQ=1 CPULIM=2 MEMREQ=100M MEMLIM=200M"
+
+if [ "$mode" == "help" ]; then
+    if [ "$2" != "defaults" ]; then
+        usage
+    else
+        echo "Test input defaults:"
+        echo ""
+        echo "numanodes=${numanodes}"
+        echo ""
+        echo "cri_resmgr_cfg=${cri_resmgr_cfg}"
+        echo ""
+        echo "pods=${pods}"
+        echo ""
+        echo "The defaults to QOSCLASS.yaml.in variables:"
+        echo "    ${yaml_in_defaults}"
+    fi
+    exit 0
+elif [ "$mode" == "play" ]; then
+    speed=${speed-10}
+    cleanup=${cleanup-0}
+elif [ "$mode" == "test" ]; then
+    PV=
+    cleanup=${cleanup-1}
+elif [ "$mode" == "record" ]; then
+    record
+else
+    usage
+    error "missing valid MODE"
+    exit 1
+fi
+
+# Prepare for test/demo
+mkdir -p $OUTPUT_DIR
+mkdir -p $COMMAND_OUTPUT_DIR
+rm -f $COMMAND_OUTPUT_DIR/0*
+( echo x > $OUTPUT_DIR/x && rm -f $OUTPUT_DIR/x ) || {
+    error "output directory outdir=$OUTPUT_DIR is not writable"
+}
+
+if [ "$binsrc" == "local" ]; then
+    [ -f "${BIN_DIR}/cri-resmgr" ] || error "missing \"${BIN_DIR}/cri-resmgr\""
+    [ -f "${BIN_DIR}/cri-resmgr-agent" ] || error "missing \"${BIN_DIR}/cri-resmgr-agent\""
+fi
+
+if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ] || [ -z "$VM_NAME" ]; then
+    screen-create-vm
+fi
+
+if ! vm-command-q "dpkg -l | grep -q kubelet"; then
+    screen-install-k8s
+fi
+
+if [ "$reinstall_cri_resmgr" == "1" ]; then
+    vm-command "kill -9 \$(pgrep cri-resmgr); rm -rf /usr/local/bin/cri-resmgr /usr/bin/cri-resmgr /usr/local/bin/cri-resmgr-agent /usr/bin/cri-resmgr-agent /var/lib/resmgr"
+fi
+
+if ! vm-command-q "[ -f /usr/local/bin/cri-resmgr ]"; then
+    screen-install-cri-resmgr
+fi
+
+# Start cri-resmgr if not already running
+if ! vm-command-q "pidof cri-resmgr" >/dev/null; then
+    screen-launch-cri-resmgr
+fi
+
+# Create kubernetes cluster or wait that it is online
+if vm-command-q "[ ! -f /var/lib/kubelet/config.yaml ]"; then
+    screen-create-singlenode-cluster
+else
+    # Wait for kube-apiserver to launch (may be down if the VM was just booted)
+    vm-wait-process kube-apiserver
+fi
+
+# Run test/demo
+TEST_FAILURES=""
+test-exclusive-cpus
+
+# Save logs
+host-command "scp $VM_SSH_USER@$VM_IP:cri-resmgr.output.txt \"$OUTPUT_DIR/\""
+
+# Cleanup
+if [ "$cleanup" == "0" ]; then
+    echo "The VM, Kubernetes and cri-resmgr are left running. Next steps:"
+    vm-print-usage
+elif [ "$cleanup" == "1" ]; then
+    host-stop-vm $vm
+    host-delete-vm $vm
+elif [ "$cleanup" == "2" ]; then
+    host-stop-vm $vm
+fi
+
+# Summarize results
+exit_status=0
+if [ -n "$TEST_FAILURES" ]; then
+    echo "FAIL:$TEST_FAILURES"
+    exit_status=1
+    exit $exit_status
+fi


### PR DESCRIPTION
- numajson2qemuopts.py: convert NUMA node list (JSON)
  with CPUs, memory and distance definitions to Qemu options.
- demo/lib: add host-create-vm support for pass-through Qemu options
  and NUMA node list in JSON.
- test/numa: add a test for CPU isolation in a five-NUMA-node setup.
- Refactor common parts from new test and demo/blockio to demo/lib/vm.
- Implements infra described in Issue #123.