### PR TITLE
e2e: "test/numa/run.sh debug" sets up delve in VM

### DIFF
--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -2,6 +2,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/command.bash"
 
 HOST_PROMPT=${HOST_PROMPT-"\e[38;5;11mhost>\e[0m "}
 HOST_LIB_DIR="$(dirname "${BASH_SOURCE[0]}")"
+HOST_PROJECT_DIR="$(dirname "$(dirname "$(realpath "$HOST_LIB_DIR")")")"
 GOVM=${GOVM-govm}
 
 host-command() {


### PR DESCRIPTION
This patch makes it easy to start debugging `cri-resmgr` with delve in a fresh VM. Command

```
./run.sh debug
```

Does the following:
- Install `delve` to a VM.
- Copy `cri-resource-manager` sources to the VM.
- Configure `delve` to find the sources on the VM.
- Print help to user how to attach debugger to the running `cri-resmgr` instance, or how to relaunch `cri-resmg` inside the debugger.