### PR TITLE
demo/vm.bash: allow sudo without tty, run any extra VM init commands.

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -13,6 +13,11 @@ VM_GOVM_COMPOSE_TEMPLATE="vms:
       - KVM_CPU_OPTS=\$(echo "\${KVM_CPU_OPTS}")
       - EXTRA_QEMU_OPTS=\$(echo "\${EXTRA_QEMU_OPTS}")
       - USE_NET_BRIDGES=${USE_NET_BRIDGES-0}
+    user-data: |
+      #!/bin/bash
+      mkdir -p /etc/sudoers.d
+      echo 'Defaults !requiretty' > /etc/sudoers.d/10-norequiretty
+\$(sed 's/^/      /g' <<< \"\${VM_EXTRA_BOOTSTRAP_COMMANDS}\")
 "
 
 vm-check-env() {


### PR DESCRIPTION
Always add `Defaults !requiretty` to the sudoers configuration to allow running sudo-wrapped
commands over ssh. This is required to bootstrap CentOS-based VMs for our end-to-end tests.

Also run any other VM commands necessary for bootstrapping as requested by setting the
VM_EXTRA_BOOTSTRAP_COMMANDS variable.