### PR TITLE
docs: implement dynamic versions menu

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,7 +1,7 @@
 {%- extends "!layout.html" %}
 
 {% block footer %}
-  {% if versions %}
+  {% if versions_menu %}
     <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
       <span class="rst-current-version" data-toggle="rst-current-version">
         <span class="fa fa-book"> GitHub Pages</span>
@@ -9,13 +9,22 @@
         <span class="fa fa-caret-down"></span>
       </span>
       <div class="rst-other-versions">
-        <dl>
+        <dl id="versions">
           <dt>{{ _('Versions') }}</dt>
-          {% for version in versions %}
-          <dd><a href="/cri-resource-manager/{{ version }}">{{ version }}</a></dd>
-          {% endfor %}
         </dl>
       </div>
     </div>
   {% endif %}
+  <script src="{{ pathto('../versions.js', 1) }}"></script>
+  <script>
+      var list = document.getElementById('versions')
+      var menuItems = getVersionsMenuItems();
+      for (var i=0; i < menuItems.length; i++) {
+        var item = document.createElement('dd');
+        var anchor = item.appendChild(document.createElement('a'));
+        anchor.appendChild(document.createTextNode(menuItems[i].name));
+        anchor.href = menuItems[i].url;
+        list.appendChild(item);
+      }
+  </script>
 {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,8 +77,8 @@ else:
 release = getenv("BUILD_VERSION", default="unknown")
 
 # Versions to show in the version menu
-versions = getenv('VERSIONS', default="").split()
-html_context = {'versions': sorted(set(versions))}
+if getenv('VERSIONS_MENU'):
+    html_context = {'versions_menu': True}
 
 # -- General configuration ---------------------------------------------------
 

--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -120,7 +120,7 @@ cd "$build_dir"
 # Add "const" files we need in root dir
 touch .nojekyll
 
-_stable=`ls -d1 v*/ || : | sort -n | tail -n1`
+_stable=`(ls -d1 v*/ || :) | sort -n | tail -n1`
 [ -n "$_stable" ] && ln -sfT "$_stable" stable
 
 # Detect existing versions from the gh-pages branch

--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -13,6 +13,19 @@ Options:
 EOF
 }
 
+# Helper function for detecting available versions from the current directory
+create_versions_js() {
+    _baseurl="/cri-resource-manager"
+
+    echo -e "function getVersionsMenuItems() {\n  return ["
+    # 'stable' is a symlink pointing to the latest version
+    [ -f stable ] && echo "    { name: 'stable', url: '$_baseurl/stable' },"
+    for f in `ls -d */  | tr -d /`; do
+        echo "    { name: '$f', url: '$_baseurl/$f' },"
+    done
+    echo -e "  ];\n}"
+}
+
 #
 # Argument parsing
 #
@@ -92,12 +105,7 @@ fi
 build_subdir=${build_subdir:-devel}
 echo "Updating site version subdir: '$build_subdir'"
 export SITE_BUILDDIR="$build_dir/$build_subdir"
-
-# Detect existing versions from the gh-pages branch
-# 'stable' is a symlink pointing to the latest version
-cd "$build_dir"
-export VERSIONS="$build_subdir ${_version:+stable} `ls -d */  | tr -d /`"
-cd -
+export VERSIONS_MENU=1
 
 make html
 
@@ -114,6 +122,9 @@ touch .nojekyll
 
 _stable=`ls -d1 v*/ || : | sort -n | tail -n1`
 [ -n "$_stable" ] && ln -sfT "$_stable" stable
+
+# Detect existing versions from the gh-pages branch
+create_versions_js > versions.js
 
 cat > index.html << EOF
 <meta http-equiv="refresh" content="0; URL='stable'" />


### PR DESCRIPTION
Change the versions menu in the bottom of navbar to be dynamic,
generated with js. The parent directory of the site is supposed to have
'versions.js' containing a simple object (map) of name-uri pairs.