### PR TITLE
memtier, controllers: split out dynamic page demotion into a controller.

### DIFF
--- a/pkg/config/duration.go
+++ b/pkg/config/duration.go
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// Duration is a time.Duration which implements JSON marshalling/unmarshalling.
+type Duration time.Duration
+
+// MarshalJSON is the JSON marshaller for (time.)Duration.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + time.Duration(d).String() + "\""), nil
+}
+
+// UnmarshalJSON is the JSON unmarshaller for (time.)Duration.
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	if len(data) < 2 {
+		return fmt.Errorf("invalid Duration data")
+	}
+	parsed, err := time.ParseDuration(string(data[1 : len(data)-1]))
+	if err != nil {
+		return err
+	}
+	*d = Duration(parsed)
+	return nil
+}
+
+// String returns the value of Duration as a string.
+func (d *Duration) String() string {
+	return time.Duration(*d).String()
+}

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -811,6 +811,15 @@ func (c *container) GetToptierLimit() int64 {
 	return c.ToptierLimit
 }
 
+func (c *container) SetPageMigration(p *PageMigrate) {
+	c.PageMigrate = p
+	c.markPending(PageMigration)
+}
+
+func (c *container) GetPageMigration() *PageMigrate {
+	return c.PageMigrate
+}
+
 func (c *container) SetCRIRequest(req interface{}) error {
 	if c.req != nil {
 		return cacheError("can't set pending container request: another pending")

--- a/pkg/cri/resource-manager/control/page-migrate/demoter_test.go
+++ b/pkg/cri/resource-manager/control/page-migrate/demoter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memtier
+package pagemigrate
 
 import (
 	"fmt"
@@ -237,11 +237,11 @@ func TestMovePages(t *testing.T) {
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			dynamicDemoter := &demoter{
-				pageMoveCount: tc.pageCount,
-				pageMover:     tc.pageMover,
+				maxPageMoveCount: tc.pageCount,
+				pageMover:        tc.pageMover,
 			}
 
-			err := dynamicDemoter.MovePages(tc.pool, tc.pageCount, tc.targetNodes)
+			err := dynamicDemoter.movePages(tc.pool, tc.pageCount, tc.targetNodes)
 			if err != nil {
 				if err.Error() != "Fake error" {
 					t.Errorf("Non-fake error: %v", err)

--- a/pkg/cri/resource-manager/control/page-migrate/flags.go
+++ b/pkg/cri/resource-manager/control/page-migrate/flags.go
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagemigrate
+
+import (
+	"github.com/intel/cri-resource-manager/pkg/config"
+)
+
+// options captures our configurable controller parameters.
+type options struct {
+	// PageScanInterval controls how much time we give containers to touch non-idle pages.
+	PageScanInterval config.Duration
+	// PageMoveInterval controls how often we trigger moving pages.
+	PageMoveInterval config.Duration
+	// MaxPageMoveCount controls how many pages we can move in a single go.
+	MaxPageMoveCount uint
+}
+
+// Our runtime configuration.
+var opt = defaultOptions().(*options)
+
+// defaultOptions returns a new options instance, all initialized to defaults.
+func defaultOptions() interface{} {
+	return &options{}
+}
+
+// Register us for configuration handling.
+func init() {
+	config.Register(PageMigrationConfigPath, PageMigrationDescription, opt, defaultOptions)
+}

--- a/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
+++ b/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
@@ -89,9 +89,8 @@ func getMigrationController() *migration {
 	if singleton == nil {
 		singleton = &migration{
 			containers: make(map[string]*container),
-			demoter:    &demoter{pageMover: &linuxPageMover{}},
 		}
-		singleton.demoter.migration = singleton
+		singleton.demoter = newDemoter(singleton)
 	}
 	return singleton
 }
@@ -100,11 +99,13 @@ func getMigrationController() *migration {
 func (m *migration) Start(cache cache.Cache, client client.Client) error {
 	m.cache = cache
 	m.syncWithCache()
+	m.demoter.Reconfigure()
 	return nil
 }
 
 // Stop shuts down the controller.
 func (m *migration) Stop() {
+	m.demoter.Stop()
 }
 
 // PreCreateHook is the controller's pre-create hook.

--- a/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
+++ b/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
@@ -1,0 +1,99 @@
+// Copyright 2019-2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagemigrate
+
+import (
+	"fmt"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/client"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+const (
+	// PageMigrationController is the name/domain of the page migration controller.
+	PageMigrationController = cache.PageMigration
+	// PageMigrationConfigPath is the configuration path for the page migration controller.
+	PageMigrationConfigPath = "resource-manager.control." + PageMigrationController
+	// PageMigrationDescription is the description for the page migration controller.
+	PageMigrationDescription = "page migration controller"
+)
+
+// migration implements the controller for memory page migration.
+type migration struct {
+	cache cache.Cache // resource manager cache
+}
+
+// Our logger instance.
+var log = logger.NewLogger(PageMigrationController)
+
+// Our singleton page migration controller.
+var singleton *migration
+
+// getMigrationController returns our singleton controller instance.
+func getMigrationController() *migration {
+	if singleton == nil {
+		singleton = &migration{}
+	}
+	return singleton
+}
+
+// Start prepares the controller for resource control/decision enforcement.
+func (m *migration) Start(cache cache.Cache, client client.Client) error {
+	m.cache = cache
+	return nil
+}
+
+// Stop shuts down the controller.
+func (m *migration) Stop() {
+}
+
+// PreCreateHook is the controller's pre-create hook.
+func (m *migration) PreCreateHook(cache.Container) error {
+	return nil
+}
+
+// PreStartHook is the controller's pre-start hook.
+func (m *migration) PreStartHook(cache.Container) error {
+	return nil
+}
+
+// PostStartHook is the controller's post-start hook.
+func (m *migration) PostStartHook(cc cache.Container) error {
+	cc.ClearPending(PageMigrationController)
+	return nil
+}
+
+// PostUpdateHook is the controller's post-update hook.
+func (m *migration) PostUpdateHook(cc cache.Container) error {
+	cc.ClearPending(PageMigrationController)
+	return nil
+}
+
+// PostStopHook is the controller's post-stop hook.
+func (m *migration) PostStopHook(cc cache.Container) error {
+	return nil
+}
+
+// migrationError creates a controller-specific formatted error message.
+func migrationError(format string, args ...interface{}) error {
+	return fmt.Errorf("page-migrate: "+format, args...)
+}
+
+// init registers this controller.
+func init() {
+	control.Register(PageMigrationController, "page migration controller", getMigrationController())
+}

--- a/pkg/cri/resource-manager/control/page-migrate/page-mover.go
+++ b/pkg/cri/resource-manager/control/page-migrate/page-mover.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memtier
+package pagemigrate
 
 import "C"
 

--- a/pkg/cri/resource-manager/controllers.go
+++ b/pkg/cri/resource-manager/controllers.go
@@ -19,5 +19,6 @@ import (
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/blockio"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/cri"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/memory"
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/page-migrate"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/rdt"
 )

--- a/pkg/cri/resource-manager/policy/builtin/memtier/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/flags.go
@@ -31,10 +31,6 @@ type options struct {
 	PreferShared bool `json:"PreferSharedCPUs"`
 	// FakeHints are the set of fake TopologyHints to use for testing purposes.
 	FakeHints fakehints `json:",omitempty"`
-
-	DirtyBitScanPeriod config.Duration `json:"DirtyBitScanPeriod"`
-	PageMovePeriod     config.Duration `json:"PageMovePeriod"`
-	PageMoveCount      uint            `json:"PageMoveCount"`
 }
 
 // Our runtime configuration.
@@ -58,14 +54,11 @@ func (fh *fakehints) merge(hints fakehints) {
 // defaultOptions returns a new options instance, all initialized to defaults.
 func defaultOptions() interface{} {
 	return &options{
-		PinCPU:             true,
-		PinMemory:          true,
-		PreferIsolated:     true,
-		PreferShared:       false,
-		FakeHints:          make(fakehints),
-		DirtyBitScanPeriod: 0,
-		PageMovePeriod:     0,
-		PageMoveCount:      0,
+		PinCPU:         true,
+		PinMemory:      true,
+		PreferIsolated: true,
+		PreferShared:   false,
+		FakeHints:      make(fakehints),
 	}
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/flags.go
@@ -15,15 +15,9 @@
 package memtier
 
 import (
-	"fmt"
-	"time"
-
 	config "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/topology"
 )
-
-// Duration is an alias for time.Duration.
-type Duration time.Duration
 
 // Options captures our configurable policy parameters.
 type options struct {
@@ -38,32 +32,9 @@ type options struct {
 	// FakeHints are the set of fake TopologyHints to use for testing purposes.
 	FakeHints fakehints `json:",omitempty"`
 
-	DirtyBitScanPeriod Duration `json:"DirtyBitScanPeriod"`
-	PageMovePeriod     Duration `json:"PageMovePeriod"`
-	PageMoveCount      uint     `json:"PageMoveCount"`
-}
-
-// MarshalJSON converts Duration to JSON string.
-func (d Duration) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + time.Duration(d).String() + "\""), nil
-}
-
-// UnmarshalJSON converts JSON string to Duration.
-func (d *Duration) UnmarshalJSON(data []byte) error {
-	if len(data) < 2 {
-		return fmt.Errorf("invalid Duration data")
-	}
-	parsed, err := time.ParseDuration(string(data[1 : len(data)-1]))
-	if err != nil {
-		return err
-	}
-	*d = Duration(parsed)
-	return nil
-}
-
-// String returns the value of Duration as a string.
-func (d *Duration) String() string {
-	return time.Duration(*d).String()
+	DirtyBitScanPeriod config.Duration `json:"DirtyBitScanPeriod"`
+	PageMovePeriod     config.Duration `json:"PageMovePeriod"`
+	PageMoveCount      uint            `json:"PageMoveCount"`
 }
 
 // Our runtime configuration.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -463,6 +463,12 @@ func (m *mockContainer) SetToptierLimit(int64) {
 func (m *mockContainer) GetToptierLimit() int64 {
 	panic("unimplemented")
 }
+func (m *mockContainer) SetPageMigration(*cache.PageMigrate) {
+	return
+}
+func (m *mockContainer) GetPageMigration() *cache.PageMigrate {
+	return nil
+}
 func (m *mockContainer) SetCRIRequest(req interface{}) error {
 	panic("unimplemented")
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -407,6 +407,12 @@ func (m *mockContainer) SetToptierLimit(int64) {
 func (m *mockContainer) GetToptierLimit() int64 {
 	panic("unimplemented")
 }
+func (m *mockContainer) SetPageMigration(*cache.PageMigrate) {
+	panic("unimplemented")
+}
+func (m *mockContainer) GetPageMigration() *cache.PageMigrate {
+	panic("unimplemented")
+}
 func (m *mockContainer) SetCRIRequest(req interface{}) error {
 	panic("unimplemented")
 }


### PR DESCRIPTION
This patch series is the first step in generalizing and improving dynamic page demotion by
introducing a new `page-migration` controller and splitting out the core of the functionality
from the `memtier` policy to this new controller. With this patch series applied any policy
can activate page demotion for container by simply attaching demotion policy decisions to
the desired containers.

In particular, the patch series
- adds functions for getting/setting page-migration policy/preferences to cache.Container
- adds a new `page-migration` controller
- moves the core of the demotion functionality to the new controller
- only leaves demotion/migration policy decision making in `memtier`
- fixes `resource-manager` to execute controller post-stop hooks for deleted containers

The current page-migration policy decision is implicitly 'idle page migration', with the policy
only providing the set of source and target nodes. Detecting idle pages and migrating them
from sources to targets is entirely taken care of in the page-migration controller. This should
be fairly easy to generalize in the future.
