### PR TITLE
tests: add NUMA node testing infra and memtier CPU isolation test

### DIFF
--- a/demo/lib/command.bash
+++ b/demo/lib/command.bash
@@ -67,11 +67,20 @@ command-end() {
     rm -f "$COMMAND_OUT_FILE.tmp"
 }
 
-command-error() {
-    # example: command-error "creating directory failed"
+command-error() { # script API
+    # Usage: command-error MESSAGE
+    #
+    # Print executed command, observed output, exit status and MESSAGE.
+    # Stop script execution.
     ( echo "command:     $COMMAND";
       echo "output:      $COMMAND_OUTPUT";
       echo "exit status: $COMMAND_STATUS";
       echo "error:       $1" ) >&2
-    exit 1
+    command-exit-if-not-interactive
+}
+
+command-exit-if-not-interactive() {
+    if [ -z "$INTERACTIVE_MODE" ] || [ "$INTERACTIVE_MODE" == "0" ]; then
+        exit ${1:-1}
+    fi
 }

--- a/demo/lib/numajson2qemuopts.py
+++ b/demo/lib/numajson2qemuopts.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+"""numajson2qemuopts - convert NUMA node list from JSON to Qemu options
+
+Example: Each of the two first groups contain two NUMA nodes. Nodes in
+the first group include two CPUs and 2G RAM, nodes in the second group
+single CPU and 1G RAM. The only NUMA node defined in the third group
+has 8G of NVRAM, and no CPU.
+
+$ ( cat << EOF
+[
+    {
+        "cpu": 2,
+        "mem": "2G",
+        "nodes": 2
+    },
+    {
+        "cpu": 1,
+        "mem": "1G",
+        "nodes": 2
+    },
+    {
+        "nvmem": "8G",
+        "dist": 20,
+        "dist-group-0": 80,
+        "dist-group-1": 80
+    }
+]
+EOF
+) | numajson2qemuopts
+
+NUMA node group definitions:
+"cpu"                 number of CPUs on every NUMA node in this group.
+                      The default is 0.
+"mem"                 mem (RAM) size on every NUMA node in this group.
+                      The default is 0G.
+"nvmem"               nvmem (non-volatile RAM) size on every NUMA node
+                      in this group. The default is 0G.
+"nodes"               number of NUMA nodes in this group. The default is 1.
+
+NUMA node distances are defined with following keys:
+"dist-group-X": N     symmetrical distance between nodes in this group and
+                      nodes in group X. The first group in the list is group 0.
+"dist-to-group-X": N  unidirectional distance from nodes in this group to
+                      nodes in group X.
+"dist-node-X": N      symmetrical distance between nodes in this group and
+                      node X. The first node in the first group is node 0,
+                      the second node in the first group is node 1, and so on.
+"dist-to-node-X": N   unidirectional distance from nodes in this group to
+                      node X.
+"dist": N             the default distance on all node links within and between
+                      all groups.
+
+Note that the distance from a node to itself is always 10 (otherwise Qemu
+would give an error).
+"""
+
+import sys
+import json
+
+def error(msg, exitstatus=1):
+    sys.stderr.write("numajson2qemuopts: %s\n" % (msg,))
+    if not exitstatus is None:
+        sys.exit(exitstatus)
+
+def siadd(s1, s2):
+    if s1.lower().endswith("g") and s2.lower().endswith("g"):
+        return str(int(s1[:-1]) + int(s2[:-1])) + "G"
+    raise ValueError('supports only sizes in gigabytes, example: 2G')
+
+def validate(numalist):
+    if not isinstance(numalist, list):
+        raise ValueError('expected list containing dicts, got %s' % (type(numalist,).__name__))
+    valid_keys = set(("cpu", "mem", "nvmem", "nodes", "dist"))
+    valid_key_prefixes = set(("dist-group-", "dist-to-group-",
+                              "dist-node-", "dist-to-node-"))
+    for numalistindex, numaspec in enumerate(numalist):
+        for key in numaspec:
+            if key in valid_keys:
+                continue
+            for prefix in valid_key_prefixes:
+                if key.startswith(prefix):
+                    try:
+                        v = int(key[len(prefix):])
+                    except:
+                        raise ValueError('integer expected in property %r after prefix %r' % (key, prefix))
+                    break
+            else:
+                raise ValueError('invalid property name in numalist: %r' % (key,))
+
+def qemuopts(numalist):
+    machineparam = "-machine pc"
+    numaparams = []
+    objectparams = []
+    lastnode = -1
+    lastcpu = -1
+    lastmem = -1
+    lastnvmem = -1
+    totalmem = "0G"
+    totalnvmem = "0G"
+    groupnodes = {} # groupnodes[NUMALISTINDEX] = (NODEID, ...)
+    validate(numalist)
+
+    # Read  "cpu" counts, and "mem" and "nvmem" sizes for all nodes.
+    for numalistindex, numaspec in enumerate(numalist):
+        nodecount = int(numaspec.get("nodes", 1))
+        groupnodes[numalistindex] = tuple(range(lastnode + 1, lastnode + 1 + nodecount))
+        cpucount = int(numaspec.get("cpu", 0))
+        memsize = numaspec.get("mem", "0")
+        if memsize != "0":
+            memcount = 1
+        else:
+            memcount = 0
+        nvmemsize = numaspec.get("nvmem", "0")
+        if nvmemsize != "0":
+            nvmemcount = 1
+        else:
+            nvmemcount = 0
+        for node in range(nodecount):
+            lastnode += 1
+            for mem in range(memcount):
+                lastmem += 1
+                objectparams.append("-object memory-backend-ram,size=%s,id=mem%s" % (memsize, lastmem))
+                numaparams.append("-numa node,nodeid=%s,memdev=mem%s" % (lastnode, lastmem))
+                totalmem = siadd(totalmem, memsize)
+            for nvmem in range(nvmemcount):
+                lastnvmem += 1
+                if lastnvmem == 0:
+                    machineparam += ",nvdimm=on"
+                # Don't use file-backed nvdimms because the file would
+                # need to be accessible from the govm VM
+                # container. Everything is ram-backed on host for now.
+                objectparams.append("-object memory-backend-ram,size=%s,id=nvmem%s" % (nvmemsize, lastnvmem))
+                # Currently nvdimm is not backed up by -device pair.
+                numaparams.append("-numa node,nodeid=%s,memdev=nvmem%s" % (lastnode, lastnvmem))
+                totalnvmem = siadd(totalnvmem, nvmemsize)
+            if cpucount > 0:
+                numaparams[-1] = numaparams[-1] + (",cpus=%s-%s" % (lastcpu + 1, lastcpu + cpucount))
+                lastcpu += cpucount
+
+    # Calculate distances in the order of precedence: nodes, groups and the default.
+    found_dests = {src: set() for src in range(lastnode + 1)}
+    # First, "dist-to-node" and "dist-node" override more general distances.
+    sourcenode = -1
+    for numalistindex, numaspec in enumerate(numalist):
+        nodecount = int(numaspec.get("nodes", 1))
+        for node in range(nodecount):
+            sourcenode += 1
+            if sourcenode not in found_dests[sourcenode]:
+                # Mark all node-to-self-distances already defined, but
+                # let Qemu use its default (10) for them instead of specifying
+                # it explicitly (-numa dist,src=N,dst=N,val=10).
+                # Qemu would give an error, if val != 10.
+                found_dests[sourcenode].add(sourcenode)
+            for destnode in range(lastnode + 1):
+                destnodedist = numaspec.get("dist-to-node-%s" % (destnode,), None)
+                symdestnodedist = numaspec.get("dist-node-%s" % (destnode,), None)
+                if not destnodedist is None and destnode not in found_dests[sourcenode]:
+                    numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, destnodedist))
+                    found_dests[sourcenode].add(destnode)
+                if not symdestnodedist is None:
+                    if destnode not in found_dests[sourcenode]:
+                        numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, symdestnodedist))
+                        found_dests[sourcenode].add(destnode)
+                    if sourcenode not in found_dests[destnode]:
+                        numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (destnode, sourcenode, symdestnodedist))
+                        found_dests[destnode].add(sourcenode)
+    # Second, "dist-to-group" and "dist-group" override the default
+    sourcenode = -1
+    for numalistindex, numaspec in enumerate(numalist):
+        nodecount = int(numaspec.get("nodes", 1))
+        for node in range(nodecount):
+            sourcenode += 1
+            for destgroup in range(len(numalist)):
+                groupdist = numaspec.get("dist-to-group-%s" % (destgroup,), None)
+                symgroupdist = numaspec.get("dist-group-%s" % (destgroup,), None)
+                if not groupdist is None:
+                    for destnode in groupnodes[destgroup]:
+                        if not destnode in found_dests[sourcenode]:
+                            numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, groupdist))
+                            found_dests[sourcenode].add(destnode)
+                if not symgroupdist is None:
+                    for destnode in groupnodes[destgroup]:
+                        if not destnode in found_dests[sourcenode]:
+                            numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, symgroupdist))
+                            found_dests[sourcenode].add(destnode)
+                        if not sourcenode in found_dests[destnode]:
+                            numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (destnode, sourcenode, symgroupdist))
+                            found_dests[destnode].add(sourcenode)
+    # Finally, use the first found default distance for all other node links
+    for numalistindex, numaspec in enumerate(numalist):
+        defaultdist = numaspec.get("dist", None)
+        if defaultdist is None:
+            continue
+        for sourcenode in range(lastnode + 1):
+            for destnode in range(lastnode + 1):
+                if not destnode in found_dests[sourcenode]:
+                    numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (sourcenode, destnode, defaultdist))
+                if not sourcenode in found_dests[destnode]:
+                    numaparams.append("-numa dist,src=%s,dst=%s,val=%s" % (destnode, sourcenode, defaultdist))
+    # Combine all parameters
+    cpuparam = "-smp %s" % (lastcpu + 1,)
+    memparam = "-m %s" % (siadd(totalmem, totalnvmem),)
+    return (machineparam + " " +
+            cpuparam + " " +
+            memparam + " " +
+            " ".join(numaparams) + " " +
+            " ".join(objectparams))
+
+def main():
+    try:
+        numalist = json.loads(sys.stdin.read())
+    except Exception as e:
+        error("error reading JSON from stdin: %s" % (e,))
+    try:
+        print(qemuopts(numalist))
+    except Exception as e:
+        error("error converting JSON to Qemu opts: %s" % (e,))
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        print(__doc__)
+        sys.exit(0)
+    main()

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -5,7 +5,26 @@ VM_SSH_USER=ubuntu
 VM_IMAGE_URL=https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
 VM_IMAGE=$(basename "$VM_IMAGE_URL")
 
-vm-command() {
+VM_GOVM_COMPOSE_TEMPLATE="vms:
+  - name: \${VM_NAME}
+    image: \${VM_IMAGE}
+    cloud: true
+    ContainerEnvVars:
+      - KVM_CPU_OPTS=\$(echo "\${KVM_CPU_OPTS}")
+      - EXTRA_QEMU_OPTS=\$(echo "\${EXTRA_QEMU_OPTS}")
+"
+
+vm-command() { # script API
+    # Usage: vm-command COMMAND
+    #
+    # Execute COMMAND on virtual machine as root.
+    # Returns the exit status of the execution.
+    # Environment variable COMMAND_OUTPUT contains what COMMAND printed
+    # in standard output and error.
+    #
+    # Examples:
+    #   vm-command "kubectl get pods"
+    #   vm-command "whoami | grep myuser" || command-error "user is not myuser"
     command-start "vm" "$VM_PROMPT" "$1"
     if [ "$2" == "bg" ]; then
         ( ssh -o StrictHostKeyChecking=No ${VM_SSH_USER}@${VM_IP} sudo bash <<<"$COMMAND" 2>&1 | command-handle-output ;
@@ -42,6 +61,23 @@ vm-networking() {
     vm-command-q "grep -q \$(hostname) /etc/hosts" || vm-command "echo \"$VM_IP \$(hostname)\" >/etc/hosts"
     if [ -n "$http_proxy" ] || [ -n "$https_proxy" ] || [ -n "$no_proxy" ]; then
         vm-command-q "grep -q no_proxy /etc/environment" || vm-command "(echo http_proxy=$http_proxy; echo https_proxy=$https_proxy; echo no_proxy=$no_proxy,$VM_IP,10.96.0.0/12,10.217.0.0/16,\$(hostname) ) >> /etc/environment"
+    fi
+}
+
+vm-install-cri-resmgr() {
+    prefix=/usr/local
+    if [ "$binsrc" == "github" ]; then
+        vm-command "apt install -y golang make"
+        vm-command "go get -d -v github.com/intel/cri-resource-manager"
+        CRI_RESMGR_SOURCE_DIR=$(awk '/package.*cri-resource-manager/{print $NF}' <<< "$COMMAND_OUTPUT")
+        vm-command "cd $CRI_RESMGR_SOURCE_DIR && make install && cd -"
+    else
+        host-command "scp \"$BIN_DIR/cri-resmgr\" \"$BIN_DIR/cri-resmgr-agent\" $VM_SSH_USER@$VM_IP:" || {
+            command-error "copying local cri-resmgr to VM failed"
+        }
+        vm-command "mv cri-resmgr cri-resmgr-agent $prefix/bin" || {
+            command-error "installing cri-resmgr to $prefix/bin failed"
+        }
     fi
 }
 
@@ -104,6 +140,20 @@ vm-install-k8s() {
     speed=60 vm-command "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -"
     speed=60 vm-command "echo \"deb https://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list"
     vm-command "apt update &&  apt install -y kubelet kubeadm kubectl"
+}
+
+vm-create-singlenode-cluster-cilium() {
+    vm-command "kubeadm init --pod-network-cidr=10.217.0.0/16 --cri-socket /var/run/cri-resmgr/cri-resmgr.sock"
+    if ! grep -q "initialized successfully" <<< "$COMMAND_OUTPUT"; then
+        command-error "kubeadm init failed"
+    fi
+    vm-command "mkdir -p \$HOME/.kube"
+    vm-command "cp -i /etc/kubernetes/admin.conf \$HOME/.kube/config"
+    vm-command "kubectl taint nodes --all node-role.kubernetes.io/master-"
+    vm-command "kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.6/install/kubernetes/quick-install.yaml"
+    if ! vm-command "kubectl rollout status --timeout=360s -n kube-system daemonsets/cilium"; then
+        command-error "installing cilium CNI to Kubernetes timed out"
+    fi
 }
 
 vm-print-usage() {

--- a/test/numa/README.md
+++ b/test/numa/README.md
@@ -1,0 +1,160 @@
+# CRI Resource Manager - NUMA node tests
+
+## Prerequisites
+
+Install:
+- `docker`
+- `govm`
+  In case of errors in building `govm` with `go get`, or creating a virtual machine (`Error when creating the new VM: repository name must be canonical`), these are the workarounds:
+  ```
+  cd ~/go/src && go get -d github.com/govm-project/govm && cd github.com/govm-project/govm && go install  && cd .. && docker build govm -f govm/Dockerfile -t govm/govm:latest
+  ```
+
+## Usage
+
+```
+[VAR=VALUE...] ./run.sh MODE
+```
+
+Get help on available `VAR=VALUE`'s with `./run.sh help`.
+
+## Test phases
+
+In the *setup phase* NUMA node tests create a virtual machine unless
+it already exists. When it is running, tests create a single-node
+cluster and launches `cri-resmgr` on it, unless they are already
+running.
+
+In the *test phase* NUMA node tests run the default test script, a
+custom script, or give a prompt (`run.sh> `) asking a user to run test
+script commands in the `interactive` mode. *Test scripts* are `bash`
+scripts that can use helper functions for running commands and
+observing the status of the virtual machine and software running on
+it.
+
+In the *tear down phase* NUMA node tests copy logs from the virtual
+machine and finally stop or delete the virtual machine, if that is
+wanted.
+
+## Test modes
+
+- `test` mode runs fast and reports `Test verdict: PASS` or
+  `FAIL`. The exit status is zero if and only if a test passed.
+
+- `play` mode runs the same phases and scripts as the `test` mode, but
+  slower. This is good for following and demonstrating what is
+  happening.
+
+- `interactive` mode runs the setup and tear down phases, but instead
+  of executing a test script it gives an interactive prompt.
+
+Print help to see clean up, execution speed and other options for all
+modes.
+
+## Running from scratch and quick rerun in existing virtual machine
+
+The test will use `govm`-managed virtual machine named in the `vm`
+environment variable. The default is `crirm-test-numa`. If a virtual
+machine with that name exists, the test will be run on it. Otherwise
+the test will create a virtual machine with that name from
+scratch. You can delete a virtual machine with `govm delete NAME`.
+
+If you want rerun the test many times, possibly with different test
+inputs or against different versions of `cri-resmgr`, either use the
+`play` mode or set `cleanup=0` in order to keep the virtual machine
+after each run. Then tests will run in the same single node cluster,
+and the test script will only delete running pods before launching new
+ones.
+
+## Testing locally built cri-resmgr and cri-resmgr from github
+
+If you make changes to `cri-resmgr` sources and rebuild it, you can
+force the test script to reinstall newly built `cri-resmgr` to
+existing virtual machine before rerunning the test:
+
+```
+cri-resource-manager$ make
+cri-resource-manager$ cd test/numa
+numa$ reinstall_cri_resmgr=1 speed=1000 ./run.sh play
+```
+
+You can also let the test script build `cri-resmgr` from the github
+master branch. This takes place inside the virtual machine, so your
+local git sources will not be affected:
+
+```
+numa$ reinstall_cri_resmgr=1 binsrc=github ./run.sh play
+```
+
+## Custom tests
+
+You can run a custom test script in a virtual machine with NUMA
+setup and single-node Kubernetes cluster is running. Example:
+
+```
+$ cat > myscript.sh << EOF
+# create two pods, each requesting two CPUs
+CPU=2 n=2 create guaranteed
+# create four pods, no resource requests
+n=4 create besteffort
+# show pods
+vm-command "kubectl get pods"
+# check that
+#   1. the first two pods are not allowed to use the same CPUs
+#   2. the first two and the last four pods are not allowed to run on
+#      the same CPUs
+#   3. the first two pods get four CPUs in total.
+verify 'cpus[0] & cpus[1] == 0' \
+       '(cpus[2] | cpus[3] | cpus[4] | cpus[5]) & (cpus[0] | cpus[1]) == 0' \
+       'bin(cpus[0] | cpus[1]).count("1") == 4'
+EOF
+$ ./run.sh play myscript.sh
+```
+
+Interactive mode helps developing and debugging custom scripts:
+
+```
+$ ./run.sh interactive
+...
+run.sh> CPU=2 n=2 create guaranteed
+```
+
+You can get help on functions available in test scripts with `./run.sh
+help script`, or with `help` when in the interactive mode.
+
+## Testing different NUMA node configurations
+
+If you change NUMA node topology of an existing virtual machine, you
+must delete the virtual machine first. Otherwise `numanodes` variable
+is ignored and the test will run in the existing NUMA
+configuration. Example:
+
+```
+numa$ govm delete my2x4
+```
+
+Run the test in a VM with two NUMA nodes, 4 CPUs and 4G RAM in each node
+```
+numa$ govm delete my2x4 ; vm=my2x4 numanodes='[{"cpu":4,"mem":"4G","nodes":2}]' ./run.sh play
+```
+
+Run the test in a VM with two NUMA nodes, 8 CPUs and 4G of memory in
+one, no CPUs and 16G of non-volatile memory (NVRAM) in the other
+
+```
+numa$ vm=mynvram numanodes='[{"cpu":8,"mem":"4G"},{"nvmem":"16G"}]' ./run.sh play
+```
+
+## Test output
+
+All test output is saved under the directory in the environment
+variable `outdir`. The default is `./output`.
+
+Executed commands with their output, exit status and timestamps are
+saved under the `output/commands` directory.
+
+You can find Qemu output from Docker logs. For instance, output of the
+most recent Qemu launced by `govm`:
+```
+$ docker logs $(docker ps | awk '/govm/{print $1; exit}')
+```

--- a/test/numa/besteffort.yaml.in
+++ b/test/numa/besteffort.yaml.in
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME} \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  terminationGracePeriodSeconds: 1

--- a/test/numa/burstable.yaml.in
+++ b/test/numa/burstable.yaml.in
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+  annotations:
+    cri-resource-manager.intel.com/prefer-isolated-cpus: '${ISO}'
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME} \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    name: busybox
+    resources:
+      requests:
+        cpu: ${CPUREQ}
+        memory: ${MEMREQ}
+      limits:
+        cpu: ${CPULIM}
+        memory: ${MEMLIM}
+  terminationGracePeriodSeconds: 1

--- a/test/numa/cri-resmgr-memtier.cfg
+++ b/test/numa/cri-resmgr-memtier.cfg
@@ -1,0 +1,6 @@
+policy:
+  Active: memtier
+  ReservedResources:
+    CPU: 750m
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy

--- a/test/numa/guaranteed.yaml.in
+++ b/test/numa/guaranteed.yaml.in
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+  annotations:
+    cri-resource-manager.intel.com/prefer-isolated-cpus: '${ISO}'
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME} \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    name: busybox
+    resources:
+      requests:
+        cpu: ${CPU}
+        memory: '${MEM}'
+      limits:
+        cpu: ${CPU}
+        memory: '${MEM}'
+  terminationGracePeriodSeconds: 1

--- a/test/numa/run.sh
+++ b/test/numa/run.sh
@@ -1,0 +1,501 @@
+#!/bin/bash
+
+DEMO_TITLE="CRI Resource Manager: Numa test"
+
+PV='pv -qL'
+
+binsrc=${binsrc-local}
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+DEMO_LIB_DIR=$(realpath "$SCRIPT_DIR/../../demo/lib")
+BIN_DIR=${bindir-$(realpath "$SCRIPT_DIR/../../bin")}
+OUTPUT_DIR=${outdir-"$SCRIPT_DIR"/output}
+COMMAND_OUTPUT_DIR="$OUTPUT_DIR"/commands
+
+# shellcheck disable=SC1091
+# shellcheck source=../../demo/lib/command.bash
+source "$DEMO_LIB_DIR"/command.bash
+# shellcheck disable=SC1091
+# shellcheck source=../../demo/lib/host.bash
+source "$DEMO_LIB_DIR"/host.bash
+# shellcheck disable=SC1091
+# shellcheck source=../../demo/lib/vm.bash
+source "$DEMO_LIB_DIR"/vm.bash
+
+script_source="$(< "$0") $(< "$DEMO_LIB_DIR/host.bash") $(< "$DEMO_LIB_DIR/command.bash") $(< "$DEMO_LIB_DIR/vm.bash")"
+
+usage() {
+    echo "$DEMO_TITLE"
+    echo "Usage: [VAR=VALUE] ./run.sh MODE [SCRIPT]"
+    echo "  MODE:     \"play\" plays the test as a demo."
+    echo "            \"record\" plays and records the demo."
+    echo "            \"test\" runs fast, reports pass or fail."
+    echo "            \"interactive\" launches interactive shell"
+    echo "            for running test script commands"
+    echo "            (see ./run.sh help script [FUNCTION])."
+    echo "  SCRIPT:   test script file to run instead of the default test."
+    echo ""
+    echo "  VARs:"
+    echo "    vm:      govm virtual machine name."
+    echo "             The default is \"crirm-test-numa\"."
+    echo "    speed:   Demo play speed."
+    echo "             The default is 10 (keypresses per second)."
+    echo "    binsrc:  Where to get cri-resmgr to the VM."
+    echo "             \"github\": go get from master and build inside VM."
+    echo "             \"local\": copy from source tree bin/ (the default)."
+    echo "                      (set bindir=/path/to/cri-resmgr* to override bin/)"
+    echo "    reinstall_cri_resmgr: If 1, stop running cri-resmgr, reinstall,"
+    echo "             and restart it on the VM before starting test run."
+    echo "             The default is 0."
+    echo "    outdir:  Save output under given directory."
+    echo "             The default is \"${SCRIPT_DIR}/output\"."
+    echo "    cleanup: Level of cleanup after a test run:"
+    echo "             0: leave VM running (the default)"
+    echo "             1: delete VM"
+    echo "             2: stop VM, but do not delete it."
+    echo ""
+    echo "  Test input VARs:"
+    echo "    numanodes: JSON to override NUMA node list used in tests."
+    echo "             Effective only if \"vm\" does not exist."
+    echo "    cri_resmgr_cfg: configuration file forced to cri-resmgr."
+    echo "    code:    Variable that contains test script code to be run"
+    echo "             if SCRIPT is not given."
+    echo ""
+    echo "Default test input VARs: ./run.sh help defaults"
+    echo ""
+    echo "Development cycle example:"
+    echo "pushd ../..; make; popd; reinstall_cri_resmgr=1 speed=120 ./run.sh play"
+}
+
+error() {
+    (echo ""; echo "error: $1" ) >&2
+    command-exit-if-not-interactive
+}
+
+out() {
+    if [ -n "$PV" ]; then
+        speed=${speed-10}
+        echo "$1" | $PV "$speed"
+    else
+        echo "$1"
+    fi
+    echo ""
+}
+
+record() {
+    clear
+    out "Recording this screencast..."
+    host-command "asciinema rec -t \"$DEMO_TITLE\" crirm-demo-blockio.cast -c \"./run.sh play\""
+}
+
+screen-create-vm() {
+    speed=60 out "### Running the test in VM \"$vm\"."
+    # Create a machine with 5 NUMA nodes.
+    # Qemu default NUMA node self-distance is 10.
+    # Define distance 22 between all 4 nodes with CPU(s).
+    # The distance from nodes with CPU(s) and the node with NVRAM is 88.
+    host-create-vm "$vm" "$numanodes"
+    vm-networking
+    if [ -z "$VM_IP" ]; then
+        error "creating VM failed"
+    fi
+}
+
+screen-install-k8s() {
+    speed=60 out "### Installing Kubernetes to the VM."
+    vm-install-containerd
+    vm-install-k8s
+}
+
+screen-install-cri-resmgr() {
+    speed=60 out "### Installing CRI Resource Manager to VM."
+    vm-install-cri-resmgr
+}
+
+screen-launch-cri-resmgr() {
+    speed=60 out "### Launching cri-resmgr with config $cri_resmgr_cfg."
+    host-command "scp \"$cri_resmgr_cfg\" $VM_SSH_USER@$VM_IP:" || {
+        command-error "copying \"$cri_resmgr_cfg\" to VM failed"
+    }
+    vm-command "cat $(basename "$cri_resmgr_cfg")"
+    vm-command "cri-resmgr -relay-socket /var/run/cri-resmgr/cri-resmgr.sock -runtime-socket /var/run/containerd/containerd.sock -force-config $(basename "$cri_resmgr_cfg") >cri-resmgr.output.txt 2>&1 &"
+}
+
+screen-create-singlenode-cluster() {
+    speed=60 out "### Setting up single-node Kubernetes cluster."
+    speed=60 out "### CRI Resource Manager + containerd will act as the container runtime."
+    vm-create-singlenode-cluster-cilium
+}
+
+screen-launch-cri-resmgr-agent() {
+    speed=60 out "### Launching cri-resmgr-agent."
+    speed=60 out "### The agent will make cri-resmgr configurable with ConfigMaps."
+    vm-command "NODE_NAME=\$(hostname) cri-resmgr-agent -kubeconfig \$HOME/.kube/config >cri-resmgr-agent.output.txt 2>&1 &"
+}
+
+get-py-cpus() {
+    # Fetch Cpus_allowed masks of running pods from the virtual machine
+    # and update them in the "cpus" dictionary in Python code.
+    speed=1000 vm-command "echo cpus={}; for pod_name in \$(kubectl get pods | awk '/pod/{print \$1}'); do pod_index=\${pod_name/pod/}; mask=\$(grep Cpus_allowed: /proc/\$(pgrep -f \${pod_name})/status | awk '{print \$2}'); echo cpus[\$pod_index]=0x\$mask; done" >/dev/null 2>&1 || {
+        command-error "error in reading Cpus_allowed masks from running pods"
+    }
+    if grep -q '=0' <<<"$COMMAND_OUTPUT"; then
+        py_cpus="$COMMAND_OUTPUT"
+    else
+        py_cpus="cpus={}"
+    fi
+}
+
+### Test script helpers
+
+sleep() { # script API
+    # Usage: sleep PARAMETERS
+    #
+    # Run sleep PARAMETERS on host.
+    host-command "sleep $*"
+}
+
+pyexec() { # script API
+    # Usage: pyexec [PYTHONCODE...]
+    #
+    # Run python3 -c PYTHONCODEs on host. Stops if execution fails.
+    #
+    # Variables available in PYTHONCODE:
+    #   cpus: dictionary {pod_number: cpu_mask}
+    #
+    # Note that variables are *not* updated when pyexec is called.
+    # You can update the variables by running "verify" without expressions.
+    #
+    # Example:
+    #   verify ; pyexec 'import pprint; pprint.pprint(cpus)'
+    PYTEMPFILE_PY="$OUTPUT_DIR/pyexec.py"
+    PYTEMPFILE_LOG="$OUTPUT_DIR/pyexec.output.txt"
+    local last_exit_status=0
+    for PYTHONCODE in "$@"; do
+        cat > "$PYTEMPFILE_PY" <<<"$py_cpus"
+        cat >> "$PYTEMPFILE_PY" <<<"$PYTHONCODE"
+        python3 "$PYTEMPFILE_PY" 2>&1 | tee "$PYTEMPFILE_LOG"
+        last_exit_status=${PIPESTATUS[0]}
+        if [ "$last_exit_status" != "0" ]; then
+            error "pyexec: non-zero exit status \"$last_exit_status\", see \"$PYTEMPFILE_PY\" and \"$PYTEMPFILE_LOG\""
+        fi
+    done
+    rm -f "$PYTEMPFILE_PY" "$PYTEMPFILE_LOG"
+    return "$last_exit_status"
+}
+
+report() { # script API
+    # Usage: report [VARIABLE...]
+    #
+    # Updates and reports current value of VARIABLE.
+    #
+    # Example:
+    #   report cpus
+    local varname
+    for varname in "$@"; do
+        if [ "$varname" == "cpus" ]; then
+            get-py-cpus
+            pyexec "
+import math
+print('Pod   Cpus_allowed_mask')
+if cpus:
+    bits_needed=int(math.log2(max(cpus.values())))+1
+    for podnum in sorted(cpus.keys()):
+        print(('pod%d  %s') % (podnum, bin(cpus[podnum])[2:].zfill(bits_needed)))
+"
+        else
+            error "report: unknown variable \"$varname\""
+        fi
+    done
+}
+
+verify() { # script API
+    # Usage: verify [EXPR...]
+    #
+    # Run python3 -c "assert(EXPR)" to test that every EXPR is True.
+    # Stop evaluation on the first EXPR not True and stops script.
+    # You can allow script execution to continue after failed verification
+    # by running verify in a subshell (in parenthesis):
+    #   (verify 'False') || echo '...but was expected to fail.'
+    #
+    # Variables available in expressions:
+    #   cpus: dictionary {pod_number: cpu_mask}
+    #
+    # Note that variables are updated every time verify is called
+    # before evaluating (asserting) expressions.
+    #
+    # Example:
+    #   require that pod0 and pod1 cpu masks are disjoint and that
+    #   pod0 cpu mask has four 1's in it:
+    #     verify 'cpus[0] & cpus[1] == 0' 'bin(cpus[0]).count("1") == 4'
+    get-py-cpus
+    for py_assertion in "$@"; do
+        speed=1000 out "### Verifying assertion '$py_assertion'"
+        ( speed=1000 host-command "python3 -c '${py_cpus}; assert($py_assertion)'" >/dev/null 2>&1 && out "### The assertion holds." ) || {
+                out "### The assertion FAILED in context ${py_cpus}"
+                echo "verify: assertion '$py_assertion' failed when ${py_cpus}" >> "$SUMMARY_FILE"
+                echo "    verify command output: $COMMAND_OUTPUT"
+                command-exit-if-not-interactive
+        }
+    done
+}
+
+delete() { # script API
+    # Usage: delete PARAMETERS
+    #
+    # Run "kubectl delete PARAMETERS".
+    vm-command "kubectl delete $*" || {
+        command-error "kubectl delete failed"
+    }
+}
+
+create() { # script API
+    # Usage: [VAR=VALUE] create TEMPLATE_NAME
+    #
+    # Create n instances from TEMPLATE_NAME.yaml.in, copy each of them
+    # from host to vm, kubectl create -f them, and wait for them
+    # becoming Ready.
+    #
+    # Parameters:
+    #   TEMPLATE_NAME: the name of the template without extension (.yaml.in)
+    #
+    # Optional parameters (VAR=VALUE):
+    #   wait: condition to be waited for (see kubectl wait --for=condition=).
+    #         If empty (""), skip waiting. The default is wait="Ready".
+    #   wait_t: wait timeout. The default is wait_t=60s.
+    template_name=$1.yaml.in
+    local template_kind
+    template_kind=$(awk '/kind/{print tolower($2)}' < "$template_name")
+    local wait=${wait-Ready}
+    local wait_t=${wait_t-60s}
+    if [ -z "$n" ]; then
+        local n=1
+    fi
+    if [ ! -f "$template_name" ]; then
+        error "error creating \"$1\": missing template ${template_name}"
+    fi
+    for _ in $(seq 1 $n); do
+        kind_count[$template_kind]=$(( ${kind_count[$template_kind]} + 1 ))
+        local NAME="${template_kind}$(( ${kind_count[$template_kind]} - 1 ))" # the first pod is pod0
+        eval "echo -e \"$(<"${template_name}")\"" > "$NAME.yaml"
+        host-command "scp $NAME.yaml $VM_SSH_USER@$VM_IP:" || {
+            command-error "copying $NAME.yaml to VM failed"
+        }
+        vm-command "cat $NAME.yaml"
+        vm-command "kubectl create -f $NAME.yaml" || {
+            command-error "kubectl create error"
+        }
+        if [ "x$wait" != "x" ]; then
+            speed=1000 vm-command "kubectl wait --timeout=${wait_t} --for=condition=${wait} ${template_kind}/$NAME" >/dev/null 2>&1 || {
+                command-error "waiting for ${template_kind} \"$NAME\" to become ready timed out"
+            }
+        fi
+    done
+}
+
+interactive() { # script API
+    # Usage: interactive
+    #
+    # Enter the interactive mode: read next script commands from
+    # the standard input until "exit".
+    echo "Entering the interactive mode until \"exit\"."
+    INTERACTIVE_MODE=$(( INTERACTIVE_MODE + 1 ))
+    # shellcheck disable=SC2162
+    while read -e -p "run.sh> " -a commands; do
+        if [ "${commands[0]}" == "exit" ]; then
+            break
+        fi
+        eval "${commands[@]}"
+    done
+    INTERACTIVE_MODE=$(( INTERACTIVE_MODE - 1 ))
+}
+
+help() { # script API
+    # Usage: help [FUNCTION|all]
+    #
+    # Print help on all functions or on the FUNCTION available in script.
+    awk -v f="$1" \
+        '/^[a-z].*script API/{split($1,a,"(");if(f==""||f==a[1]||f=="all"){print "";print a[1]":";l=2}}
+         !/^    #/{l=l-1}
+         /^    #/{if(l>=1){split($0,a,"#"); print "   "a[2]; if (f=="") l=0}}' <<<"$script_source"
+}
+
+### End of user code helpers
+
+test-user-code() {
+    vm-command-q "kubectl get pods 2>&1 | grep -q NAME" && vm-command "kubectl delete pods --all --now"
+    ( eval "$code" ) || {
+        TEST_FAILURES="${TEST_FAILURES} test script failed"
+    }
+}
+
+# Validate parameters
+INTERACTIVE_MODE=0
+mode=$1
+user_script_file=$2
+vm=${vm-"crirm-test-numa"}
+cri_resmgr_cfg=${cri_resmgr_cfg-"${SCRIPT_DIR}/cri-resmgr-memtier.cfg"}
+cleanup=${cleanup-0}
+reinstall_cri_resmgr=${reinstall_cri_resmgr-0}
+numanodes=${numanodes-'[
+    {"cpu": 1, "mem": "1G", "nodes": 2},
+    {"cpu": 2, "mem": "2G"},
+    {"cpu": 4, "mem": "4G"},
+    {"nvmem": "8G",
+     "dist": 22,
+     "dist-group-0": 88,
+     "dist-group-1": 88,
+     "dist-group-2": 88
+    }]'}
+code=${code-"
+CPU=1 create guaranteed # creates pod 0, 1 CPU taken
+CPU=2 create guaranteed # creates pod 1, 3 CPUs taken
+CPU=3 create guaranteed # creates pod 2, 6 CPUs taken
+verify \\
+    'bin(cpus[0]).count(\"1\") == 1' \\
+    'bin(cpus[1]).count(\"1\") == 2' \\
+    'bin(cpus[2]).count(\"1\") == 3' \\
+    'bin(cpus[0] | cpus[1] | cpus[2]).count(\"1\") == 6'
+
+n=3 create besteffort   # creates pods 3, 4 and 5
+verify \\
+    '(cpus[3] | cpus[4] | cpus[5]) & (cpus[0] | cpus[1] | cpus[2]) == 0' || true
+
+delete pods pod2        # deletes pod 2, 3 CPUs taken
+n=2 create besteffort   # creates pods 6 and 7
+CPU=2 n=2 create guaranteed # creates pod 8 and 9, 7 CPUs taken
+verify \\
+    'bin(cpus[0] | cpus[1] | cpus[8] | cpus[9]).count(\"1\") == 7'
+"}
+
+yaml_in_defaults="CPU=1 MEM=100M ISO=true CPUREQ=1 CPULIM=2 MEMREQ=100M MEMLIM=200M"
+
+if [ "$mode" == "help" ]; then
+    if [ "$2" == "defaults" ]; then
+        echo "Test input defaults:"
+        echo ""
+        echo "numanodes=${numanodes}"
+        echo ""
+        echo "cri_resmgr_cfg=${cri_resmgr_cfg}"
+        echo ""
+        echo -e "code=\"${code}\""
+        echo ""
+        echo "The defaults to QOSCLASS.yaml.in variables:"
+        echo "    ${yaml_in_defaults}"
+    elif [ "$2" == "script" ]; then
+        if [ "x$3" == "x" ]; then
+            help
+        else
+            help "$3"
+        fi
+    elif [ "x$2" == "x" ]; then
+        usage
+    else
+        echo "invalid help page, try:"
+        echo "  ./run.sh help"
+        echo "  ./run.sh help defaults"
+        echo "  ./run.sh help script [FUNCTION|all]"
+        exit 1
+    fi
+    exit 0
+elif [ "$mode" == "play" ]; then
+    speed=${speed-10}
+elif [ "$mode" == "test" ]; then
+    PV=
+elif [ "$mode" == "interactive" ]; then
+    PV=
+elif [ "$mode" == "record" ]; then
+    record
+else
+    usage
+    error "missing valid MODE"
+    exit 1
+fi
+
+if [ -n "$user_script_file" ]; then
+    if [ ! -f "$user_script_file" ]; then
+        error "cannot find test script file \"$user_script_file\""
+    fi
+    code=$(<"$user_script_file")
+fi
+
+# Prepare for test/demo
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$COMMAND_OUTPUT_DIR"
+rm -f "$COMMAND_OUTPUT_DIR"/0*
+( echo x > "$OUTPUT_DIR"/x && rm -f "$OUTPUT_DIR"/x ) || {
+    error "output directory outdir=$OUTPUT_DIR is not writable"
+}
+
+SUMMARY_FILE="$OUTPUT_DIR/summary.txt"
+echo -n "" > "$SUMMARY_FILE" || error "cannot write summary to \"$SUMMARY_FILE\""
+
+if [ "$binsrc" == "local" ]; then
+    [ -f "${BIN_DIR}/cri-resmgr" ] || error "missing \"${BIN_DIR}/cri-resmgr\""
+    [ -f "${BIN_DIR}/cri-resmgr-agent" ] || error "missing \"${BIN_DIR}/cri-resmgr-agent\""
+fi
+
+if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ] || [ -z "$VM_NAME" ]; then
+    screen-create-vm
+fi
+
+if ! vm-command-q "dpkg -l | grep -q kubelet"; then
+    screen-install-k8s
+fi
+
+if [ "$reinstall_cri_resmgr" == "1" ]; then
+    vm-command "kill -9 \$(pgrep cri-resmgr); rm -rf /usr/local/bin/cri-resmgr /usr/bin/cri-resmgr /usr/local/bin/cri-resmgr-agent /usr/bin/cri-resmgr-agent /var/lib/resmgr"
+fi
+
+if ! vm-command-q "[ -f /usr/local/bin/cri-resmgr ]"; then
+    screen-install-cri-resmgr
+fi
+
+# Start cri-resmgr if not already running
+if ! vm-command-q "pidof cri-resmgr" >/dev/null; then
+    screen-launch-cri-resmgr
+fi
+
+# Create kubernetes cluster or wait that it is online
+if vm-command-q "[ ! -f /var/lib/kubelet/config.yaml ]"; then
+    screen-create-singlenode-cluster
+else
+    # Wait for kube-apiserver to launch (may be down if the VM was just booted)
+    vm-wait-process kube-apiserver
+fi
+
+declare -A kind_count # associative arrays for counting created objects, like kind_count[pod]=1
+eval "${yaml_in_defaults}"
+if [ "$mode" == "interactive" ]; then
+    interactive
+else
+    # Run test/demo
+    TEST_FAILURES=""
+    test-user-code
+fi
+
+# Save logs
+host-command "scp $VM_SSH_USER@$VM_IP:cri-resmgr.output.txt \"$OUTPUT_DIR/\""
+
+# Cleanup
+if [ "$cleanup" == "0" ]; then
+    echo "The VM, Kubernetes and cri-resmgr are left running. Next steps:"
+    vm-print-usage
+elif [ "$cleanup" == "1" ]; then
+    host-stop-vm "$vm"
+    host-delete-vm "$vm"
+elif [ "$cleanup" == "2" ]; then
+    host-stop-vm "$vm"
+fi
+
+# Summarize results
+exit_status=0
+if [ "$mode" == "test" ]; then
+    if [ -n "$TEST_FAILURES" ]; then
+        echo "Test verdict: FAIL" >> "$SUMMARY_FILE"
+    else
+        echo "Test verdict: PASS" >> "$SUMMARY_FILE"
+    fi
+    cat "$SUMMARY_FILE"
+fi
+exit $exit_status


### PR DESCRIPTION
- numajson2qemuopts.py: convert NUMA node list (JSON)
  with CPUs, memory and distance definitions to Qemu options.
- demo/lib: add host-create-vm support for pass-through Qemu options
  and NUMA node list in JSON.
- test/numa: add a test/demo for CPU binding.
- Refactor common parts from new test and demo/blockio to demo/lib/vm.
- Implements infra described in Issue #123.
- Implements a part of Container Affinity E2E validation, Issue #319.