### PR TITLE
memtier, topology-aware: fix post-alloc update of shared cpuset.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -407,8 +407,8 @@ func (p *policy) updateSharedAllocations(grant Grant) error {
 	log.Debug("* updating shared allocations affected by %s", grant)
 
 	for _, other := range p.allocations.grants {
-		if other.SharedPortion() == 0 {
-			log.Debug("  => %s not affected (no shared portion)...", other)
+		if other.SharedPortion() == 0 && !other.ExclusiveCPUs().IsEmpty() {
+			log.Debug("  => %s not affected (only exclusive CPUs)...", other)
 			continue
 		}
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -208,8 +208,8 @@ func (p *policy) updateSharedAllocations(grant CPUGrant) error {
 	log.Debug("* updating shared allocations affected by %s", grant)
 
 	for _, other := range p.allocations.CPU {
-		if other.SharedPortion() == 0 {
-			log.Debug("  => %s not affected (no shared portion)...", other)
+		if other.SharedPortion() == 0 && !other.ExclusiveCPUs().IsEmpty() {
+			log.Debug("  => %s not affected (only exclusive CPUs)...", other)
 			continue
 		}
 


### PR DESCRIPTION
Only skip updating the cpuset of those containers that run on a purely exclusive set of cpus.
This should fix BestEffort containers not getting properly updated after exclusive allocations.