### PR TITLE
Implement versioned documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
         - master
-        - documentation/test
+        - release-*
+    tags:
+        - v*
 
 jobs:
   update-gh-pages:
@@ -13,24 +15,24 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build docs builder image
       run: make site-build
-    - name: Branch off base for updated gh-pages
+
+    - name: Fetch gh-pages
+      run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages
+
+    - name: Install build dependencies
       run: |
-        git branch gh-pages
-        git checkout gh-pages
-    - name: Add latest generated docs to gh-pages
-      shell: bash
+        pip3 install --user -r docs/requirements.txt
+        echo "`python3 -m site --user-base`/bin" >> $GITHUB_PATH
+
+    - name: Add docs from this revision to gh-pages
       run: |
-        touch _build/.nojekyll
-        rm -rf _build/.doctrees _build/_sources
-        git --work-tree _build add --no-all -v .
-        author=$(git log --merges --pretty=format:%an -n 1)
-        email=$(git log --merges --pretty=format:%ae -n 1)
-        git config --global user.name "$author"
-        git config --global user.email "$email"
-        git commit -m "publish-docs.yml: generated latest html output."
-    - name: Publish/force-push to gh-pages
+        git config user.name "Github"
+        git config user.email "no-reply@github.com"
+        ./scripts/build/update-gh-pages.sh
+
+    - name: Publish/push to gh-pages
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        git push -f https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages
+        git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git gh-pages

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,21 @@
+{%- extends "!layout.html" %}
+
+{% block footer %}
+  {% if versions %}
+    <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+      <span class="rst-current-version" data-toggle="rst-current-version">
+        <span class="fa fa-book"> Read the Docs</span>
+        v: {{ version }}
+        <span class="fa fa-caret-down"></span>
+      </span>
+      <div class="rst-other-versions">
+        <dl>
+          <dt>{{ _('Versions') }}</dt>
+          {% for version in versions %}
+          <dd><a href="/cri-resource-manager/{{ version }}">{{ version }}</a></dd>
+          {% endfor %}
+        </dl>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ author = 'various'
 
 master_doc = 'docs/index'
 
+
 ##############################################################################
 #
 # This section determines the behavior of links to local items in .md files.
@@ -63,6 +64,9 @@ else:
 version = getenv("SITE_VERSION", default="unknown")
 release = getenv("BUILD_VERSION", default="unknown")
 
+# Versions to show in the version menu
+versions = getenv('VERSIONS', default="").split()
+html_context = {'versions': sorted(set(versions))}
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,19 @@ else:
     githubFileURL = githubFileURL + baseBranch + "/"
     githubDirURL = githubDirURL + baseBranch + "/"
 
-version = getenv("SITE_VERSION", default="unknown")
+# Version displayed in the upper left corner of the site
+ref = getenv('GITHUB_REF', default="")
+if ref == "refs/heads/master":
+    version = "devel"
+elif ref.startswith("refs/heads/release-"):
+    # For release branches just show the latest tag name
+    buildVersion = getenv("BUILD_VERSION", default="unknown")
+    version = buildVersion.split('-')[0]
+elif ref.startswith("refs/tags/"):
+    version = ref[len("refs/tags/"):]
+else:
+    version = getenv("BUILD_VERSION", default="unknown")
+
 release = getenv("BUILD_VERSION", default="unknown")
 
 # Versions to show in the version menu

--- a/scripts/build/get-buildid
+++ b/scripts/build/get-buildid
@@ -153,10 +153,6 @@ package_versions() {
     esac
 }
 
-site_version() {
-    [[ $VERSION =~ ^([0-9]+\.[0-9]+)(\.[0-9]+)*$ ]] && SITE=${BASH_REMATCH[1]} || SITE=devel
-}
-
 print_variables() {
     local _what _var _val
 
@@ -181,10 +177,6 @@ print_variables() {
             tar)
                 [ -n "$SHVAR" ] && _var='tarversion='
                 _val="$VERSION"
-                ;;
-            site)
-                [ -n "$SHVAR" ] && _var='siteversion='
-                _val="$SITE"
                 ;;
             *)
                 print_usage "unknown version/buildid-related tag \"$_what\""
@@ -235,9 +227,6 @@ while [ "$#" != "0" ]; do
         --tar)
             PRINT="$PRINT tar"
             ;;
-        --site)
-            PRINT="$PRINT site"
-            ;;
         --all)
             PRINT="version buildid rpm deb tar"
             ;;
@@ -280,7 +269,6 @@ if [ -z "$STORE" ] && [ -z "$PRINT" ]; then
 fi
 
 package_versions
-site_version
 print_variables
 
 if [ -n "$STORE" ]; then

--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -1,0 +1,137 @@
+#!/bin/bash -e
+set -o pipefail
+
+script=`basename $0`
+
+usage () {
+cat << EOF
+Usage: $script [-h] [-a] [BUILD_SUBDIR]
+
+Options:
+  -h         show this help and exit
+  -a         amend (with --reset-author) instead of creating a new commit
+EOF
+}
+
+#
+# Argument parsing
+#
+while [ "${1#-}" != "$1" -a -n "$1" ]; do
+    case "$1" in
+        -a|--amend)
+            amend="--amend --reset-author"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+build_subdir="$1"
+
+# Check that no extra args were provided
+if [ $# -gt 1 ]; then
+    echo "ERROR: unknown arguments: $@"
+    usage
+    exit 1
+fi
+
+#
+# Build the documentation
+#
+build_dir="_build-ghpages"
+echo "Creating new Git worktree at $build_dir"
+git worktree add "$build_dir" gh-pages
+
+# Drop worktree on exit
+trap "echo 'Removing Git worktree $build_dir'; git worktree remove --force '$build_dir'" EXIT
+
+# Parse subdir name from GITHUB_REF
+if [ -z "$build_subdir" ]; then
+    case "$GITHUB_REF" in
+        refs/tags/*)
+            _base_ref=${GITHUB_REF#refs/tags/}
+            ;;
+        refs/heads/*)
+            _base_ref=${GITHUB_REF#refs/heads/}
+            ;;
+        *) _base_ref=
+    esac
+    echo "Parsed baseref: '$_base_ref'"
+
+    case "$GITHUB_REF" in
+        refs/tags/v*)
+            _version=${GITHUB_REF#refs/tags/v}
+            ;;
+        refs/heads/release-*)
+            _version=${GITHUB_REF#refs/heads/release-}
+            ;;
+        *) _version=
+    esac
+    echo "Detected version: '$_version'"
+
+    _version=`echo -n $_version | sed -nE s'!^([0-9]+\.[0-9]+).*$!\1!p'`
+
+    # Use version as the subdir
+    build_subdir=${_version:+v$_version}
+    # Fallback to base-ref i.e. name of the branch or tag
+    if [ -z "$build_subdir" ]; then
+        # For master branch we use the name 'devel'
+        [ "$_base_ref" = "master" ] && build_subdir=devel || build_subdir=$_base_ref
+    fi
+fi
+
+# Default to 'devel' if no subdir was given and we couldn't parse
+# it
+build_subdir=${build_subdir:-devel}
+echo "Updating site version subdir: '$build_subdir'"
+export SITE_BUILDDIR="$build_dir/$build_subdir"
+
+# Detect existing versions from the gh-pages branch
+# 'stable' is a symlink pointing to the latest version
+cd "$build_dir"
+export VERSIONS="$build_subdir ${_version:+stable} `ls -d */  | tr -d /`"
+cd -
+
+make html
+
+#
+# Update gh-pages branch
+#
+commit_hash=`git describe --dirty --always`
+
+# Switch to work in the gh-pages worktree
+cd "$build_dir"
+
+# Add "const" files we need in root dir
+touch .nojekyll
+
+_stable=`ls -d1 v*/ || : | sort -n | tail -n1`
+[ -n "$_stable" ] && ln -sfT "$_stable" stable
+
+cat > index.html << EOF
+<meta http-equiv="refresh" content="0; URL='devel'" />
+EOF
+
+if [ -z "`git status --short`" ]; then
+    echo "No new content, gh-pages branch already up-to-date"
+    exit 0
+fi
+
+# Create a new commit
+commit_msg=`echo -e "Update documentation for $build_subdir\n\nAuto-generated from $commit_hash by '$script'"`
+
+echo "Committing changes..."
+# Exclude doctrees dir
+git add -- ":!$build_subdir/.doctrees"
+git commit $amend -m "$commit_msg"
+
+cd -
+
+echo "gh-pages branch successfully updated"


### PR DESCRIPTION
This PR implements a complete pipeline of versioned documentation:
- adds a helper script for updating the `gh-pages` branch
- customizes the sphinx theme to include a version menu
- integrates versioned documentation into github actions

The basic idea here is that documentation is built whenever `master` or any `release-*` branch is update. It builds documentation for the updated "version" only, i.e. we don't always rebuild all documentation. The reasoning behind is:
- Only maintain documentation per major release. Latest point release (e.g. `v0.x.(y+1)` should be compatible with the previous point release (`v0.x.y`), also documentation-wise. This is what many other projects do, too.
- Build on updates of release branch, not on tags in order to make it easier to maintain older documentation. E.g. there is no need to make a new release if only documentation is updated. This logic is simple, stupid. Another way to achieve this with better "gating" would be to just build on tags by default, but, allow gh-pages update if the tip commit has a certain "meta-tag" e.g. `gh-pages: publish` or smth.
- Only build docs for the ref/rev that was updated. That's what we do for everything else (container images etc), too. The specifics how to build/update gh-pages for certain ref is coded in `.github/workflows/publish-docs.yml`. We don't want to guess/depend how documentation is built in other branches as tools/versions/the whole logic might change over time.

A demonstration, generated with github actions, with two versions (master and 0.4) can be seen in my personal repo:
https://marquiz.github.io/cri-resource-manager

An alternative approach to #433 