### PR TITLE
e2e: write files under vm-files to vm

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -112,6 +112,12 @@ vm-wait-process() {
     fi
 }
 
+vm-write-file() {
+    local vm_path_file="$1"
+    local file_content_b64="$(base64 <<<$2)"
+    vm-command-q "mkdir -p $(dirname "$vm_path_file"); echo -n \"$file_content_b64\" | base64 -d > \"$vm_path_file\""
+}
+
 vm-set-kernel-cmdline() { # script API
     # Usage: vm-set-kernel-cmdline E2E-DEFAULTS
     #


### PR DESCRIPTION
- run_tests.sh looks for vm-files directories under policy,
  topology and test directories and constructs vm_files
  variable recursively.
- run.sh writes files in vm_files associative array to vm.
- Files are written to vm before running/restarting cri-resmgr.