### PR TITLE
packaging: various packaging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ install-config-%:
 	for f in $$(find $$dir -name \*.cfg.sample); do \
 	    echo "  $$f in $(DESTDIR)$(CONFIGDIR)..."; \
 	    df=$${f##*/}; \
-	    $(INSTALL) -m 0644 -T $$f $(DESTDIR)$(CONFIGDIR)/$${df%.sample}; \
+	    $(INSTALL) -m 0644 -T $$f $(DESTDIR)$(CONFIGDIR)/$${df}; \
 	done
 
 clean-%:

--- a/cmd/cri-resmgr/cri-resource-manager.service.in
+++ b/cmd/cri-resmgr/cri-resource-manager.service.in
@@ -5,7 +5,7 @@ Before=kubelet.service
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/sysconfig/cri-resource-manager
+EnvironmentFile=__DEFAULTDIR__/cri-resource-manager
 ExecStart=/usr/bin/cri-resmgr $CONFIG_OPTIONS $POLICY_OPTIONS
 Restart=always
 

--- a/dockerfiles/cross-build/Dockerfile.centos-7
+++ b/dockerfiles/cross-build/Dockerfile.centos-7
@@ -9,12 +9,10 @@ ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN yum install -y /usr/bin/bash /usr/bin/make /usr/bin/git \
-    /usr/bin/grep /usr/bin/sed /usr/bin/tr /usr/bin/find \
-    /usr/bin/sort /usr/bin/uniq \
-    /usr/bin/wget /usr/bin/tar /usr/bin/bzip2 /usr/bin/gzip \
-    kernel-devel rpm-build clang gcc \
-    curl-devel zlib-devel openssl-devel expat-devel
+RUN yum install -y rpm-build \
+    kernel-devel clang gcc \
+    curl-devel zlib-devel openssl-devel expat-devel \
+    make wget
 
 # fetch and build go from sources
 RUN arch="$(rpm --eval %{_arch})"; \

--- a/dockerfiles/cross-build/Dockerfile.centos-8
+++ b/dockerfiles/cross-build/Dockerfile.centos-8
@@ -7,11 +7,9 @@ ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN yum install -y /usr/bin/bash /usr/bin/git /usr/bin/make \
-    /usr/bin/grep /usr/bin/sed /usr/bin/tr /usr/bin/find \
-    /usr/bin/sort /usr/bin/uniq \
-    /usr/bin/wget /usr/bin/tar /usr/bin/bzip2 \
-    kernel-devel rpm-build clang gcc
+RUN yum install -y rpm-build \
+    kernel-devel clang gcc \
+    git-core make wget
 
 RUN arch="$(rpm --eval %{_arch})"; \
     case "${arch}" in \

--- a/dockerfiles/cross-build/Dockerfile.centos-8
+++ b/dockerfiles/cross-build/Dockerfile.centos-8
@@ -7,7 +7,7 @@ ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN yum install -y rpm-build \
+RUN dnf install -y rpm-build \
     kernel-devel clang gcc \
     git-core make wget
 

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -11,7 +11,7 @@ RUN dnf install -y /usr/bin/bash /usr/bin/git /usr/bin/make \
     /usr/bin/grep /usr/bin/sed /usr/bin/tr /usr/bin/find \
     /usr/bin/sort /usr/bin/uniq \
     /usr/bin/wget /usr/bin/tar /usr/bin/bzip2 \
-    kernel-devel rpm-build clang gcc
+    kernel-devel rpm-build systemd-rpm-macros clang gcc
 
 RUN arch="$(rpm --eval %{_arch})"; \
     case "${arch}" in \

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -7,11 +7,9 @@ ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN dnf install -y /usr/bin/bash /usr/bin/git /usr/bin/make \
-    /usr/bin/grep /usr/bin/sed /usr/bin/tr /usr/bin/find \
-    /usr/bin/sort /usr/bin/uniq \
-    /usr/bin/wget /usr/bin/tar /usr/bin/bzip2 \
-    kernel-devel rpm-build systemd-rpm-macros clang gcc
+RUN dnf install -y rpm-build systemd-rpm-macros \
+    kernel-devel gcc clang \
+    git-core make wget
 
 RUN arch="$(rpm --eval %{_arch})"; \
     case "${arch}" in \

--- a/dockerfiles/cross-build/Dockerfile.suse-15.1
+++ b/dockerfiles/cross-build/Dockerfile.suse-15.1
@@ -7,12 +7,10 @@ ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN zypper install -y bash git make grep \
-    sed findutils coreutils \
-    tar bzip2 wget \
-    clang gcc \
-    kernel-devel \
-    rpm-build
+RUN zypper install -y rpm-build \
+    kernel-devel clang gcc \
+    git make \
+    wget
 
 RUN arch="$(rpm --eval %{_arch})"; \
     case "${arch}" in \

--- a/dockerfiles/cross-build/Dockerfile.suse-15.2
+++ b/dockerfiles/cross-build/Dockerfile.suse-15.2
@@ -1,0 +1,32 @@
+# pull in base + a minimal set of useful packages
+FROM opensuse/leap as suse-15.2-build
+
+ARG GOLANG_VERSION=1.14.8
+ARG GOLANG_URLDIR=https://dl.google.com/go
+ARG CREATE_USER="build"
+ARG USER_OPTIONS=""
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+
+RUN zypper install -y rpm-build \
+    kernel-devel clang gcc \
+    git make \
+    wget
+
+RUN arch="$(rpm --eval %{_arch})"; \
+    case "${arch}" in \
+        x86_64) goarch=linux-amd64;; \
+        i386) goarch=linux-386;; \
+        armhf) goarch=linux-armv6l;; \
+        ppc64el) goarch=linux-ppc64le;; \
+        s390x) goarch=linux-s390x;; \
+    esac; \
+    \
+    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
+    \
+    export PATH="/usr/local/go/bin:$PATH" && \
+    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
+    go version
+
+RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
+    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
@@ -1,0 +1,35 @@
+# pull in base + a minimal set of useful packages
+FROM ubuntu:20.04 as ubuntu-20.04-build
+
+ARG GOLANG_VERSION=1.14.8
+ARG GOLANG_URLDIR=https://dl.google.com/go
+ARG CREATE_USER="test"
+ARG USER_OPTIONS=""
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV DEBIAN_FRONTEND noninteractive
+
+# pull in stuff for building
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tzdata build-essential fakeroot devscripts \
+        bash git make sed debhelper wget ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN arch="$(dpkg --print-architecture)"; \
+    case "${arch##*-}" in \
+        amd64) goarch=linux-amd64;; \
+        i386) goarch=linux-386;; \
+        armhf) goarch=linux-armv6l;; \
+        ppc64el) goarch=linux-ppc64le;; \
+        s390x) goarch=linux-s390x;; \
+    esac; \
+    \
+    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
+    \
+    export PATH="/usr/local/go/bin:$PATH" && \
+    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
+    go version
+
+RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
+    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :

--- a/scripts/build/docker-build-image
+++ b/scripts/build/docker-build-image
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VOLUMES="-v /sys:/sys -v /home:/mnt/host/home"
+VOLUMES=(-v /sys:/sys -v /home:/mnt/host/home)
 IMAGE=$1
 DOCKERFILE=dockerfiles/cross-build/Dockerfile.${IMAGE%-build}
 shift
@@ -8,7 +8,7 @@ shift
 while [ -n "$1" ]; do
     case $1 in
         --volume|-v)
-            VOLUMES="$VOLUMES -v $2"
+            VOLUMES=("${VOLUMES[@]}" -v "$2")
             shift 2
             ;;
         --container|-c)
@@ -21,7 +21,7 @@ while [ -n "$1" ]; do
             shift
             ;;
         *)
-            PASSTHROUGH="$PASSTHROUGH $1"
+            PASSTHROUGH=("${PASSTHROUGH[@]}" "$1")
             shift
             ;;
     esac
@@ -31,15 +31,15 @@ echo "* Building docker images with"
 echo "  - Dockerfile: $DOCKERFILE"
 echo "  - image name: $IMAGE"
 echo "  - container : $CONTAINER"
-echo "  - volumes   : $VOLUMES"
-echo "  - options   : $PASSTHROUGH"
+echo "  - volumes   : " "${VOLUMES[@]}"
+echo "  - options   : " "${PASSTHROUGH[@]}"
 
 docker build . \
        -f "$DOCKERFILE" -t "$IMAGE" \
        --build-arg "CREATE_USER=$USER" \
        --build-arg USER_OPTIONS="-u__$(id -u)" \
-       "$PASSTHROUGH" || exit 1
+       "${PASSTHROUGH[@]}" || exit 1
 
 if [ -n "$CONTAINER" ]; then
-    docker create --name "$CONTAINER" "$VOLUMES" "$IMAGE"
+    docker create --name "$CONTAINER" "${VOLUMES[@]}" "$IMAGE"
 fi


### PR DESCRIPTION
  - fix previous shellcheck 'fix' breaking scripts/build/docker-build-image
  - fix broken fedora cross-builds
  - reduce initial in-container dnf/yum/zypper operation cost by using a minimal viable package set
  - retain `fallback.cfg.sample` sample config name when installing it to `/etc/cri-resmgr`
  - use `/etc/default` for default options on deb-based distros and `/etc/sysconfig` only on rpm-based ones
  - add the necessary collateral for Ubuntu-20.04 cross-builds
  - add generic cross-build targets `cross-packages`, `cross-rpm`, and `cross-deb`