### PR TITLE
memtier: better affinity scoring

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -560,6 +560,9 @@ func (p *policy) calculateContainerAffinity(container cache.Container) map[strin
 		}
 	}
 
+	// self-affinity does not make sense, so remove any
+	delete(result, container.GetCacheID())
+
 	log.Debug("  => affinity: %v", result)
 
 	return result

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -775,7 +775,7 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 	log.Debug("  - depth is a TIE")
 
 	// 6) more isolated capacity wins
-	if request.Isolate() {
+	if request.Isolate() && (isolated1 > 0 || isolated2 > 0) {
 		if isolated1 > isolated2 {
 			return true
 		}
@@ -790,7 +790,7 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 	}
 
 	// 7) more slicable shared capacity wins
-	if request.FullCPUs() > 0 {
+	if request.FullCPUs() > 0 && (shared1 > 0 || shared2 > 0) {
 		if shared1 > shared2 {
 			log.Debug("  => %s WINS on more slicable capacity", node1.Name())
 			return true

--- a/test/e2e/policies/memtier/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies/memtier/n4c16/test00-basic-placement/code.var.sh
@@ -1,0 +1,38 @@
+
+# pod0: Test that 4 guaranteed containers eligible for isolated CPU allocation
+# gets evenly spread over NUMA nodes.
+CONTCOUNT=4 CPU=1 create guaranteed
+report allowed
+verify \
+    'len(cpus["pod0c0"]) == 1' \
+    'len(cpus["pod0c1"]) == 1' \
+    'len(cpus["pod0c2"]) == 1' \
+    'len(cpus["pod0c3"]) == 1' \
+    'disjoint_sets(cpus["pod0c0"], cpus["pod0c1"], cpus["pod0c2"], cpus["pod0c3"])' \
+    'disjoint_sets(nodes["pod0c0"], nodes["pod0c1"], nodes["pod0c2"], nodes["pod0c3"])'
+
+kubectl delete pods --all --now
+
+# pod1: Test that 4 guaranteed containers not eligible for isolated CPU allocation
+# gets evenly spread over NUMA nodes.
+CONTCOUNT=4 CPU=3 create guaranteed
+report allowed
+verify \
+    'len(cpus["pod1c0"]) == 3' \
+    'len(cpus["pod1c1"]) == 3' \
+    'len(cpus["pod1c2"]) == 3' \
+    'len(cpus["pod1c3"]) == 3' \
+    'disjoint_sets(cpus["pod1c0"], cpus["pod1c1"], cpus["pod1c2"], cpus["pod1c3"])' \
+    'disjoint_sets(nodes["pod1c0"], nodes["pod1c1"], nodes["pod1c2"], nodes["pod1c3"])'
+
+kubectl delete pods --all --now
+
+# pod2: Test that 4 burstable containers not eligible for isolated/exclusive CPU allocation
+# gets evenly spread over NUMA nodes.
+CONTCOUNT=4 CPUREQ=3 CPULIM=4 create burstable
+report allowed
+verify \
+    'disjoint_sets(cpus["pod2c0"], cpus["pod2c1"], cpus["pod2c2"], cpus["pod2c3"])' \
+    'disjoint_sets(nodes["pod2c0"], nodes["pod2c1"], nodes["pod2c2"], nodes["pod2c3"])'
+
+kubectl delete pods --all --now

--- a/test/e2e/policies/memtier/n4c16/test03-simple-affinity/code.var.sh
+++ b/test/e2e/policies/memtier/n4c16/test03-simple-affinity/code.var.sh
@@ -1,0 +1,80 @@
+# Test that guaranteed and burstable pods get the CPUs they require
+# when there are enough CPUs available.
+
+inject-affinities() {
+    local var=$1 srcdst src dst hdr line
+    shift
+    if [ -z "$var" ] || [ -z "${!var}" ]; then
+        return 0
+    fi
+    case "$var" in
+        ANTI_*|*_ANTI_*) hdr="cri-resource-manager.intel.com/anti-affinity";;
+        *)      hdr="cri-resource-manager.intel.com/affinity";;
+    esac
+    for srcdst in ${!var}; do
+        src=${srcdst%:*}
+        dst=${srcdst#*:}
+        [ -n "$hdr" ] && { echo "    $hdr: |"; hdr=""; }
+        line="$src: [ ${dst//,/, } ]"
+        echo 1>&2 "* [affinity]: injecting affinity '$line'"
+        echo "      $line"
+    done
+}
+
+deref_keys() {
+    eval "echo \${!$1[@]}"
+}
+
+deref_value() {
+    eval "echo \${$1[$2]}"
+}
+
+inject-annotations() {
+    local var=$1 values key value
+    shift
+    if [ -z "$var" ] || [ -z "${!var}" ]; then
+        return 0
+    fi
+    for key in $(deref_keys ${!var}); do
+        value=$(deref_value ${!var} $key)
+        line="$key: $value"
+        echo 1>&2 "* [annotation]: injecting annotation '$line'"
+        echo "    $line"
+    done
+}
+
+# pod0
+# 4 containers, no affinities => spread out evenly over NUMA nodes
+CONTCOUNT=4 CPU=1 create guaranteed+affinity
+report allowed
+
+verify \
+    'nodes["pod0c0"] == {"node0"}' \
+    'nodes["pod0c1"] == {"node1"}' \
+    'nodes["pod0c2"] == {"node2"}' \
+    'nodes["pod0c3"] == {"node3"}'
+
+kubectl delete pods --all --now
+
+# pod1
+# 4 containers, affinites [0,1], [2,3] => colocate c0,c1 in node0, c2,c3 in node1
+CONTCOUNT=4 AFFINITIES="pod1c0:pod1c1 pod1c2:pod1c3" CPU=1 create guaranteed+affinity
+report allowed
+
+verify \
+    'nodes["pod1c0"] == nodes["pod1c1"] == {"node0"}' \
+    'nodes["pod1c2"] == nodes["pod1c3"] == {"node1"}'
+
+kubectl delete pods --all --now
+
+# pod2
+# 6 containers, anti-affinites 4:[0,1,2], 5:[0,2,3]
+#   => don't co-locate 4 with {0,1,2}, or 5 with {0,2,3}
+CONTCOUNT=6 ANTI_AFFINITIES="pod2c4:pod2c0,pod2c1,pod2c2 pod2c5:pod2c0,pod2c2,pod2c3" CPU=1 \
+    create guaranteed+affinity
+report allowed
+
+verify \
+    'disjoint_sets(nodes["pod2c4"], nodes["pod2c0"], nodes["pod2c1"], nodes["pod2c2"])' \
+    'disjoint_sets(nodes["pod2c5"], nodes["pod2c0"], nodes["pod2c2"], nodes["pod2c3"])'
+

--- a/test/e2e/policies/memtier/n4c16/test03-simple-affinity/guaranteed+affinity.yaml.in
+++ b/test/e2e/policies/memtier/n4c16/test03-simple-affinity/guaranteed+affinity.yaml.in
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+  annotations:
+$([ -z "$(type -t inject-affinities)" ] || inject-affinities AFFINITIES)
+$([ -z "$(type -t inject-affinities)" ] || inject-affinities ANTI_AFFINITIES)
+$([ -z "$(type -t inject-annotations)" ] || inject-annotations ANNOTATIONS)
+spec:
+  containers:
+  $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
+  - name: ${NAME}c$(( contnum - 1 ))
+    image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: ${CPU}
+        memory: '${MEM}'
+      limits:
+        cpu: ${CPU}
+        memory: '${MEM}'
+  "; done )
+  terminationGracePeriodSeconds: 1


### PR DESCRIPTION
Notes:
  - This PR has been updated by pre-merging pending PRs #406. That should be reviewed separately.
  - The algorithm has been slightly updated to dilute node/pool scores along the path less aggressively.

Calculate affinity for every node n based on the raw
affinities of the nodes along the path from n to root
and all the sub-nodes in the tree rooted at n.