### PR TITLE
test/e2e: a bunch of small fixes and improvements.

### DIFF
--- a/demo/lib/topology.py
+++ b/demo/lib/topology.py
@@ -54,7 +54,7 @@ import sys
 
 _bash_topology_dump = """for cpu in /sys/devices/system/cpu/cpu[0-9]*; do cpu_id=${cpu#/sys/devices/system/cpu/cpu}; echo "cpu p:$(< ${cpu}/topology/physical_package_id) d:$(< ${cpu}/topology/die_id) n:$(basename  ${cpu}/node* | sed 's:node::g') c:$(< ${cpu}/topology/core_id) t:$(< ${cpu}/topology/thread_siblings) cpu:${cpu_id}" ; done;  for node in /sys/devices/system/node/node[0-9]*; do node_id=${node#/sys/devices/system/node/node}; echo "dist n:$node_id d:$(< $node/distance)"; echo "mem n:$node_id s:$(awk '/MemTotal/{print $4/1024}' < $node/meminfo)"; done"""
 
-_bash_res_allowed = r"""for process in '%s'; do for pid in $(pgrep -f $process); do [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ] && echo "${process}/${pid} $(awk '/Cpus_allowed:/{c=$2}/Mems_allowed:/{m=$2}END{print "c:"c" m:"m}' < /proc/$pid/status)"; done; done"""
+_bash_res_allowed = r"""for process in '%s'; do for pid in $(pgrep -f $process); do name=$(cat /proc/$pid/cmdline | tr '\0 ' '\n' | grep -E "^$process"); [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ] && echo "${name}/${pid} $(awk '/Cpus_allowed:/{c=$2}/Mems_allowed:/{m=$2}END{print "c:"c" m:"m}' < /proc/$pid/status)"; done; done"""
 
 def error(msg, exit_status=1):
     """Print error message and exit."""

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -158,7 +158,7 @@ get-py-allowed() {
         echo -e "$COMMAND_OUTPUT" > "$topology_dump_file"
     fi
     # Fetch data and update allowed* variables from the virtual machine
-    vm-command "$("$DEMO_LIB_DIR/topology.py" bash_res_allowed pod{0,1,2,3,4,5,6,7,8,9}c{0,1,2,3})" >/dev/null || {
+    vm-command "$("$DEMO_LIB_DIR/topology.py" bash_res_allowed 'pod[0-9]*c[0-9]*')" >/dev/null || {
         command-error "error fetching res_allowed from $VM_NAME"
     }
     echo -e "$COMMAND_OUTPUT" > "$res_allowed_file"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -260,8 +260,9 @@ resolve-template() {
         fi
         if [ -z "$r" ]; then
             r="$t"
+            echo 1>&2 "template $name resolved to file $r"
         else
-            echo "WARNING: template file $r shadows $t"
+            echo 1>&2 "WARNING: template file $r shadows $t"
         fi
     done
     if [ -n "$r" ]; then

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -549,7 +549,7 @@ create() { # script API
     for _ in $(seq 1 $n); do
         kind_count[$template_kind]=$(( ${kind_count[$template_kind]} + 1 ))
         local NAME="${template_kind}$(( ${kind_count[$template_kind]} - 1 ))" # the first pod is pod0
-        eval "echo -e \"$(<"${template_file}")\"" > "$OUTPUT_DIR/$NAME.yaml"
+        eval "echo -e \"$(<"${template_file}")\"" | grep -v '^ *$' > "$OUTPUT_DIR/$NAME.yaml"
         host-command "scp \"$OUTPUT_DIR/$NAME.yaml\" $VM_SSH_USER@$VM_IP:" || {
             command-error "copying \"$OUTPUT_DIR/$NAME.yaml\" to VM failed"
         }

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -8,7 +8,7 @@ usage() {
     echo "TESTS_DIR is expected to be structured as POLICY/TOPOLOGY/TEST with files:"
     echo "POLICY/cri-resmgr.cfg: configuration of cri-resmgr"
     echo "POLICY/TOPOLOGY/topology.var.json: contents of the topology variable for run.sh"
-    echo "POLICY/TOPOLOGY/code.var.sh: contents of the code var (that is, test script)"
+    echo "POLICY/TOPOLOGY/TEST/code.var.sh: contents of the code var (that is, test script)"
 }
 
 error() {

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -116,7 +116,8 @@ for POLICY_DIR in "$TESTS_ROOT_DIR"/*; do
                         export outdir="$TEST_DIR/output"
                         mkdir -p "$outdir"
                         echo "Run $(basename "$TEST_DIR")"
-                        "$RUN_SH" test 2>&1 | tee "$outdir/run.sh.output"
+                        TEST_DIR=$TEST_DIR TOPOLOGY_DIR=$TOPOLOGY_DIR POLICY_DIR=$POLICY_DIR \
+                            "$RUN_SH" test 2>&1 | tee "$outdir/run.sh.output"
                         test_name="$(basename "$POLICY_DIR")/$(basename "$TOPOLOGY_DIR")/$(basename "$TEST_DIR")"
                         if grep -q "Test verdict: PASS" "$outdir/run.sh.output"; then
                             echo "PASS $test_name" >> "$summary_file"


### PR DESCRIPTION
This patch set contains the following fixes to the end-to-end test infra:

  - fix a small typo in the usage/help message of `test/e2e/run_tests.sh`
  - correctly pass the `test`, `topology` and `policy` `directories` to `run.sh` for template resolution
  - print the resolved template path and any template shadowing `warnings` to `stderr`
  - catch and give special treatment to python `KeyError` and `IndexError` `exceptions` during verification
  - filter empty lines from evaluated YAML templates
  - don't hardcode a max. test case limit of 9 pods with 4 containers each
