### PR TITLE
packaging: install sysconf collateral to $(DEFAULTDIR).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,12 +263,12 @@ install-systemd-%:
 
 install-sysconf-%:
 	$(Q)bin=$(patsubst install-sysconf-%,%,$@); dir=cmd/$$bin; \
-	echo "Installing sysconf collateral for $$bin..."; \
-	$(INSTALL) -d $(DESTDIR)$(SYSCONFDIR)/sysconfig && \
+	echo "Installing sysconf/default collateral for $$bin..."; \
+	$(INSTALL) -d $(DESTDIR)$(DEFAULTDIR) && \
 	for f in $$(find $$dir -name \*.sysconf); do \
-	    echo "  $$f in $(DESTDIR)$(SYSCONFDIR)/sysconfig..."; \
+	    echo "  $$f in $(DESTDIR)$(DEFAULTDIR)..."; \
 	    df=$${f##*/}; df=$${df%.sysconf}; \
-	    $(INSTALL) -m 0644 -T $$f $(DESTDIR)$(SYSCONFDIR)/sysconfig/$$df; \
+	    $(INSTALL) -m 0644 -T $$f $(DESTDIR)$(DEFAULTDIR)/$$df; \
 	done
 
 install-config-%:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -65,12 +65,12 @@ build `rpm` packages for `CentOS 8`
 ## Post-Install Configuration
 
 The provided packages install `systemd` service files and sample configuration.
-The easiest way to get up and running is to copy the sample configuration in
-the correct place and start CRI Resource Manager using systemd. You can do
-this using the following commands:
+The easiest way to get up and running is to rename the sample configuration and
+start CRI Resource Manager using systemd. You can do this using the following
+commands:
 
 ```
-cp /usr/share/doc/cri-resource-manager/fallback.cfg.sample /etc/cri-resmgr/fallback.cfg
+mv /etc/cri-resmgr/fallback.cfg.sample /etc/cri-resmgr/fallback.cfg
 systemctl start cri-resource-manager
 ```
 

--- a/packaging/deb.in/rules
+++ b/packaging/deb.in/rules
@@ -16,6 +16,10 @@ override_dh_auto_build:
 override_dh_auto_install:
 	export PATH="$$PATH:$$(go env GOPATH)/bin"; \
 	make BUILD_DIRS="__BUILD_DIRS__" install DESTDIR=debian/__PACKAGE__
+	mkdir -p debian/__PACKAGE__/usr/share/doc/__PACKAGE__
+	cp CONTRIBUTING.md LICENSE README.md SECURITY.md cmd/*/*.sample \
+	    debian/__PACKAGE__/usr/share/doc/__PACKAGE__
+
 
 override_dh_gencontrol:
 	dh_gencontrol -- -v$(PACKAGEVERSION)


### PR DESCRIPTION
Use `$(DEFAULTDIR)` to correctly pick distro-specific location for defaults (`/etc/sysconfig` vs. `/etc/default`).
This should fill incorrect default location used and referenced in debian/ubuntu packages.