### PR TITLE
docs: apply the webhook only after the webhook service is available

### DIFF
--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -18,8 +18,7 @@ the [provided Dockerfile][/cmd/cri-resmgr-webhook/Dockerfile] and published it,
 you can set up the webhook with these commands:
 
 ```
-  kubectl apply -f cmd/cri-resmgr-webhook/mutating-webhook-config.yaml
   kubectl apply -f cmd/cri-resmgr-webhook/webhook-deployment.yaml
-
+  kubectl wait --for=condition=Available -n cri-resmgr deployments/cri-resmgr-webhook
+  kubectl apply -f cmd/cri-resmgr-webhook/mutating-webhook-config.yaml
 ```
-


### PR DESCRIPTION
If `mutating-webhook-config.yaml` is applied before `webhook-deployment.yaml`, creating and updating pods will fail. That includes creating the `cri-resmgr-webhook` pod behind the webhook service.