### PR TITLE
e2e: start-up improvements in proxies and printing

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -353,6 +353,13 @@ default-setup-proxies() {
     if [ -z "$http_proxy$https_proxy$ftp_proxy$no_proxy" ]; then
         return 0
     fi
+    if vm-command-q "grep -q \"http_proxy=$http_proxy\" /etc/profile.d/proxy.sh && \
+                     grep -q \"https_proxy=$https_proxy\" /etc/profile.d/proxy.sh && \
+                     grep -q \"ftp_proxy=$ftp_proxy\" /etc/profile.d/proxy.sh && \
+                     grep -q \"no_proxy=$no_proxy\" /etc/profile.d/proxy.sh" 2>/dev/null; then
+        # No changes in proxy configuration
+        return 0
+    fi
 
     local file scope="" append="--append"
     local hn=$(vm-command-q hostname)

--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -150,6 +150,7 @@ host-create-vm() {
     else
         echo "Warning: cannot verify Qemu version on govm image. In case of failure, check it is >= 5.0" >&2
     fi
+    echo "# VM Qemu output : docker logs $VM_CONTAINER_ID"
     echo "# VM Qemu monitor: docker exec -it $VM_CONTAINER_ID nc local:/data/monitor"
     VM_MONITOR="docker exec -i $VM_CONTAINER_ID nc local:/data/monitor"
     host-wait-vm-ssh-server


### PR DESCRIPTION
- Do not change VM proxies if proxy configuration is already
  up-to-date. This removes unnecessary start-up commands when
  connecting to an already running VM for the test.
- Print docker command for viewing VM console output at start-up.