### PR TITLE
rdt: fix crash/misplaced logging of deletion.

### DIFF
--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -200,7 +200,6 @@ func (ctl *rdtctl) stopMonitor(c cache.Container) error {
 			if err := cls.DeleteMonGroup(name); err != nil {
 				return err
 			}
-		} else {
 			log.Info("%q: removed monitoring group %q",
 				c.PrettyName(), cls.Name()+"/"+mg.Name())
 		}


### PR DESCRIPTION
Fix a crash due to misplaced logging of monitor group deletion in the RDT controller. Should fix #346 .