### PR TITLE
critest: fix memtier test and default cleanup

### DIFF
--- a/test/critest/run.sh
+++ b/test/critest/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST="CRI validation tests with critest"
+TEST_TITLE="CRI validation tests with critest"
 
 PV='pv -qL'
 
@@ -10,11 +10,18 @@ BIN_DIR=$(realpath "$SCRIPT_DIR/../../bin")
 OUTPUT_DIR=${outdir-$SCRIPT_DIR/output}
 COMMAND_OUTPUT_DIR=$OUTPUT_DIR/commands
 
-source $DEMO_LIB_DIR/command.bash
-source $DEMO_LIB_DIR/host.bash
-source $DEMO_LIB_DIR/vm.bash
+# shellcheck disable=SC1091
+# shellcheck source=../../demo/lib/command.bash
+source "$DEMO_LIB_DIR"/command.bash
+# shellcheck disable=SC1091
+# shellcheck source=../../demo/lib/host.bash
+source "$DEMO_LIB_DIR"/host.bash
+# shellcheck disable=SC1091
+# shellcheck source=../../demo/lib/vm.bash
+source "$DEMO_LIB_DIR"/vm.bash
 
 usage() {
+    echo "$TEST_TITLE"
     echo "Usage: [VAR=VALUE] ./run.sh MODE"
     echo "  MODE:     \"play\" plays the test as a demo."
     echo "            \"test\" runs fast, reports pass or fail."
@@ -25,8 +32,9 @@ usage() {
     echo "             The default is \"crirm-test-critest\"."
     echo "    speed:   Demo play speed."
     echo "             The default is 10 (keypresses per second)."
-    echo "    cleanup: 0: leave VM running. (The default in the \"play\" mode.)"
-    echo "             1: delete VM (The default in the \"test\" mode.)"
+    echo "    cleanup: Level of cleanup after a test run:"
+    echo "             0: leave VM running (the default)"
+    echo "             1: delete VM"
     echo "             2: stop VM, but do not delete it."
     echo "    outdir:  Save output under given directory."
     echo "             The default is \"${SCRIPT_DIR}/output\"."
@@ -40,7 +48,7 @@ error() {
 out() {
     if [ -n "$PV" ]; then
         speed=${speed-10}
-        echo "$1" | $PV $speed
+        echo "$1" | $PV "$speed"
     else
         echo "$1"
     fi
@@ -49,7 +57,7 @@ out() {
 
 screen-create-vm() {
     speed=60 out "### Running the test in VM \"$vm\"."
-    host-create-vm $vm
+    host-create-vm "$vm" "$topology"
     if [ -z "$VM_IP" ]; then
         error "creating VM failed"
     fi
@@ -70,8 +78,8 @@ screen-copy-cri-resmgr() {
     vm-command "mv cri-resmgr tsl $prefix/bin/" || {
         command-error "installing cri-resmgr to $prefix/bin failed"
     }
-    PV= vm-command "command -v cri-resmgr" >/dev/null
-    ( echo $COMMAND_OUTPUT | grep -q $prefix/bin/cri-resmgr ) || {
+    PV="" vm-command "command -v cri-resmgr" >/dev/null
+    ( echo "$COMMAND_OUTPUT" | grep -q $prefix/bin/cri-resmgr ) || {
         command-error "\"cri-resmgr\" does not execute $prefix/bin/cri-resmgr on VM"
     }
 
@@ -81,7 +89,7 @@ screen-install-critest() {
     speed=60 out "### Installing critest to VM."
     vm-command "apt update && apt install -y golang make socat"
     vm-command "go get -d github.com/kubernetes-sigs/cri-tools"
-    CRI_TOOLS_SOURCE_DIR=$(awk '/package.*cri-tools/{print $NF}' <<< $COMMAND_OUTPUT)
+    CRI_TOOLS_SOURCE_DIR=$(awk '/package.*cri-tools/{print $NF}' <<< "$COMMAND_OUTPUT")
     [ -n "$CRI_TOOLS_SOURCE_DIR" ] || {
         command-error "downloading cri-tools failed"
     }
@@ -104,7 +112,6 @@ screen-critest-crirm-config() {
 }
 
 screen-critest-containerd() {
-    config_file=$1
     cri_endpoint=/var/run/containerd/containerd.sock
     vm-command "rm -rf *.tsl; critest -runtime-endpoint unix://$cri_endpoint 2>&1 | tsl -uU -F \"%(ts) s critest: %(line)s\" -o critest.output.tsl"
     vm-command-q "cat *.tsl | sort -n | awk '{if (t_start==0) t_start=\$1; \$1=sprintf(\"%.6fs\", \$1-t_start); print;}'" > "$OUTPUT_DIR/test-containerd.log"
@@ -112,16 +119,18 @@ screen-critest-containerd() {
 
 require_cmd() {
     cmd=$1
-    if ! command -v $cmd >/dev/null ; then
+    if ! command -v "$cmd" >/dev/null ; then
         error "required command missing \"${cmd}\", make sure it is in PATH"
     fi
 }
 
 # Validate parameters
 mode=$1
+topology=${topology:='[{"cores": 2, "mem": "8G"}]'}
 distro=${distro:="ubuntu-20.04"}
 cri=${cri:="containerd"}
 vm=${vm:="critest-$distro-$cri"}
+cleanup=${cleanup-0}
 host-set-vm-config "$vm" "$distro" "$cri"
 
 cd "${SCRIPT_DIR}" || error "failed to cd to \"${SCRIPT_DIR}\""
@@ -129,20 +138,18 @@ tests=${tests-*.cfg}
 
 if [ "$mode" == "test" ]; then
     PV=
-    cleanup=${cleanup-1}
 elif [ "$mode" == "play" ] ; then
     speed=${speed-10}
-    cleanup=${cleanup-0}
 else
     usage
     error "invalid MODE"
 fi
 
 # Prepare for test/demo
-mkdir -p $OUTPUT_DIR
-mkdir -p $COMMAND_OUTPUT_DIR
-rm -f $COMMAND_OUTPUT_DIR/0*
-( echo x > $OUTPUT_DIR/x && rm -f $OUTPUT_DIR/x ) || {
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$COMMAND_OUTPUT_DIR"
+rm -f "$COMMAND_OUTPUT_DIR"/0*
+( echo x > "$OUTPUT_DIR/x" && rm -f "$OUTPUT_DIR/x" ) || {
     error "output directory outdir=$OUTPUT_DIR is not writable"
 }
 
@@ -164,7 +171,7 @@ fi
 # Run test/demo
 # 1. Run critest on cri-resmgr with each config file.
 for config_file in $tests; do
-    screen-critest-crirm-config $config_file
+    screen-critest-crirm-config "$config_file"
 done
 # 2. Run critest without cri-resmgr for reference.
 screen-critest-containerd
@@ -183,11 +190,13 @@ fi
 # Summarize results
 SUMMARY_FILE="$OUTPUT_DIR/summary.txt"
 echo -n "" > "$SUMMARY_FILE" || error "cannot write summary to \"$SUMMARY_FILE\""
-for testlog in $OUTPUT_DIR/test-*.log; do
-    echo -n "$(basename "$testlog") " >> "$SUMMARY_FILE"
-    awk 'BEGIN{s=0;e=0}/critest: /{if(s==0)s=$1;e=$1}END{printf "(runtime %.2f s): ",e-s}' < "$testlog" >> "$SUMMARY_FILE"
-    # remove ansi colors from critest output in the summary
-    grep Pending "$testlog" | grep critest: | tail -n 1 | sed -r -e "s/[[:cntrl:]]\[[0-9]+m//g" -e "s/^.* -- //g" >> "$SUMMARY_FILE"
+for testlog in "$OUTPUT_DIR"/test-*.log; do
+    {
+        echo -n "$(basename "$testlog") "
+        awk 'BEGIN{s=0;e=0}/critest: /{if(s==0)s=$1;e=$1}END{printf "(runtime %.2f s): ",e-s}' < "$testlog"
+        # remove ansi colors from critest output in the summary
+        grep Pending "$testlog" | grep critest: | tail -n 1 | sed -r -e "s/[[:cntrl:]]\[[0-9]+m//g" -e "s/^.* -- //g"
+    } >> "$SUMMARY_FILE"
 done
 exit_status=0
 # Declare verdict in test mode
@@ -195,7 +204,7 @@ if [ "$mode" == "test" ]; then
     echo "" >> "$SUMMARY_FILE"
     # Test is passed if all critest executions had the same passrate,
     # no matter which cri-resmgr configuration was used.
-    if [ "$(awk -F: '/Passed/{print $2}' < $SUMMARY_FILE | sort -u | wc -l)" == "1" ]; then
+    if [ "$(awk -F: '/Passed/{print $2}' < "$SUMMARY_FILE" | sort -u | wc -l)" == "1" ]; then
         echo "All critest results are the same." >> "$SUMMARY_FILE"
         echo "Test verdict: PASS" >> "$SUMMARY_FILE"
     else
@@ -206,5 +215,5 @@ if [ "$mode" == "test" ]; then
 fi
 echo ""
 echo "Summary:"
-cat $SUMMARY_FILE
-exit $exit_status
+cat "$SUMMARY_FILE"
+exit "$exit_status"


### PR DESCRIPTION
- Fix critest on memtier policy, broken due to bad topology.
- Align cleanup behavior after test with e2e tests.
- Fix shellcheck errors.