### PR TITLE
memtier: produce more correct, easier to read node supply dumps

### DIFF
--- a/pkg/cri/resource-manager/kubernetes/cpuset.go
+++ b/pkg/cri/resource-manager/kubernetes/cpuset.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"strconv"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+// ShortCPUSet prints the cpuset as a string, trying to further shorten compared to .String().
+func ShortCPUSet(cset cpuset.CPUSet) string {
+	str, sep := "", ""
+
+	beg, end, step := -1, -1, -1
+	for _, cpu := range strings.Split(cset.String(), ",") {
+		if strings.Contains(cpu, "-") {
+			str += sep + cpu
+			sep = ","
+			continue
+		}
+		i, err := strconv.ParseInt(cpu, 10, 0)
+		if err != nil {
+			return cset.String()
+		}
+		id := int(i)
+		if beg < 0 {
+			beg, end = id, id
+			continue
+		}
+		if step < 0 {
+			end = id
+			step = end - beg
+			continue
+		}
+		if id-end == step {
+			end = id
+			continue
+		}
+		str += sep + mkRange(beg, end, step)
+		sep = ","
+		beg, end = id, id
+		step = -1
+	}
+
+	if beg >= 0 {
+		str += sep + mkRange(beg, end, step)
+	}
+
+	return str
+}
+
+func mkRange(beg, end, step int) string {
+	if beg < 0 {
+		return ""
+	}
+	if beg == end {
+		return strconv.FormatInt(int64(beg), 10)
+	}
+
+	b, e := strconv.FormatInt(int64(beg), 10), strconv.FormatInt(int64(end), 10)
+	if step == 1 {
+		return b + "-" + e
+	}
+	if beg+step == end {
+		return b + "," + e
+	}
+
+	s := strconv.FormatInt(int64(step), 10)
+	return b + "-" + e + ":" + s
+}

--- a/pkg/cri/resource-manager/kubernetes/cpuset_test.go
+++ b/pkg/cri/resource-manager/kubernetes/cpuset_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+func TestShortCPUSet(t *testing.T) {
+	tcases := []struct {
+		source string
+		native string
+		short  string
+	}{
+		{source: "", native: "", short: ""},
+		{source: "1", native: "1", short: "1"},
+		{source: "1,2", native: "1-2", short: "1,2"},
+		{source: "1,2,3,4,5,6,7", native: "1-7", short: "1-7"},
+		{source: "1,3,5,7,9,11", native: "1,3,5,7,9,11", short: "1-11:2"},
+		{source: "1,3,5,7,8,10,12,14,16", native: "1,3,5,7-8,10,12,14,16", short: "1-7:2,10-16:2"},
+		{
+			source: "0,2,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,64,66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110",
+			native: "0,2,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,64,66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110",
+			short:  "0-110:2",
+		},
+	}
+	for _, tc := range tcases {
+		cset := cpuset.MustParse(tc.source)
+		native := cset.String()
+		if native != tc.native {
+			t.Errorf("incorrect native CPUSet for %q, expected %q, got %q",
+				tc.source, tc.native, native)
+		}
+		short := ShortCPUSet(cset)
+		if native != tc.native {
+			t.Errorf("incorrect shortened CPUSet for %q, expected %q, got %q",
+				tc.source, tc.short, short)
+		}
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/node.go
@@ -91,7 +91,7 @@ type Node interface {
 	GetSupply() Supply
 	// FreeSupply returns the available CPU supply of this node.
 	FreeSupply() Supply
-	// GrantedSharedCPU returns the amount of granted shared CPU capacity of this node.
+	// GrantedSharedCPU returns the amount of granted shared CPU of this node and its children.
 	GrantedSharedCPU() int
 	// GetMemset
 	GetMemset(mtype memoryType) system.IDSet
@@ -277,8 +277,8 @@ func (n *node) Dump(prefix string, level ...int) {
 	idt := indent(prefix, lvl)
 
 	n.self.node.dump(prefix, lvl)
-	log.Debug("%s  - node CPU: %v", idt, n.noderes)
-	log.Debug("%s  - free CPU: %v", idt, n.freeres)
+	log.Debug("%s  - %s", idt, n.noderes.DumpCapacity())
+	log.Debug("%s  - %s", idt, n.freeres.DumpAllocatable())
 	log.Debug("%s  - normal memory: %v", idt, n.mem)
 	log.Debug("%s  - HBM memory: %v", idt, n.hbm)
 	log.Debug("%s  - PMEM memory: %v", idt, n.pMem)
@@ -370,7 +370,7 @@ func (n *node) GetPhysicalNodeIDs() []system.ID {
 	return n.self.node.GetPhysicalNodeIDs()
 }
 
-// GrantedSharedCPU returns the amount of granted shared CPU capacity of this node.
+// GrantedSharedCPU returns the amount of granted shared CPU of this node and its children.
 func (n *node) GrantedSharedCPU() int {
 	granted := n.freeres.Granted()
 	for _, c := range n.children {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
 )
 
@@ -69,8 +70,10 @@ type Supply interface {
 	Reserve(Grant) error
 	// ReserveMemory accounts for memory grants after reloading cached allocations.
 	ReserveMemory(Grant) error
-	// String returns a printable representation of this supply.
-	String() string
+	// DumpCapacity returns a printable representation of the supply's resource capacity.
+	DumpCapacity() string
+	// DumpAllocatable returns a printable representation of the supply's alloctable resources.
+	DumpAllocatable() string
 }
 
 // Request represents CPU and memory resources requested by a container.
@@ -582,16 +585,16 @@ func (cs *supply) Reserve(g Grant) error {
 
 	if !cs.isolated.Intersection(isolated).Equals(isolated) {
 		return policyError("can't reserve isolated CPUs (%s) of %s from %s",
-			isolated.String(), g.String(), cs.String())
+			isolated.String(), g.String(), cs.DumpAllocatable())
 	}
 	if !cs.sharable.Intersection(exclusive).Equals(exclusive) {
 		return policyError("can't reserve exclusive CPUs (%s) of %s from %s",
-			exclusive.String(), g.String(), cs.String())
+			exclusive.String(), g.String(), cs.DumpAllocatable())
 	}
 
 	if 1000*(cs.sharable.Size()-exclusive.Size())-(cs.granted+fraction) < 0 {
 		return policyError("can't reserve %d fractional CPUs of %s from %s",
-			fraction, g.String(), cs.String())
+			fraction, g.String(), cs.DumpAllocatable())
 	}
 
 	cs.isolated = cs.isolated.Difference(isolated)
@@ -639,23 +642,87 @@ func (cs *supply) takeCPUs(from, to *cpuset.CPUSet, cnt int) (cpuset.CPUSet, err
 	return cset, err
 }
 
-// String returns the CPU and memory supply as a string.
-func (cs *supply) String() string {
-	none, isolated, sharable, sep := "-", "", "", ""
+// DumpCapacity returns a printable representation of the supply's resource capacity.
+func (cs *supply) DumpCapacity() string {
+	cpu, mem, sep := "", cs.mem.String(), ""
 
 	if !cs.isolated.IsEmpty() {
-		isolated = fmt.Sprintf("isolated:%s", cs.isolated)
+		cpu = fmt.Sprintf("isolated:%s", kubernetes.ShortCPUSet(cs.isolated))
 		sep = ", "
-		none = ""
 	}
 	if !cs.sharable.IsEmpty() {
-		sharable = fmt.Sprintf("%ssharable:%s (granted:%d, free: %d)", sep,
-			cs.sharable, cs.granted, 1000*cs.sharable.Size()-cs.granted)
-		none = ""
+		cpu += sep + fmt.Sprintf("sharable:%s (%dm)", kubernetes.ShortCPUSet(cs.sharable),
+			1000*cs.sharable.Size())
 	}
-	mem := "limit: { pmem:" + strconv.FormatUint(cs.mem[memoryPMEM], 10) + ", dram: " + strconv.FormatUint(cs.mem[memoryDRAM], 10) + "}" + ", granted: { pmem:" + strconv.FormatUint(cs.grantedMem[memoryPMEM], 10) + ", dram: " + strconv.FormatUint(cs.grantedMem[memoryDRAM], 10) + "}"
 
-	return "<" + cs.node.Name() + " CPU: " + none + isolated + sharable + ", Mem: " + mem + ">"
+	capacity := "<" + cs.node.Name() + " capacity: "
+
+	if cpu == "" && mem == "" {
+		capacity += "-"
+	} else {
+		sep = ""
+		if cpu != "" {
+			capacity += "CPU: " + cpu
+			sep = ", "
+		}
+		if mem != "" {
+			capacity += sep + "MemLimit: " + mem
+		}
+	}
+	capacity += ">"
+
+	return capacity
+}
+
+// DumpAllocatable returns a printable representation of the supply's resource capacity.
+func (cs *supply) DumpAllocatable() string {
+	cpu, mem, sep := "", cs.mem.String(), ""
+
+	if !cs.isolated.IsEmpty() {
+		cpu = fmt.Sprintf("isolated:%s", kubernetes.ShortCPUSet(cs.isolated))
+		sep = ", "
+	}
+
+	local_granted := cs.granted
+	total_granted := cs.node.GrantedSharedCPU()
+	if !cs.sharable.IsEmpty() {
+		cpu += sep + fmt.Sprintf("sharable:%s (", kubernetes.ShortCPUSet(cs.sharable))
+		sep = ""
+		if local_granted > 0 || total_granted > 0 {
+			cpu += fmt.Sprintf("grants:")
+			kind := ""
+			if local_granted > 0 {
+				cpu += fmt.Sprintf("%dm", local_granted)
+				kind = "local"
+				sep = "/"
+			}
+			if total_granted > 0 {
+				cpu += sep + fmt.Sprintf("%dm", total_granted)
+				kind += sep + "subtree"
+			}
+			cpu += " " + kind
+			sep = ", "
+		}
+		cpu += sep + fmt.Sprintf("free:%dm)", 1000*cs.sharable.Size()-total_granted)
+	}
+
+	allocatable := "<" + cs.node.Name() + " allocatable: "
+
+	if cpu == "" && mem == "" {
+		allocatable += "-"
+	} else {
+		sep = ""
+		if cpu != "" {
+			allocatable += "CPU: " + cpu
+			sep = ", "
+		}
+		if mem != "" {
+			allocatable += sep + "MemLimit: " + mem
+		}
+	}
+	allocatable += ">"
+
+	return allocatable
 }
 
 // newRequest creates a new request for the given container.
@@ -963,7 +1030,6 @@ func (cg *grant) MemLimit() memoryMap {
 // String returns a printable representation of the CPU grant.
 func (cg *grant) String() string {
 	var isolated, exclusive, shared, sep string
-	mem := "mem limit: { pmem: " + strconv.FormatUint(cg.allocatedMem[memoryPMEM], 10) + ", dram: " + strconv.FormatUint(cg.allocatedMem[memoryDRAM], 10) + " }"
 
 	isol := cg.IsolatedCPUs()
 	if !isol.IsEmpty() {
@@ -975,11 +1041,17 @@ func (cg *grant) String() string {
 		sep = ", "
 	}
 	if cg.portion > 0 {
-		shared = fmt.Sprintf("%sshared: %s (%d milli-CPU)", sep,
+		shared = fmt.Sprintf("%sshared: %s (%dm)", sep,
 			cg.node.FreeSupply().SharableCPUs(), cg.portion)
+		sep = ", "
 	}
 
-	return fmt.Sprintf("<CPU grant for %s from %s: %s%s%s, mem: %s>",
+	mem := cg.allocatedMem.String()
+	if mem != "" {
+		mem = sep + "MemLimit: " + mem
+	}
+
+	return fmt.Sprintf("<CPU grant for %s from %s: %s%s%s%s>",
 		cg.container.PrettyName(), cg.node.Name(), isolated, exclusive, shared, mem)
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -256,6 +256,27 @@ func createMemoryMap(normalMemory, persistentMemory, hbMemory uint64) memoryMap 
 	}
 }
 
+func (m memoryMap) String() string {
+	mem, sep := "", ""
+
+	dram, pmem, hbm := m[memoryDRAM], m[memoryPMEM], m[memoryHBM]
+	if dram > 0 || pmem > 0 || hbm > 0 {
+		if dram > 0 {
+			mem += "dram:" + strconv.FormatUint(dram, 10)
+			sep = ", "
+		}
+		if pmem > 0 {
+			mem += sep + "pmem:" + strconv.FormatUint(pmem, 10)
+			sep = ", "
+		}
+		if hbm > 0 {
+			mem += sep + "hbm:" + strconv.FormatUint(hbm, 10)
+		}
+	}
+
+	return mem
+}
+
 // GetNode returns the node supplying CPU and memory.
 func (cs *supply) GetNode() Node {
 	return cs.node


### PR DESCRIPTION
When dumping a node in the tree of pools, calculating free shared CPU considered only
containers directly assigned to the node. Fix this to also account for any other containers
assigned elsewhere in the subtree below the node.

Additionally, split printing memory maps into a function of its own, dump CPU resources
and memory maps in a more compact  form. Finally, provide a function for more compact
human-readable dumps of CPUSets, by combining ranges of CPUs also when the diff
between subsequent elements is other then 1. This can shorten CPUSets like
`0,2,4,6,8,10,12,14,16,18,20` to `0-20:2`.