### PR TITLE
memtier: add multi-die topology support.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/hint.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/hint.go
@@ -52,6 +52,25 @@ func numaHintScore(hint topology.Hint, sysIDs ...system.ID) float64 {
 	return 0.0
 }
 
+// Calculate the die node score of the given hint and die.
+func dieHintScore(hint topology.Hint, sysID system.ID, socket system.CPUPackage) float64 {
+	numaNodes := system.NewIDSet(socket.DieNodeIDs(sysID)...)
+
+	for _, idstr := range strings.Split(hint.NUMAs, ",") {
+		hID, err := strconv.ParseInt(idstr, 0, 0)
+		if err != nil {
+			log.Warn("invalid hint NUMA node %s from %s", idstr, hint.Provider)
+			return 0.0
+		}
+
+		if numaNodes.Has(system.ID(hID)) {
+			return 1.0
+		}
+	}
+
+	return 0.0
+}
+
 // Calculate the socket node score of the given hint and NUMA node.
 func socketHintScore(hint topology.Hint, sysID system.ID) float64 {
 	for _, idstr := range strings.Split(hint.Sockets, ",") {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -82,6 +82,18 @@ func (p *mockCPUPackage) NodeIDs() []system.ID {
 	return []system.ID{}
 }
 
+func (p *mockCPUPackage) DieIDs() []system.ID {
+	return []system.ID{0}
+}
+
+func (p *mockCPUPackage) DieCPUSet(system.ID) cpuset.CPUSet {
+	return cpuset.NewCPUSet()
+}
+
+func (p *mockCPUPackage) DieNodeIDs(system.ID) []system.ID {
+	return []system.ID{}
+}
+
 type mockCPU struct {
 	isolated cpuset.CPUSet
 	online   cpuset.CPUSet
@@ -98,6 +110,9 @@ func (c *mockCPU) ID() system.ID {
 }
 func (c *mockCPU) PackageID() system.ID {
 	return c.pkg.ID()
+}
+func (c *mockCPU) DieID() system.ID {
+	return system.ID(0)
 }
 func (c *mockCPU) NodeID() system.ID {
 	return c.node.ID()

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -68,6 +68,15 @@ func (fake *mockSystemCPUPackage) CPUSet() cpuset.CPUSet {
 func (fake *mockSystemCPUPackage) NodeIDs() []system.ID {
 	return []system.ID{}
 }
+func (p *mockSystemCPUPackage) DieIDs() []system.ID {
+	return []system.ID{0}
+}
+func (p *mockSystemCPUPackage) DieCPUSet(system.ID) cpuset.CPUSet {
+	return cpuset.NewCPUSet()
+}
+func (p *mockSystemCPUPackage) DieNodeIDs(system.ID) []system.ID {
+	return []system.ID{}
+}
 
 type mockCPU struct {
 	id            system.ID
@@ -86,6 +95,9 @@ func (c *mockCPU) ID() system.ID {
 }
 func (c *mockCPU) PackageID() system.ID {
 	return c.pkg.ID()
+}
+func (c *mockCPU) DieID() system.ID {
+	return system.ID(0)
 }
 func (c *mockCPU) NodeID() system.ID {
 	return c.node.ID()

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -105,13 +105,19 @@ type system struct {
 type CPUPackage interface {
 	ID() ID
 	CPUSet() cpuset.CPUSet
+	DieIDs() []ID
 	NodeIDs() []ID
+	DieNodeIDs(ID) []ID
+	DieCPUSet(ID) cpuset.CPUSet
 }
 
 type cpuPackage struct {
-	id    ID    // package id
-	cpus  IDSet // CPUs in this package
-	nodes IDSet // nodes in this package
+	id       ID           // package id
+	cpus     IDSet        // CPUs in this package
+	nodes    IDSet        // nodes in this package
+	dies     IDSet        // dies in this package
+	dieCPUs  map[ID]IDSet // CPUs per die
+	dieNodes map[ID]IDSet // NUMA nodes per die
 }
 
 // Node represents a NUMA node.
@@ -138,6 +144,7 @@ type node struct {
 type CPU interface {
 	ID() ID
 	PackageID() ID
+	DieID() ID
 	NodeID() ID
 	CoreID() ID
 	ThreadCPUSet() cpuset.CPUSet
@@ -152,6 +159,7 @@ type cpu struct {
 	path     string  // sysfs path
 	id       ID      // CPU id
 	pkg      ID      // package id
+	die      ID      // die id
 	node     ID      // node id
 	core     ID      // core id
 	threads  IDSet   // sibling/hyper-threads
@@ -269,6 +277,11 @@ func (sys *system) Discover(flags DiscoveryFlag) error {
 			sys.Info("package #%d:", id)
 			sys.Debug("   cpus: %s", pkg.cpus)
 			sys.Debug("  nodes: %s", pkg.nodes)
+			sys.Debug("   dies: %s", pkg.dies)
+			for die := range pkg.dies {
+				sys.Debug("    die #%v nodes: %v", die, pkg.DieNodeIDs(die))
+				sys.Debug("    die #%v cpus: %s", die, pkg.DieCPUSet(die).String())
+			}
 		}
 
 		for id, node := range sys.nodes {
@@ -280,6 +293,7 @@ func (sys *system) Discover(flags DiscoveryFlag) error {
 		for id, cpu := range sys.cpus {
 			sys.Debug("CPU #%d:", id)
 			sys.Debug("        pkg: %d", cpu.pkg)
+			sys.Debug("        die: %d", cpu.die)
 			sys.Debug("       node: %d", cpu.node)
 			sys.Debug("       core: %d", cpu.core)
 			sys.Debug("    threads: %s", cpu.threads)
@@ -508,6 +522,7 @@ func (sys *system) discoverCPU(path string) error {
 		if _, err := readSysfsEntry(path, "topology/physical_package_id", &cpu.pkg); err != nil {
 			return err
 		}
+		readSysfsEntry(path, "topology/die_id", &cpu.die)
 		if _, err := readSysfsEntry(path, "topology/core_id", &cpu.core); err != nil {
 			return err
 		}
@@ -562,6 +577,11 @@ func (c *cpu) ID() ID {
 // PackageID returns package id of this CPU.
 func (c *cpu) PackageID() ID {
 	return c.pkg
+}
+
+// DieID returns the die id of this CPU.
+func (c *cpu) DieID() ID {
+	return c.die
 }
 
 // NodeID returns the node id of this CPU.
@@ -820,14 +840,29 @@ func (sys *system) discoverPackages() error {
 		pkg, found := sys.packages[cpu.pkg]
 		if !found {
 			pkg = &cpuPackage{
-				id:    cpu.pkg,
-				cpus:  NewIDSet(),
-				nodes: NewIDSet(),
+				id:       cpu.pkg,
+				cpus:     NewIDSet(),
+				nodes:    NewIDSet(),
+				dies:     NewIDSet(),
+				dieCPUs:  make(map[ID]IDSet),
+				dieNodes: make(map[ID]IDSet),
 			}
 			sys.packages[cpu.pkg] = pkg
 		}
 		pkg.cpus.Add(cpu.id)
 		pkg.nodes.Add(cpu.node)
+		pkg.dies.Add(cpu.die)
+
+		if dieCPUs, ok := pkg.dieCPUs[cpu.die]; !ok {
+			pkg.dieCPUs[cpu.die] = NewIDSet(cpu.id)
+		} else {
+			dieCPUs.Add(cpu.id)
+		}
+		if dieNodes, ok := pkg.dieNodes[cpu.die]; !ok {
+			pkg.dieNodes[cpu.die] = NewIDSet(cpu.node)
+		} else {
+			dieNodes.Add(cpu.node)
+		}
 	}
 
 	return nil
@@ -843,9 +878,30 @@ func (p *cpuPackage) CPUSet() cpuset.CPUSet {
 	return p.cpus.CPUSet()
 }
 
+// DieIDs returns the die ids for this package.
+func (p *cpuPackage) DieIDs() []ID {
+	return p.dies.SortedMembers()
+}
+
 // NodeIDs returns the NUMA node ids for this package.
 func (p *cpuPackage) NodeIDs() []ID {
 	return p.nodes.SortedMembers()
+}
+
+// DieNodeIDs returns the set of NUMA nodes in the given die of this package.
+func (p *cpuPackage) DieNodeIDs(id ID) []ID {
+	if dieNodes, ok := p.dieNodes[id]; ok {
+		return dieNodes.SortedMembers()
+	}
+	return []ID{}
+}
+
+// DieCPUSet returns the set of CPUs in the given die of this package.
+func (p *cpuPackage) DieCPUSet(id ID) cpuset.CPUSet {
+	if dieCPUs, ok := p.dieCPUs[id]; ok {
+		return dieCPUs.CPUSet()
+	}
+	return cpuset.NewCPUSet()
 }
 
 // Discover cache associated with the given CPU.


### PR DESCRIPTION
Add topology support for physical packages with multiple dies. On multi-die systems the topology tree will
have additional nodes/pools representing dies. On a multi-socket system with multiple dies per socket the
full topology hierarchy is `root->socket->die->NUMA node` with `SNC` enabled. Consequently, allocations
not fitting into a single NUMA node will spill to the parent die before the socket.