### PR TITLE
affinity fixes: fix a few doc thinkos, make simple affinities symmetric, improve scoring.

### DIFF
--- a/docs/container-affinity.md
+++ b/docs/container-affinity.md
@@ -45,7 +45,7 @@ metadata:
             - value1
             ...
             - valueN
-        - match:
+          match:
             key: key-ref
             operator: op
             values:
@@ -70,7 +70,7 @@ metadata:
             - value1
             ...
             - valueN
-        - match:
+          match:
             key: key-ref
             operator: op
             values:

--- a/pkg/apis/resmgr/expression.go
+++ b/pkg/apis/resmgr/expression.go
@@ -63,15 +63,15 @@ const (
 	// NotExist evalutes to true if the named key does not exist.
 	NotExist Operator = "NotExist"
 	// AlwaysTrue always evaluates to true.
-	AlwaysTrue = "AlwaysTrue"
+	AlwaysTrue Operator = "AlwaysTrue"
 	// Matches tests if the key value matches the only given globbing pattern.
-	Matches = "Matches"
+	Matches Operator = "Matches"
 	// MatchesNot is true if Matches would be false for the same key and pattern.
-	MatchesNot = "MatchesNot"
+	MatchesNot Operator = "MatchesNot"
 	// MatchesAny tests if the key value matches any of the given globbing patterns.
-	MatchesAny = "MatchesAny"
+	MatchesAny Operator = "MatchesAny"
 	// MatchesNone is true if MatchesAny would be false for the same key and patterns.
-	MatchesNone = "MatchesNone"
+	MatchesNone Operator = "MatchesNone"
 )
 
 // Our logger instance.

--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -47,24 +47,7 @@ type Affinity struct {
 	Weight int32              `json:"weight,omitempty"` // (optional) weight for this affinity
 }
 
-// Operator defines the possible operators for an Expression.
-type Operator string
-
 const (
-	// Equals tests for equality with a single value.
-	Equals Operator = "Equals"
-	// NotEqual test for inequality with a single value.
-	NotEqual Operator = "NotEqual"
-	// In tests if the key's value is one of the specified set.
-	In Operator = "In"
-	// NotIn tests if the key's value is not one of the specified set.
-	NotIn Operator = "NotIn"
-	// Exists evalutes to true if the named key exists.
-	Exists Operator = "Exists"
-	// NotExist evalutes to true if the named key does not exist.
-	NotExist Operator = "NotExist"
-	// AlwaysTrue always evaluates to true.
-	AlwaysTrue = "AlwaysTrue"
 	// UserWeightCutoff is the cutoff we clamp user-provided weights to.
 	UserWeightCutoff = 1000
 	// DefaultWeight is the default assigned weight if omitted in annotations.

--- a/pkg/cri/resource-manager/cache/affinity_test.go
+++ b/pkg/cri/resource-manager/cache/affinity_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+)
+
+func TestSimpleParsingSymmetry(t *testing.T) {
+	c1, c2, c3, c4, c5 := "c1", "c2", "c3", "c4", "c5"
+
+	tcases := []struct {
+		source string
+		result map[string][]string
+	}{
+		{
+			source: `c1: [ c2 ]`,
+			result: map[string][]string{
+				c1: {c2},
+				c2: {c1},
+			},
+		},
+		{
+			source: `c1: [ c2, c3, c4, c5 ]`,
+			result: map[string][]string{
+				c1: {c2, c3, c4, c5},
+				c2: {c1},
+				c3: {c1},
+				c4: {c1},
+				c5: {c1},
+			},
+		},
+		{
+			source: `
+c1: [ c2 ]
+c2: [ c3, c4, c5 ]
+c4: [ c5 ]
+`,
+			result: map[string][]string{
+				c1: {c2},
+				c2: {c1, c3, c4, c5},
+				c3: {c2},
+				c4: {c2, c5},
+				c5: {c2, c4},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		pca := podContainerAffinity{}
+		if !pca.parseSimple(&pod{Name: "testpod"}, tc.source, 1) {
+			t.Errorf("failed to parse simple container affinity %q", tc.source)
+			continue
+		}
+
+		found := map[string]map[string]struct{}{}
+		for name, affinities := range pca {
+			for _, a := range affinities {
+				for _, o := range a.Match.Values {
+					forw, ok := found[name]
+					if !ok {
+						forw = map[string]struct{}{}
+						found[name] = forw
+					}
+					back, ok := found[o]
+					if !ok {
+						back = map[string]struct{}{}
+						found[o] = back
+					}
+					forw[o] = struct{}{}
+					back[name] = struct{}{}
+				}
+			}
+		}
+
+		for name, others := range tc.result {
+			for _, o := range others {
+				if _, ok := found[name][o]; !ok {
+					t.Errorf("simple affinity %q did not produce %s: %s",
+						tc.source, name, o)
+				} else {
+					delete(found[name], o)
+					if len(found[name]) == 0 {
+						delete(found, name)
+					}
+				}
+			}
+		}
+		for name, others := range found {
+			val := ""
+			sep := ""
+			for o := range others {
+				val += sep + o
+				sep = ", "
+			}
+			t.Errorf("simple affinity %q produced unexpected %s: [ %s ]", tc.source, name, val)
+		}
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -559,6 +559,9 @@ func (p *policy) calculateContainerAffinity(container cache.Container) map[strin
 		}
 	}
 
+	// self-affinity does not make sense, so remove any
+	delete(result, container.GetCacheID())
+
 	log.Debug("  => affinity: %v", result)
 
 	return result

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
@@ -33,22 +33,36 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
-func findNodeWithID(id int, nodes []Node) *Node {
+func findNodeWithID(id int, nodes []Node) Node {
 	for _, node := range nodes {
 		if node.NodeID() == id {
-			return &node
+			return node
 		}
 	}
 	panic("No node found")
 }
 
 func setLinks(nodes []Node, tree map[int][]int) {
+	parents := map[int]int{}
+
 	for parent, children := range tree {
 		parentNode := findNodeWithID(parent, nodes)
 		for _, child := range children {
 			childNode := findNodeWithID(child, nodes)
-			(*childNode).LinkParent(*parentNode)
+			childNode.LinkParent(parentNode)
+			parents[child] = parent
 		}
+	}
+	orphans := []int{}
+	for id := range tree {
+		if _, ok := parents[id]; !ok {
+			node := findNodeWithID(id, nodes)
+			node.LinkParent(nilnode)
+			orphans = append(orphans, id)
+		}
+	}
+	if len(orphans) != 1 {
+		panic(fmt.Sprintf("expected one root node, got %d with IDs %v", len(orphans), orphans))
 	}
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -49,6 +49,8 @@ type Supply interface {
 	AccountRelease(Grant)
 	// GetScore calculates how well this supply fits/fulfills the given request.
 	GetScore(Request) Score
+	// AllocatableSharedCPU calculates the allocatable amount of shared CPU of this supply.
+	AllocatableSharedCPU(...bool) int
 	// Allocate allocates CPU capacity from this supply and returns it as a grant.
 	Allocate(Request) (Grant, error)
 	// ReleaseCPU releases a previously allocated CPU grant from this supply.
@@ -460,25 +462,30 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 		exclusive, err = cs.takeCPUs(&cs.isolated, nil, cr.full)
 		if err != nil {
 			return nil, policyError("internal error: "+
-				"can't allocate %d exclusive CPUs from %s of %s",
-				cr.full, cs.isolated, cs.node.Name())
+				"%s: can't allocate %d exclusive CPUs %s",
+				cs.node.Name(), cr.full, cs.isolated)
 		}
 
-	case cr.full > 0 && (1000*cs.sharable.Size()-cs.granted)/1000 > cr.full:
+	case cr.full > 0 && cs.AllocatableSharedCPU() >= 1000*cr.full:
 		exclusive, err = cs.takeCPUs(&cs.sharable, nil, cr.full)
 		if err != nil {
 			return nil, policyError("internal error: "+
-				"can't slice %d exclusive CPUs from %s(-%d) of %s",
-				cr.full, cs.sharable, cs.granted, cs.node.Name())
+				"%s: can't take %d exclusive CPUs from %s: %v",
+				cs.node.Name(), cr.full, cs.sharable, err)
 		}
+
+	case cr.full > 0:
+		return nil, policyError("internal error: "+
+			"%s: can't slice %d exclusive CPUs from %s, %dm available",
+			cs.node.Name(), cr.full, cs.sharable, cs.AllocatableSharedCPU())
 	}
 
 	// allocate requested portion of the sharable set
 	if cr.fraction > 0 {
-		if 1000*cs.sharable.Size()-cs.granted < cr.fraction {
+		if cs.AllocatableSharedCPU() < cr.fraction {
 			return nil, policyError("internal error: "+
-				"not enough sharable CPU for %d in %s(-%d) of %s",
-				cr.fraction, cs.sharable, cs.granted, cs.node.Name())
+				"%s: not enough sharable CPU for %dm, %dm available",
+				cs.node.Name(), cr.fraction, cs.sharable, cs.AllocatableSharedCPU())
 		}
 		cs.granted += cr.fraction
 	}
@@ -592,7 +599,7 @@ func (cs *supply) Reserve(g Grant) error {
 			exclusive.String(), g.String(), cs.DumpAllocatable())
 	}
 
-	if 1000*(cs.sharable.Size()-exclusive.Size())-(cs.granted+fraction) < 0 {
+	if cs.AllocatableSharedCPU() < 1000*exclusive.Size()+fraction {
 		return policyError("can't reserve %d fractional CPUs of %s from %s",
 			fraction, g.String(), cs.DumpAllocatable())
 	}
@@ -689,7 +696,7 @@ func (cs *supply) DumpAllocatable() string {
 		cpu += sep + fmt.Sprintf("sharable:%s (", kubernetes.ShortCPUSet(cs.sharable))
 		sep = ""
 		if local_granted > 0 || total_granted > 0 {
-			cpu += fmt.Sprintf("grants:")
+			cpu += fmt.Sprintf("granted:")
 			kind := ""
 			if local_granted > 0 {
 				cpu += fmt.Sprintf("%dm", local_granted)
@@ -703,7 +710,7 @@ func (cs *supply) DumpAllocatable() string {
 			cpu += " " + kind
 			sep = ", "
 		}
-		cpu += sep + fmt.Sprintf("free:%dm)", 1000*cs.sharable.Size()-total_granted)
+		cpu += sep + fmt.Sprintf("allocatable:%dm)", cs.AllocatableSharedCPU(true))
 	}
 
 	allocatable := "<" + cs.node.Name() + " allocatable: "
@@ -865,22 +872,7 @@ func (cs *supply) GetScore(req Request) Score {
 	}
 
 	// calculate free shared capacity
-	// Notes:
-	//   Take into account the supplies/grants in all ancestors, making sure
-	//   none of them gets overcommitted as the result of fulfilling this request.
-	shared := 1000*cs.sharable.Size() - cs.node.GrantedSharedCPU()
-	log.Debug("%s: unadjusted free shared CPU: %dm", cs.node.Name(), shared)
-	for node := cs.node.Parent(); !node.IsNil(); node = node.Parent() {
-		pSupply := node.FreeSupply()
-		pShared := 1000*pSupply.SharableCPUs().Size() - pSupply.GetNode().GrantedSharedCPU()
-		if pShared < shared {
-			log.Debug("%s: capping free shared CPU (%dm -> %dm) to avoid overcommit of %s",
-				cs.node.Name(), shared, pShared, node.Name())
-			shared = pShared
-		}
-	}
-	log.Debug("%s: ancestor-adjusted free shared CPU: %dm", cs.node.Name(), shared)
-	score.shared = shared
+	score.shared = cs.AllocatableSharedCPU()
 
 	// calculate isolated node capacity CPU
 	if cr.isolate {
@@ -928,6 +920,34 @@ func (cs *supply) GetScore(req Request) Score {
 	}
 
 	return score
+}
+
+// AllocatableSharedCPU calculates the allocatable amount of shared CPU of this supply.
+func (cs *supply) AllocatableSharedCPU(quiet ...bool) int {
+	verbose := !(len(quiet) > 0 && quiet[0])
+
+	// Notes:
+	//   Take into account the supplies/grants in all ancestors, making sure
+	//   none of them gets overcommitted as the result of fulfilling this request.
+	shared := 1000*cs.sharable.Size() - cs.node.GrantedSharedCPU()
+	if verbose {
+		log.Debug("%s: unadjusted free shared CPU: %dm", cs.node.Name(), shared)
+	}
+	for node := cs.node.Parent(); !node.IsNil(); node = node.Parent() {
+		pSupply := node.FreeSupply()
+		pShared := 1000*pSupply.SharableCPUs().Size() - pSupply.GetNode().GrantedSharedCPU()
+		if pShared < shared {
+			if verbose {
+				log.Debug("%s: capping free shared CPU (%dm -> %dm) to avoid overcommit of %s",
+					cs.node.Name(), shared, pShared, node.Name())
+			}
+			shared = pShared
+		}
+	}
+	if verbose {
+		log.Debug("%s: ancestor-adjusted free shared CPU: %dm", cs.node.Name(), shared)
+	}
+	return shared
 }
 
 // Eval...


### PR DESCRIPTION
- fix affinity full syntax examples in docs
- make simple affinities implicitly symmetric
- filter out affinities for a container on itself
- add better node affinity scoring 

Despite being explicitly documented to the contrary, based on feedback we received users expect
`simple affinity annotations` to result in implicitly symmetric `affinity expressions`.  IOW they expect
that for every pair of containers X, Y an existing affinity X: Y implies Y: X. Considering the semantics
(Y pulls X), the syntax (almost a matrix of containers) and the fact that the simple notation very much
hides the true versatility of affinity expressions, this expectation is rather understandable.
Therefore we now implicitly generate a fully symmetric set of affinities from the simple notation.

Calculate affinity for every pool node n as a combination of affinities of the nodes x along the path
from n to root and those in the subtree rooted at n. The resulting affinity is a sum of raw affinities of
these nodes with every raw node affinity diluted (divided) by 1<<(distance from n to x).