### PR TITLE
docs: install git into the site builder container image

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,7 @@
 FROM sphinxdoc/sphinx:3.2.1
 
+RUN apt-get update && apt-get install -y git
+
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
Add git so that we're able to detect the version in the container build.
And, something other than "failed to determine version from any source"
is shown in the upper left corner of the page.