### PR TITLE
memtier, topology-aware: fix exclusive allocation of multiple CPUs

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -332,10 +332,12 @@ func (p *policy) applyGrant(grant Grant) error {
 		cpus = shared.String()
 		kind = "shared"
 	} else {
-		cpus = exclusive.Union(shared).String()
 		kind = "exclusive"
 		if portion > 0 {
 			kind += "+shared"
+			cpus = exclusive.Union(shared).String()
+		} else {
+			cpus = exclusive.String()
 		}
 	}
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -132,10 +132,12 @@ func (p *policy) applyGrant(grant CPUGrant) error {
 		cpus = shared.String()
 		kind = "shared"
 	} else {
-		cpus = exclusive.Union(shared).String()
 		kind = "exclusive"
 		if portion > 0 {
 			kind += "+shared"
+			cpus = exclusive.Union(shared).String()
+		} else {
+			cpus = exclusive.String()
 		}
 	}
 


### PR DESCRIPTION
Tested with `memtier`:

With this patch (and with PR #349 cherry-picked for testing, using `test/numa/run.sh`):

```
vm=c4m4x2 cleanup=0 numanodes='[{"cpu": 4, "mem": "4G", "nodes": 2}]' reinstall_cri_resmgr=1 binsrc=local cri_resmgr_cfg=cri-resmgr-memtier.cfg
code="create guaranteed; CPU=2 create guaranteed; CPU=3 create guaranteed; report cpus"
./run.sh test
...
Pod   Cpus_allowed_mask
pod0  0000001
pod1  0000110
pod2  1110000
```

Running against current master (that is, use binsrc=github):
```
vm=c4m4x2 cleanup=0 numanodes='[{"cpu": 4, "mem": "4G", "nodes": 2}]' reinstall_cri_resmgr=1 binsrc=github cri_resmgr_cfg=cri-resmgr-memtier.cfg
code="create guaranteed; CPU=2 create guaranteed; CPU=3 create guaranteed; report cpus"
./run.sh test
...
Pod   Cpus_allowed_mask
pod0  00001111
pod1  00001111
pod2  11110000
```