### PR TITLE
e2e: topology.py visualizes memory nodes and Mems_allowed

### DIFF
--- a/demo/lib/topology.py
+++ b/demo/lib/topology.py
@@ -7,37 +7,42 @@ Usage: topology.py [options] command
 Options:
   -t TOPOLOGY_DUMP    load topology_dump from TOPOLOGY_DUMP file instead of
                       the topology_dump environment variable or local host.
-  -c CPUS_ALLOWED     load cpus_allowed from CPUS_ALLOWED file instead of
-                      the cpus_allowed environment variable or local host.
+  -r RES_ALLOWED      load res_allowed from RES_ALLOWED file instead of
+                      the res_allowed environment variable or local host.
 
 Commands:
   help                print help
-  cpus                view cpu topology from topology_dump.
+  cpus                view CPU topology from topology_dump.
   cpus_allowed [PROCESS...]
-                      view how matching procesess are allowed to use CPUs
-                      in the CPU topology tree. If cpus_allowed data is not
-                      read from CPUS_ALLOWED file or the cpus_allowed
-                      environment variable, "pgrep -f PROCESS" is used to
-                      match processes.
+                      view how matching PROCESSes are allowed to use CPUs.
+                      (Uses RES_ALLOWED like res_allowed below.)
+  res                 view CPU and memory topology from topology_dump.
+  res_allowed [PROCESS...]
+                      view how matching PROCESSes are allowed to use CPUs
+                      and memory in CPU/mem topology tree.
+                      If the RES_ALLOWED file or the res_allowed
+                      environment variable are not defined, "pgrep -f PROCESS"
+                      is used to match processes.
   bash_topology_dump  print a Bash command that creates topology_dump.
-  bash_cpus_allowed PROCESS [PROCESS...]
-                      print a Bash command that creates cpus_allowed dump
-                      that contains Cpus_allowed masks of processes
-                      matching "pgrep -f PROCESS".
+  bash_res_allowed PROCESS [PROCESS...]
+                      print a Bash command that creates res_allowed
+                      dump that contains Cpus_allowed and Mems_allowed
+                      masks of processes matching "pgrep -f PROCESS".
 
 Examples:
   Print local host CPU topology
   $ topology.py cpus
 
   Print how processes with pod0..2 in their names are allowed to use CPUs
-  $ topology.py cpus_allowed pod0 pod1 pod2
+  $ topology.py res_allowed pod0 pod1 pod2
 
   Print remote host CPU topology
   $ topology_dump="$(ssh remotehost "$(topology.py bash_topology_dump)")" topology.py cpus
 
   Watch how pod0..2 are allowed to CPUS on remote host, read topology only once
   $ export topology_dump="$(ssh remotehost "$(topology.py bash_topology_dump)")"
-  $ watch 'cpus_allowed=$(ssh remotehost "$(topology.py bash_cpus_allowed pod0 pod1 pod2)") topology.py cpus_allowed'
+  $ watch 'res_allowed=$(ssh remotehost "$(topology.py bash_res_allowed pod0 pod1 pod2)") topology.py res_allowed'
+
 """
 
 import getopt
@@ -46,9 +51,9 @@ import re
 import subprocess
 import sys
 
-_bash_topology_dump = """for cpu in /sys/devices/system/cpu/cpu[0-9]*; do cpu_id=${cpu#/sys/devices/system/cpu/cpu}; echo "cpu p:$(< ${cpu}/topology/physical_package_id) d:$(< ${cpu}/topology/die_id) n:$(basename  ${cpu}/node* | sed 's:node::g') c:$(< ${cpu}/topology/core_id) t:$(< ${cpu}/topology/thread_siblings) cpu:${cpu_id}" ; done;  for node in /sys/devices/system/node/node[0-9]*; do node_id=${node#/sys/devices/system/node/node}; echo "node dist $node_id: $(< $node/distance)"; echo "node mem $node_id: $(awk '/MemTotal/{print $4/1024}' < $node/meminfo) MB"; done"""
+_bash_topology_dump = """for cpu in /sys/devices/system/cpu/cpu[0-9]*; do cpu_id=${cpu#/sys/devices/system/cpu/cpu}; echo "cpu p:$(< ${cpu}/topology/physical_package_id) d:$(< ${cpu}/topology/die_id) n:$(basename  ${cpu}/node* | sed 's:node::g') c:$(< ${cpu}/topology/core_id) t:$(< ${cpu}/topology/thread_siblings) cpu:${cpu_id}" ; done;  for node in /sys/devices/system/node/node[0-9]*; do node_id=${node#/sys/devices/system/node/node}; echo "dist n:$node_id d:$(< $node/distance)"; echo "mem n:$node_id s:$(awk '/MemTotal/{print $4/1024}' < $node/meminfo)"; done"""
 
-_bash_cpus_allowed = r"""for process in '%s'; do for pid in $(pgrep -f $process); do [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ] && echo "${process}-${pid} $(awk '/Cpus_allowed:/{print $2}' < /proc/$pid/status)"; done; done"""
+_bash_res_allowed = r"""for process in '%s'; do for pid in $(pgrep -f $process); do [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ] && echo "${process}-${pid} $(awk '/Cpus_allowed:/{c=$2}/Mems_allowed:/{m=$2}END{print "c:"c" m:"m}' < /proc/$pid/status)"; done; done"""
 
 def error(msg, exit_status=1):
     """Print error message and exit."""
@@ -138,46 +143,69 @@ def get_local_topology_dump():
     """Return topology_dump from local system."""
     return bash_output(_bash_topology_dump)
 
-def get_local_cpus_allowed_dump(processes):
-    """Return cpus_allowed from local system."""
-    return bash_output(_bash_cpus_allowed % ("' '".join(processes),))
+def get_local_res_allowed_dump(processes):
+    """Return res_allowed from local system."""
+    return bash_output(_bash_res_allowed % ("' '".join(processes),))
 
-def dump_to_topology(dump):
+def dump_to_topology(dump, show_mem=True):
     """Parse topology_dump, return topology data structures."""
     # Output data structures:
     tree = {} # {"package0": {"die1": {"node1": ...}}}
     cpu_branch = {} # {cpu_id: (package_name, die_name, node_name, core_name, thread_name, cpu_name)}
+    node_branch = {} # {node_id: (package_name, die_name, node_name)}
+    mem_branch = {} # {node_id: (package_name, ...)}
     # Example input line to be parsed:
+    # cpu line:
     # "cpu p:0 d:1 n:3 c:2 t:00003000 cpu:13"
-    re_dump_line = re.compile('cpu p:(?P<package>[0-9]+) d:(?P<die>[0-9]+) n:(?P<node>[0-9]+) c:(?P<core>[0-9]+) t:(?P<thread_siblings>[0-9a-f,]+) cpu:(?P<cpu_id>[0-9]+)')
-    numeric_lines = []
+    # mem line:
+    # "mem n:4: s:8063.83"
+    re_cpu_line = re.compile('cpu p:(?P<package>[0-9]+) d:(?P<die>[0-9]+) n:(?P<node>[0-9]+) c:(?P<core>[0-9]+) t:(?P<thread_siblings>[0-9a-f,]+) cpu:(?P<cpu_id>[0-9]+)')
+    re_mem_line = re.compile('mem n:(?P<node>[0-9]+) s:(?P<size>[0-9.]+)')
+    re_dist_line = re.compile('dist n:(?P<node>[0-9]+) d:(?P<dist>([0-9 ]+))')
+    numeric_cpu_lines = []
+    numeric_mem_lines = []
+    numeric_dist_lines = []
     for line in dump.splitlines():
-        try:
-            mdict = re_dump_line.match(line).groupdict()
-        except:
+        m = re_cpu_line.match(line)
+        if m:
+            mdict = m.groupdict()
+            package = int(mdict["package"])
+            die = int(mdict["die"])
+            node = int(mdict["node"])
+            core = int(mdict["core"])
+            thread_siblings = eval("0x" + mdict["thread_siblings"].replace(",", ""))
+            cpu_id = int(mdict["cpu_id"])
+            # Calculate thread id.
+            # Let the lowest CPU bit owner in thread_siblings be thread 0, next thread 1 and so on.
+            thread = -1
+            bit = 1 << cpu_id
+            while bit:
+                if thread_siblings & bit:
+                    thread += 1
+                bit >>= 1
+            numeric_cpu_lines.append((package, die, node, core, thread, cpu_id))
             continue
-        package = int(mdict["package"])
-        die = int(mdict["die"])
-        node = int(mdict["node"])
-        core = int(mdict["core"])
-        thread_siblings = eval("0x" + mdict["thread_siblings"].replace(",", ""))
-        cpu_id = int(mdict["cpu_id"])
-        # Calculate thread id.
-        # Let the lowest CPU bit owner in thread_siblings be thread 0, next thread 1 and so on.
-        thread = -1
-        bit = 1 << cpu_id
-        while bit:
-            if thread_siblings & bit:
-                thread += 1
-            bit >>= 1
-        numeric_lines.append((package, die, node, core, thread, cpu_id))
-    max_package_len = max(len(str(nl[0])) for nl in numeric_lines)
-    max_die_len = max(len(str(nl[1])) for nl in numeric_lines)
-    max_node_len = max(len(str(nl[2])) for nl in numeric_lines)
-    max_core_len = max(len(str(nl[3])) for nl in numeric_lines)
-    max_thread_len = max(len(str(nl[4])) for nl in numeric_lines)
-    max_cpu_id_len = max(len(str(nl[5])) for nl in numeric_lines)
-    for (package, die, node, core, thread, cpu_id) in numeric_lines:
+        m = re_mem_line.match(line)
+        if m:
+            mdict = m.groupdict()
+            numeric_mem_lines.append((int(mdict["node"]), float(mdict["size"])))
+            continue
+        m = re_dist_line.match(line)
+        if m:
+            mdict = m.groupdict()
+            numeric_dist_lines.append((int(mdict["node"]),
+                                      tuple([int(n) for n in mdict["dist"].strip().split()])))
+    numeric_mem_lines.sort() # make sure memory sizes are from node 0, 1, ...
+    numeric_dist_lines.sort()
+
+    # Build tree on CPUs
+    max_package_len = max(len(str(nl[0])) for nl in numeric_cpu_lines)
+    max_die_len = max(len(str(nl[1])) for nl in numeric_cpu_lines)
+    max_node_len = max(len(str(nl[2])) for nl in numeric_cpu_lines)
+    max_core_len = max(len(str(nl[3])) for nl in numeric_cpu_lines)
+    max_thread_len = max(len(str(nl[4])) for nl in numeric_cpu_lines)
+    max_cpu_id_len = max(len(str(nl[5])) for nl in numeric_cpu_lines)
+    for (package, die, node, core, thread, cpu_id) in numeric_cpu_lines:
         branch = ("package" + str(package).zfill(max_package_len),
                   "die" + str(die).zfill(max_die_len),
                   "node" + str(node).zfill(max_node_len),
@@ -186,24 +214,58 @@ def dump_to_topology(dump):
                   "cpu" + str(cpu_id).zfill(max_cpu_id_len))
         add_tree(tree, branch, {})
         cpu_branch[cpu_id] = branch
-    return {"tree": tree, "cpu_branch": cpu_branch}
+        node_branch[node] = branch[:3]
+    if show_mem:
+        # Add node memory information to the tree
+        for node, distvec in numeric_dist_lines:
+            mem_node_name = "node" + str(node).zfill(max_node_len)
+            node_mem_size = str(int(round((numeric_mem_lines[node][1]/1024)))) + "G"
+            dists = sorted(distvec)
+            if node in node_branch:
+                # This node has CPU(s) as it has been added to the tree already in CPU lines.
+                # Add memory branch to the tree under the existing node branch.
+                branch = node_branch[node] + (
+                    "mem", mem_node_name, node_mem_size)
+            elif (dists[0] == 10 # sane distance-to-self
+                  and (len(dists) < 3 or dists[1] < dists[2])  # there is a node closer than others
+                  and distvec.index(dists[1]) in node_branch): # that node is already in the tree
+                # This means that the node has the same memory controller as this node.
+                # Add memory branch from this node under the existing node.
+                node_same_ctrl = distvec.index(dists[1])
+                branch = node_branch[node_same_ctrl] + (
+                    "mem", mem_node_name, node_mem_size)
+                node_branch[node] = branch[:3]
+            else:
+                # Suitable memory controller not found, create completely separate branch.
+                branch = ("packagex", "mem", "node" + str(node).zfill(max_node_len),
+                    "mem", mem_node_name, node_mem_size)
+                node_branch[node] = branch[:3]
+            add_tree(tree, branch, {})
+            mem_branch[node] = branch
+    return {"tree": tree,
+            "cpu_branch": cpu_branch,
+            "node_branch": node_branch,
+            "mem_branch": mem_branch}
 
-def dump_to_cpus_allowed(cpus_allowed_dump):
-    """Parse cpus_allowed data, return cpus_allowed data structure."""
+def dump_to_res_allowed(res_allowed_dump):
+    """Parse res_allowed data, return allowed cpu and mem bitmasks in a data structure."""
     # Output data structure:
-    owner_mask = {} # {owner_string: bitmask_int}
+    owner_mask = {} # {owner_string: {"cpu": bitmask_int, "mem": bitmask_int}}
     # Example input line to be parsed:
-    # "pod2  040c0000,00000000"
-    re_owner_mask = re.compile(r'(?P<owner>[^ ]+)\s+(?P<mask>[0-9a-f,]+)')
-    for line in cpus_allowed_dump.splitlines():
+    # "pod2  c:040c0000,00000000 m:00000000,00000300"
+    re_owner_mask = re.compile(r'(?P<owner>[^ ]+)\s+c:(?P<cpumask>[0-9a-f,]+)\s+m:(?P<memmask>[0-9a-f,]+)')
+    for line in res_allowed_dump.splitlines():
         try:
             mdict = re_owner_mask.match(line).groupdict()
         except:
-            warning("cannot parse cpus_allowed line %r" % (line,))
-        owner_mask[mdict["owner"]] = eval("0x" + mdict["mask"].replace(",", ""))
+            warning("cannot parse res_allowed line %r" % (line,))
+        owner_mask[mdict["owner"]] = {
+            "cpu": eval("0x" + mdict["cpumask"].replace(",", "")),
+            "mem": eval("0x" + mdict["memmask"].replace(",", ""))
+        }
     return owner_mask
 
-def get_topology():
+def get_topology(show_mem=True):
     """Return topology data structure."""
     # Priority: use file, environment variable or read from local system
     if opt_topology_dump:
@@ -212,44 +274,53 @@ def get_topology():
         topology_dump = os.getenv("topology_dump")
     if not topology_dump:
         topology_dump = get_local_topology_dump()
-    return dump_to_topology(topology_dump)
+    return dump_to_topology(topology_dump, show_mem=show_mem)
 
-def get_cpus_allowed(processes):
-    """Return cpus_allowed data structure."""
+def get_res_allowed(processes):
+    """Return res_allowed data structure."""
     # Priority: use file, environment variable or read from local system
-    if opt_cpus_allowed_dump:
-        cpus_allowed_dump = opt_cpus_allowed_dump
+    if opt_res_allowed_dump:
+        res_allowed_dump = opt_res_allowed_dump
     else:
-        cpus_allowed_dump = os.getenv("cpus_allowed")
-    if not cpus_allowed_dump:
-        cpus_allowed_dump = get_local_cpus_allowed_dump(processes)
-    return dump_to_cpus_allowed(cpus_allowed_dump)
+        res_allowed_dump = os.getenv("res_allowed")
+    if not res_allowed_dump:
+        res_allowed_dump = get_local_res_allowed_dump(processes)
+    return dump_to_res_allowed(res_allowed_dump)
 
-def report_cpus():
-    """Print CPU topology tree."""
-    topology = get_topology()
+def report_res(show_mem=True):
+    """Print topology tree."""
+    topology = get_topology(show_mem=show_mem)
     print(str_tree(topology["tree"]))
 
-def report_cpus_allowed(processes):
-    """Print CPU topology tree with chosen processes as leaf nodes."""
-    topology = get_topology()
+def report_res_allowed(processes, show_mem=True):
+    """Print topology tree with allowed processes as leaf nodes."""
+    topology = get_topology(show_mem=show_mem)
     tree = topology["tree"]
     cpu_branch = topology["cpu_branch"]
+    mem_branch = topology["mem_branch"]
+    node_branch = topology["node_branch"]
     max_cpu = max(cpu_branch.keys())
-    cpus_allowed = get_cpus_allowed(processes)
+    max_node = max(node_branch.keys())
+    res_allowed = get_res_allowed(processes)
     # add found owners to tree as children of cpus
-    for owner, mask in sorted(cpus_allowed.items()):
+    for owner, masks in sorted(res_allowed.items()):
+        cpumask = masks["cpu"]
+        memmask = masks["mem"]
         for cpu in range(max_cpu + 1):
-            if mask & (1 << cpu):
+            if cpumask & (1 << cpu):
                 add_tree(tree, cpu_branch[cpu], {owner: {}})
+        if show_mem:
+            for node in range(max_node + 1):
+                if memmask & (1 << node):
+                    add_tree(tree, mem_branch[node], {owner: {}})
     print(str_tree(tree))
 
 if __name__ == "__main__":
     opt_topology_dump = None
-    opt_cpus_allowed_dump = None
+    opt_res_allowed_dump = None
     options, commands = getopt.gnu_getopt(
-        sys.argv[1:], 'ht:c:',
-        ['help', '--topology-dump-file=', '--cpus-allowed-file='])
+        sys.argv[1:], 'ht:r:',
+        ['help', '--topology-dump-file=', '--res-allowed-file='])
     for opt, arg in options:
         if opt in ["-h", "--help"]:
             print(__doc__)
@@ -259,23 +330,27 @@ if __name__ == "__main__":
                 opt_topology_dump = open(arg).read()
             except IOError as e:
                 error("cannot read topology dump from file %r: %s" % (arg, e))
-        elif opt in ["-c", "--cpus-allowed-file"]:
+        elif opt in ["-r", "--res-allowed-file"]:
             try:
-                opt_cpus_allowed_dump = open(arg).read()
+                opt_res_allowed_dump = open(arg).read()
             except IOError as e:
-                error("cannot read cpus_allowed dump from file %r: %s" % (arg, e))
+                error("cannot read res_allowed dump from file %r: %s" % (arg, e))
     if not commands:
         error("missing command, see --help")
     elif commands[0] == "help":
         print(__doc__)
         error(None, exit_status=0)
     elif commands[0] == "cpus":
-        report_cpus()
+        report_res(show_mem=False)
     elif commands[0] == "cpus_allowed":
-        report_cpus_allowed(commands[1:])
+        report_res_allowed(commands[1:], show_mem=False)
+    elif commands[0] == "res":
+        report_res(show_mem=True)
+    elif commands[0] == "res_allowed":
+        report_res_allowed(commands[1:])
     elif commands[0] == "bash_topology_dump":
         print(_bash_topology_dump)
-    elif commands[0] == "bash_cpus_allowed":
-        print(_bash_cpus_allowed % ("' '".join(commands[1:]),))
+    elif commands[0] == "bash_res_allowed":
+        print(_bash_res_allowed % ("' '".join(commands[1:]),))
     else:
         error('invalid command %r' % (commands[0],))


### PR DESCRIPTION
This patch enables watching how Mems_allowed nodes are aligned in the topology tree.

Example: suspicious behavior in a corner case where a pod requesting more memory than available in any node. 
```
$ topology=... ./run.sh interactive
run.sh> CPU=1 MEM=12G create guaranteed
...
apiVersion: v1
kind: Pod
metadata:
  name: pod0
  labels:
    app: pod0
  annotations:
    cri-resource-manager.intel.com/prefer-isolated-cpus: 'true'
spec:
  containers:
  - image: busybox
    command:
      - sh
      - -c
      - echo pod0 $(sleep inf)
    imagePullPolicy: IfNotPresent
    name: busybox
    resources:
      requests:
        cpu: 1
        memory: '12G'
      limits:
        cpu: 1
        memory: '12G'
  terminationGracePeriodSeconds: 1
```

When printing resources allowed to pod0, it seems to be allowed to use only single 1G memory node:

```
package0 die0 node0 core0 thread0 cpu00
                          thread1 cpu01
                    mem   node0   1G
                          node8   8G
              node1 core1 thread0 cpu02
                          thread1 cpu03 pod0-205509
                    mem   node1   1G    pod0-205509
         die1 node2 core0 thread0 cpu04
                          thread1 cpu05
                    mem   node2   1G
                          node9   8G
              node3 core1 thread0 cpu06
                          thread1 cpu07
                    mem   node3   1G
package1 die0 node4 core0 thread0 cpu08
                          thread1 cpu09
                    mem   node4   1G
              node5 core1 thread0 cpu10
                          thread1 cpu11
                    mem   node5   1G
         die1 node6 core0 thread0 cpu12
                          thread1 cpu13
                    mem   node6   1G
              node7 core1 thread0 cpu14
                          thread1 cpu15
                    mem   node7   1G
```