### PR TITLE
e2e: fix deprecated node distance syntax in numalist JSON.

### DIFF
--- a/test/numa/run.sh
+++ b/test/numa/run.sh
@@ -343,9 +343,7 @@ numanodes=${numanodes-'[
     {"cpu": 4, "mem": "4G"},
     {"nvmem": "8G",
      "dist": 22,
-     "dist-group-0": 88,
-     "dist-group-1": 88,
-     "dist-group-2": 88
+     "node-dist": {"0": 88, "1": 88, "2": 88, "3": 88}
     }]'}
 code=${code-"
 CPU=1 create guaranteed # creates pod 0, 1 CPU taken


### PR DESCRIPTION
Distance syntax is was changed to such that all top-level keys have
fixed names instead of "dist-group-SOURCEGROUP"-like names that were
allowed in the first version. The default numanodes value was not
updated at that point, which caused regression.