### PR TITLE
e2e/demo: run.sh passes through USE_NET_BRIDGES to govm

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -12,6 +12,7 @@ VM_GOVM_COMPOSE_TEMPLATE="vms:
     ContainerEnvVars:
       - KVM_CPU_OPTS=\$(echo "\${KVM_CPU_OPTS}")
       - EXTRA_QEMU_OPTS=\$(echo "\${EXTRA_QEMU_OPTS}")
+      - USE_NET_BRIDGES=${USE_NET_BRIDGES-0}
 "
 
 vm-check-env() {


### PR DESCRIPTION
With USE_NET_BRIDGES=1 govm launches Qemu with bridge configuration
instead of the default macvlan. The bridge configuration works in
github actions, while the default does not.

USE_NET_BRIDGES must be 0 by default until govm PR https://github.com/govm-project/govm/pull/44 is merged.
(Update: it is merged. However, we should make sure that govm/govm:latest image gets updated too, because using USE_NET_BRIDGES=1 with an outdated image will refuse to launch Qemu from the image.)

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>