### PR TITLE
docs: archive documentation for tagged releases.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -11,6 +11,11 @@
       <div class="rst-other-versions">
         <dl id="versions">
           <dt>{{ _('Versions') }}</dt>
+          <dt>
+        </dl>
+        <dl>
+          <a href="/cri-resource-manager/releases">all releases</a>
+          </dt>
         </dl>
       </div>
     </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '_work', 'generate', 'README.md', 'RELEASE.md']
+exclude_patterns = ['_build', '_work', 'generate', 'README.md', 'RELEASE.md', 'docs/releases']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/releases/conf.py
+++ b/docs/releases/conf.py
@@ -1,0 +1,74 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'CRI Resource Manager'
+copyright = '2020, various'
+author = 'various'
+
+# Versions to show in the version menu
+version = "all releases"
+if os.getenv('VERSIONS_MENU'):
+    html_context = {'versions_menu': True}
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+        'recommonmark',
+        'sphinx_markdown_tables'
+        ]
+source_suffix = {
+        '.rst': 'restructuredtext',
+        '.md': 'markdown'
+        }
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['../_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+html_theme_options = {
+    'display_version': True,
+}
+
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+#html_static_path = ['_static']
+
+# Callbacks for recommonmark
+def setup(app):
+    app.connect('missing-reference',ignoreMissingRefs)
+
+def ignoreMissingRefs(app, env, node, contnode):
+    return contnode

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,21 @@
+# Releases
+
+For up-to-date user documentation see the [documentation site](/cri-resource-manager)
+
+## Documentation for Released Versions
+<div id="releases">
+</div>
+<script src="releases.js"></script>
+<script>
+  var list = document.getElementById('releases').appendChild(document.createElement("ul"));
+  var releaseItems = getReleaseListItems();
+  for (var i=0; i < releaseItems.length; i++) {
+    var item = document.createElement('li');
+    var paragraph = item.appendChild(document.createElement("p"));
+    var anchor = paragraph.appendChild(document.createElement('a'));
+    anchor.appendChild(document.createTextNode(releaseItems[i].name));
+    anchor.href = releaseItems[i].url;
+    anchor.class = "reference external";
+    list.appendChild(item);
+  }
+</script>


### PR DESCRIPTION
Use a separate 'releases' subdir for the documentation archive.

Builds on top of #440 