### PR TITLE
memtier: fix eligible but unsatisfied isolated allocation, add basic placement tests.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -775,7 +775,7 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 	log.Debug("  - depth is a TIE")
 
 	// 6) more isolated capacity wins
-	if request.Isolate() {
+	if request.Isolate() && (isolated1 > 0 || isolated2 > 0) {
 		if isolated1 > isolated2 {
 			return true
 		}
@@ -790,7 +790,7 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 	}
 
 	// 7) more slicable shared capacity wins
-	if request.FullCPUs() > 0 {
+	if request.FullCPUs() > 0 && (shared1 > 0 || shared2 > 0) {
 		if shared1 > shared2 {
 			log.Debug("  => %s WINS on more slicable capacity", node1.Name())
 			return true

--- a/test/e2e/policies/memtier/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies/memtier/n4c16/test00-basic-placement/code.var.sh
@@ -1,0 +1,38 @@
+
+# pod0: Test that 4 guaranteed containers eligible for isolated CPU allocation
+# gets evenly spread over NUMA nodes.
+CONTCOUNT=4 CPU=1 create guaranteed
+report allowed
+verify \
+    'len(cpus["pod0c0"]) == 1' \
+    'len(cpus["pod0c1"]) == 1' \
+    'len(cpus["pod0c2"]) == 1' \
+    'len(cpus["pod0c3"]) == 1' \
+    'disjoint_sets(cpus["pod0c0"], cpus["pod0c1"], cpus["pod0c2"], cpus["pod0c3"])' \
+    'disjoint_sets(nodes["pod0c0"], nodes["pod0c1"], nodes["pod0c2"], nodes["pod0c3"])'
+
+kubectl delete pods --all --now
+
+# pod1: Test that 4 guaranteed containers not eligible for isolated CPU allocation
+# gets evenly spread over NUMA nodes.
+CONTCOUNT=4 CPU=3 create guaranteed
+report allowed
+verify \
+    'len(cpus["pod1c0"]) == 3' \
+    'len(cpus["pod1c1"]) == 3' \
+    'len(cpus["pod1c2"]) == 3' \
+    'len(cpus["pod1c3"]) == 3' \
+    'disjoint_sets(cpus["pod1c0"], cpus["pod1c1"], cpus["pod1c2"], cpus["pod1c3"])' \
+    'disjoint_sets(nodes["pod1c0"], nodes["pod1c1"], nodes["pod1c2"], nodes["pod1c3"])'
+
+kubectl delete pods --all --now
+
+# pod2: Test that 4 burstable containers not eligible for isolated/exclusive CPU allocation
+# gets evenly spread over NUMA nodes.
+CONTCOUNT=4 CPUREQ=3 CPULIM=4 create burstable
+report allowed
+verify \
+    'disjoint_sets(cpus["pod2c0"], cpus["pod2c1"], cpus["pod2c2"], cpus["pod2c3"])' \
+    'disjoint_sets(nodes["pod2c0"], nodes["pod2c1"], nodes["pod2c2"], nodes["pod2c3"])'
+
+kubectl delete pods --all --now


### PR DESCRIPTION
Do not compare negative isolated capacities. In particular,
never consider equal negative capacities a tie. Do the same
for negative shared capacity. It's only for code symmetry, the
existing filtering of pools with insufficient resources should
already protect us from ever hitting that problem.

Add a minimal test set for verifying basic `memtier` container
placement.