### PR TITLE
resource-manager: always setup node agent connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ You can do it with the following command:
 ```
 
 When started this way CRI Resource Manager reads its configuration from the
-given file. It also disables its agent interface for external configuration
-and updates.
+given file. It does not fetch external configuration from the node agent and
+also disables the config interface for receiving configuration updates.
 
 ### Using CRI Resource Manager Agent and a ConfigMap
 

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -93,10 +93,8 @@ func NewResourceManager() (ResourceManager, error) {
 		return nil, err
 	}
 
-	if opt.ForceConfig == "" {
-		if err := m.setupConfigAgent(); err != nil {
-			return nil, err
-		}
+	if err := m.setupAgentInterface(); err != nil {
+		return nil, err
 	}
 
 	if err := m.loadConfig(); err != nil {
@@ -324,8 +322,8 @@ func (m *resmgr) setupCache() error {
 
 }
 
-// setupConfigAgent sets up the connection to the configuration agent.
-func (m *resmgr) setupConfigAgent() error {
+// setupAgentInterface sets up the connection to the node agent.
+func (m *resmgr) setupAgentInterface() error {
 	var err error
 
 	if m.agent, err = agent.NewAgentInterface(opt.AgentSocket); err != nil {


### PR DESCRIPTION
Always setup connection to the node agent as it serves other functions
than just config handling. Formerly the agent connection was not
initialized if --force-config was used. This was problematic, as e.g.
static-pools policy requires services (other than config) from the agent
and refused to work when forced config was used.