### PR TITLE
e2e: integrate resource allocations topology to test scripts

### DIFF
--- a/test/numa/besteffort.yaml.in
+++ b/test/numa/besteffort.yaml.in
@@ -10,7 +10,7 @@ spec:
     command:
       - sh
       - -c
-      - echo ${NAME} \$(sleep inf)
+      - echo ${NAME}c0 \$(sleep inf)
     imagePullPolicy: IfNotPresent
     name: busybox
   terminationGracePeriodSeconds: 1

--- a/test/numa/burstable.yaml.in
+++ b/test/numa/burstable.yaml.in
@@ -12,7 +12,7 @@ spec:
     command:
       - sh
       - -c
-      - echo ${NAME} \$(sleep inf)
+      - echo ${NAME}c0 \$(sleep inf)
     imagePullPolicy: IfNotPresent
     name: busybox
     resources:

--- a/test/numa/guaranteed.yaml.in
+++ b/test/numa/guaranteed.yaml.in
@@ -12,7 +12,7 @@ spec:
     command:
       - sh
       - -c
-      - echo ${NAME} \$(sleep inf)
+      - echo ${NAME}c0 \$(sleep inf)
     imagePullPolicy: IfNotPresent
     name: busybox
     resources:


### PR DESCRIPTION
- Change variables visible in test script functions "verify",
  "report" and "pyexec". Details below.
- Add allowed_RESOURCE[POD] variables to enable verifications
  like verify 'len(allowed_nodes["pod0"]) == 1'.
- Add \"allowed\" variable to contain topology tree with pods as leaf
  nodes on branches they are allowed to use.
- "report allowed" prints full topology tree with pods allowed to
  use the resources.
- Drop "cpus" variable showing CPU masks without topology. The same
  information is now available through allowed_cpus[pod].