### PR TITLE
docs: change the text in the top of version menu

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,7 +4,7 @@
   {% if versions %}
     <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
       <span class="rst-current-version" data-toggle="rst-current-version">
-        <span class="fa fa-book"> Read the Docs</span>
+        <span class="fa fa-book"> GitHub Pages</span>
         v: {{ version }}
         <span class="fa fa-caret-down"></span>
       </span>


### PR DESCRIPTION
Use "GitHub Pages" (instead of "Read the Docs") as that's what serving
our site.