### PR TITLE
Containerized build of documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,11 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get install -y python3-setuptools
-        pip3 install --user -r docs/requirements.txt
+    - name: Build docs builder image
+      run: make site-build
     - name: Branch off base for updated gh-pages
       run: |
         git branch gh-pages
@@ -23,7 +20,6 @@ jobs:
     - name: Add latest generated docs to gh-pages
       shell: bash
       run: |
-        PATH="$HOME/.local/bin:$PATH" make html
         cp -rv _build/html/* .
         for f in $(find _build/html -type f -name '.*'); do \
             cp -v $f ./${f#_build/html/}; \

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -20,22 +20,13 @@ jobs:
     - name: Add latest generated docs to gh-pages
       shell: bash
       run: |
-        cp -rv _build/html/* .
-        for f in $(find _build/html -type f -name '.*'); do \
-            cp -v $f ./${f#_build/html/}; \
-        done
-        for src in $(find _build/html -type f); do \
-            dst="${src#_build/html/}"; \
-            echo "adding generated $dst to git repo..."; \
-            git add ./$dst; \
-        done
-        touch .nojekyll
-        git add .nojekyll
+        touch _build/html/.nojekyll
+        git --work-tree _build/html add --no-all -v .
         author=$(git log --merges --pretty=format:%an -n 1)
         email=$(git log --merges --pretty=format:%ae -n 1)
         git config --global user.name "$author"
         git config --global user.email "$email"
-        git commit -m "publish-docs.yml: generated latest html output." .
+        git commit -m "publish-docs.yml: generated latest html output."
     - name: Publish/force-push to gh-pages
       shell: bash
       env:

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,5 @@
+FROM sphinxdoc/sphinx:3.2.1
+
+COPY docs/requirements.txt .
+
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
Add makefile rules for building and serving the html documentation inside a
container.
- Running `make site-build` will build the html content unders docs.
- Running `make site-serve` builds the site content and serves it at
http://localhost:8081/

Also use containerized build in github workflows – use the same workflow as developers are likely to use. Verifies that
containerized build of documentation works.

Drops all other files than the generated documentation in `gh-pages` branch in order to make
sure that the documentation is self-contained and does not depend on the
source tree.


The updated workflow can be verified here:
https://marquiz.github.io/cri-resource-manager