### PR TITLE
docs: create file references to github repo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,15 +51,21 @@ master_doc = 'docs/index'
 baseBranch = "master"
 useGitHubURL = True
 commitSHA = getenv('GITHUB_SHA')
-githubBaseURL = "https://github.com/intel/cri-resource-manager/"
-githubFileURL = githubBaseURL + "blob/"
-githubDirURL = githubBaseURL + "tree/"
-if commitSHA:
-    githubFileURL = githubFileURL + commitSHA + "/"
-    githubDirURL = githubDirURL + commitSHA + "/"
+githubServerURL = getenv('GITHUB_SERVER_URL')
+githubRepository = getenv('GITHUB_REPOSITORY')
+if githubServerURL and githubRepository:
+    githubBaseURL = join(githubServerURL, githubRepository)
 else:
-    githubFileURL = githubFileURL + baseBranch + "/"
-    githubDirURL = githubDirURL + baseBranch + "/"
+    githubBaseURL = "https://github.com/intel/cri-resource-manager/"
+
+githubFileURL = join(githubBaseURL, "blob/")
+githubDirURL = join(githubBaseURL, "tree/")
+if commitSHA:
+    githubFileURL = join(githubFileURL, commitSHA)
+    githubDirURL = join(githubDirURL, commitSHA)
+else:
+    githubFileURL = join(githubFileURL, baseBranch)
+    githubDirURL = join(githubDirURL, baseBranch)
 
 # Version displayed in the upper left corner of the site
 ref = getenv('GITHUB_REF', default="")
@@ -223,7 +229,7 @@ def fixLocalMDAnchors(app, doctree, docname):
                 if useGitHubURL:
                 # Replace references to local files with links to the GitHub repo
                 #
-                    newURI = githubFileURL + filePath
+                    newURI = join(githubFileURL, filePath)
                     print("new url: ", newURI)
                     node['refuri']=newURI
                 else:
@@ -245,5 +251,5 @@ def fixLocalMDAnchors(app, doctree, docname):
         elif "#" not in uri: # ignore anchors
         # turn links to directories into links to the repo
             if isdir(filePath):
-                newURI = githubDirURL + filePath
+                newURI = join(githubDirURL, filePath)
                 node['refuri']=newURI

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ master_doc = 'docs/index'
 ##############################################################################
 
 baseBranch = "master"
-useGitHubURL = False
+useGitHubURL = True
 commitSHA = getenv('GITHUB_SHA')
 githubBaseURL = "https://github.com/intel/cri-resource-manager/"
 githubFileURL = githubBaseURL + "blob/"
@@ -147,7 +147,6 @@ def fixRSTLinkInMD(app, env, node, contnode):
     if isHTTPLink(refTarget):
         return
 
-    filePath = refTarget.lstrip("/")
     if isRSTFileLink(refTarget) and not isHTTPLink(refTarget):
     # This occurs when a .rst file is referenced from a .md file
     # Currently unable to check if file exists as no file
@@ -158,7 +157,7 @@ def fixRSTLinkInMD(app, env, node, contnode):
         contnode['refuri'] = contnode['refuri'].replace('.rst','.html')
         contnode['internal'] = "True"
         return contnode
-    else:
+    elif refTarget.startswith("/"):
     # This occurs when a file is referenced for download from an .md file.
     # Construct a list of them and short-circuit the warning. The files
     # are moved later (need file location context). To avoid warnings,
@@ -167,6 +166,7 @@ def fixRSTLinkInMD(app, env, node, contnode):
     #
     # Example: [Makefile](/Makefile)
     #
+        filePath = refTarget.lstrip("/")
         if isfile(filePath) or isdir(filePath):
             return contnode
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,8 +28,8 @@ path.
 
 The choice of policy to use along with any potential parameters specific to that
 policy are taken from the configuration file. You can take a look at the
-[sample configurations](sample-configs) for some minimal/trivial examples. For instance,
-you can use [sample-configs/memtier-policy.cfg](sample-configs/memtier-policy.cfg)
+[sample configurations](/sample-configs) for some minimal/trivial examples. For instance,
+you can use [sample-configs/memtier-policy.cfg](/sample-configs/memtier-policy.cfg)
 as `<config-file>` to activate the topology aware policy with memory tiering support.
 
 **NOTE**: Currently the available policies are work in progress.
@@ -127,9 +127,9 @@ option `--reset-policy`. The whole sequence of switching policies this way is
 When the [agent][agent] is in use, it is also possible to `adjust` container `resource
 assignments` externally, using dedicated `Adjustment` `Custom Resources` in
 the `adjustments.criresmgr.intel.com` group. You can use the
-[provided schema](pkg/apis/resmgr/v1alpha1/adjustment-schema.yaml) to define
+[provided schema](/pkg/apis/resmgr/v1alpha1/adjustment-schema.yaml) to define
 the `Adjustment` resource. Then you can copy and modify the
-[sample adjustment CR](sample-configs/external-adjustment.yaml) as a starting
+[sample adjustment CR](/sample-configs/external-adjustment.yaml) as a starting
 point to test some overrides.
 
 An `Adjustment` consists of a
@@ -282,7 +282,7 @@ kli@r640-1:~> kubectl get -n kube-system adjustments.criresmgr.intel.com -ojson 
 
 You can use CRI Resource Manager to simply inspect all proxied CRI requests and
 responses without applying any policy. Run CRI Resource Manager with the
-provided [sample configuration](sample-configs/cri-full-message-dump.cfg)
+provided [sample configuration](/sample-configs/cri-full-message-dump.cfg)
 for doing this.
 
 


### PR DESCRIPTION
When referencing files in this repo, create links to our github repo
instead of making a local copy.

Also, fixes handling of file references. When running through missing
references, only ignore file references with an absolute path. These
will reference the repo root directory and will be turned later on to
references to GitHub, directly. Missing references with a relative path
raise an error (as they should because the file really is missing).

Fix the broken references in the documentation, too, so that the
documentation builds without errors.