### PR TITLE
cache: make simple affinities implicitly symmetric.

### DIFF
--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -142,14 +142,55 @@ func (pca *podContainerAffinity) parseSimple(pod *pod, value string, weight int3
 	}
 
 	podScope := pod.ScopeExpression()
+
+	//
+	// Notes:
+	//   We turn affinities given in the simple notation into a symmetric set of
+	//   affinities. IOW, if X has affinity on Y with wight W, then Y will have
+	//   affinity on X with W as well. In practice this is done by
+	//     1) ensuring there is an affinity Y: X for every affinity X: Y
+	//     2) generating an affinity expression for every container with affinities
+	//  The generated expression uses the operator Equal or In depending on whether
+	//  if the container has affinities on exactly one container in the symmetric
+	//  set.
+	//
+
+	symmetric := map[string]map[string]struct{}{}
+
 	for name, values := range parsed {
+		for _, v := range values {
+			forw, ok := symmetric[name]
+			if !ok {
+				forw = map[string]struct{}{}
+				symmetric[name] = forw
+			}
+			back, ok := symmetric[v]
+			if !ok {
+				back = map[string]struct{}{}
+				symmetric[v] = back
+			}
+			forw[v], back[name] = struct{}{}, struct{}{}
+		}
+	}
+
+	var op resmgr.Operator
+	for name, affinities := range symmetric {
+		others := []string{}
+		for o := range affinities {
+			others = append(others, o)
+		}
+		if len(others) == 1 {
+			op = resmgr.Equals
+		} else {
+			op = resmgr.In
+		}
 		(*pca)[name] = append((*pca)[name],
 			&Affinity{
 				Scope: podScope,
 				Match: &resmgr.Expression{
 					Key:    kubernetes.ContainerNameLabel,
-					Op:     resmgr.In,
-					Values: values,
+					Op:     op,
+					Values: others,
 				},
 				Weight: weight,
 			})

--- a/pkg/cri/resource-manager/cache/affinity_test.go
+++ b/pkg/cri/resource-manager/cache/affinity_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+)
+
+func TestSimpleParsingSymmetry(t *testing.T) {
+	c1, c2, c3, c4, c5 := "c1", "c2", "c3", "c4", "c5"
+
+	tcases := []struct {
+		source string
+		result map[string][]string
+	}{
+		{
+			source: `c1: [ c2 ]`,
+			result: map[string][]string{
+				c1: {c2},
+				c2: {c1},
+			},
+		},
+		{
+			source: `c1: [ c2, c3, c4, c5 ]`,
+			result: map[string][]string{
+				c1: {c2, c3, c4, c5},
+				c2: {c1},
+				c3: {c1},
+				c4: {c1},
+				c5: {c1},
+			},
+		},
+		{
+			source: `
+c1: [ c2 ]
+c2: [ c3, c4, c5 ]
+c4: [ c5 ]
+`,
+			result: map[string][]string{
+				c1: {c2},
+				c2: {c1, c3, c4, c5},
+				c3: {c2},
+				c4: {c2, c5},
+				c5: {c2, c4},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		pca := podContainerAffinity{}
+		if !pca.parseSimple(&pod{Name: "testpod"}, tc.source, 1) {
+			t.Errorf("failed to parse simple container affinity %q", tc.source)
+			continue
+		}
+
+		found := map[string]map[string]struct{}{}
+		for name, affinities := range pca {
+			for _, a := range affinities {
+				for _, o := range a.Match.Values {
+					forw, ok := found[name]
+					if !ok {
+						forw = map[string]struct{}{}
+						found[name] = forw
+					}
+					back, ok := found[o]
+					if !ok {
+						back = map[string]struct{}{}
+						found[o] = back
+					}
+					forw[o] = struct{}{}
+					back[name] = struct{}{}
+				}
+			}
+		}
+
+		for name, others := range tc.result {
+			for _, o := range others {
+				if _, ok := found[name][o]; !ok {
+					t.Errorf("simple affinity %q did not produce %s: %s",
+						tc.source, name, o)
+				} else {
+					delete(found[name], o)
+					if len(found[name]) == 0 {
+						delete(found, name)
+					}
+				}
+			}
+		}
+		for name, others := range found {
+			val := ""
+			sep := ""
+			for o := range others {
+				val += sep + o
+				sep = ", "
+			}
+			t.Errorf("simple affinity %q produced unexpected %s: [ %s ]", tc.source, name, val)
+		}
+	}
+}


### PR DESCRIPTION
For affinities given in the simple notation always
generate a symmetric set of affinity expressions. IOW,
for every affinity X: Y with weight W, make sure there
is an affinity Y: X with weight W. |W| is now implicitly
DefaultWeight.