### PR TITLE
fix: force coldstart off, disable PMEM-only allocations if we have PMEM in movable memory zones.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -52,6 +52,10 @@ func (fake *mockSystemNode) GetMemoryType() system.MemoryType {
 	return fake.memType
 }
 
+func (fake *mockSystemNode) HasNormalMemory() bool {
+	return true
+}
+
 func (fake *mockSystemNode) CPUSet() cpuset.CPUSet {
 	return cpuset.NewCPUSet()
 }

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -653,7 +653,13 @@ func newRequest(container cache.Container) Request {
 		if err != nil {
 			log.Error("Failed to parse cold start preference")
 		} else {
-			coldStart = parsedColdStart.duration
+			if parsedColdStart.duration > 0 {
+				if coldStartOff {
+					log.Error("coldstart disabled (movable non-DRAM memory zones present)")
+				} else {
+					coldStart = parsedColdStart.duration
+				}
+			}
 		}
 	}
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -661,6 +661,12 @@ func newRequest(container cache.Container) Request {
 				}
 			}
 		}
+	} else if mtype == memoryPMEM {
+		if coldStartOff {
+			mtype = mtype | memoryDRAM
+			log.Error("%s: forced also DRAM usage (movable non-DRAM memory zones present)",
+				container.PrettyName())
+		}
 	}
 
 	return &request{

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -55,6 +55,10 @@ func (fake *mockSystemNode) GetMemoryType() system.MemoryType {
 	return system.MemoryTypeDRAM
 }
 
+func (fake *mockSystemNode) HasNormalMemory() bool {
+	return true
+}
+
 type mockSystemCPUPackage struct {
 	id system.ID // package id
 }


### PR DESCRIPTION
We can't allocate a container exclusively to PMEM in movable memory zones. In such a case forcibly disable
coldstart and forcibly add DRAM to the memory preferences of all containers.