### PR TITLE
e2e: add tests for static-pools

### DIFF
--- a/test/e2e/policies.test-suite/static-pools/README.txt
+++ b/test/e2e/policies.test-suite/static-pools/README.txt
@@ -1,0 +1,11 @@
+# E2E static-pools policy test
+
+## Requirements
+
+This test requires containerd v1.4 or later on the VM. Earlier
+containerd versions fail to mount container images built on top of
+Clear Linux base image. That includes mounting cri-resmgr-webhook.
+
+`cri-resmgr-webhook` image must be present on the host (`make
+images`). The latest image in `docker images cri-resmgr-webhook` list
+will be installed and tested on the VM.

--- a/test/e2e/policies.test-suite/static-pools/cmk-exclusive.yaml.in
+++ b/test/e2e/policies.test-suite/static-pools/cmk-exclusive.yaml.in
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+spec:
+  terminationGracePeriodSeconds: 1
+  tolerations:
+    - key: 'cmk'
+      operator: 'Equal'
+      value: 'true'
+      effect: 'NoSchedule'
+  containers:
+    - name: ${NAME}c0
+      image: busybox
+      env:
+$([ -z $STP_POOL ] || echo "
+        - name: STP_POOL
+          value: '${STP_POOL}'")
+$([ -z $STP_SOCKET_ID ] || echo "
+        - name: STP_SOCKET_ID
+          value: '${STP_SOCKET_ID}'")
+      command: ['sh', '-c']
+      args:
+        - 'while :; do echo ${NAME}c0 CMK_CPUS_ASSIGNED=\"\$CMK_CPUS_ASSIGNED\"; sleep 1; done'
+      resources:
+        requests:
+          cpu: ${CPU}
+$([ "$EXCLCORES" = "omit" ] || echo "
+          cmk.intel.com/exclusive-cores: '${EXCLCORES}'")
+        limits:
+          cpu: ${CPU}
+$([ "$EXCLCORES" = "omit" ] || echo "
+          cmk.intel.com/exclusive-cores: '${EXCLCORES}'")

--- a/test/e2e/policies.test-suite/static-pools/cmk-isolate.yaml.in
+++ b/test/e2e/policies.test-suite/static-pools/cmk-isolate.yaml.in
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+spec:
+  terminationGracePeriodSeconds: 1
+  tolerations:
+    - key: 'cmk'
+      operator: 'Equal'
+      value: 'true'
+      effect: 'NoSchedule'
+  containers:
+    - name: ${NAME}c0
+      image: busybox
+      env:
+$([ -z $STP_POOL ] || echo "
+        - name: STP_POOL
+          value: '${STP_POOL}'")
+$([ -z $STP_SOCKET_ID ] || echo "
+        - name: STP_SOCKET_ID
+          value: '${STP_SOCKET_ID}'")
+$([ "$CMDSPLIT" = "command_all" ] && echo "
+      command: ['cmk', 'isolate' $CMK_ISOLATE, 'sh', '-c', 'while :; do echo ${NAME}c0 ${ECHO_VARS}; sleep 1; done']"
+  [ "$CMDSPLIT" = "command_cmk_sh" ] && echo "
+      command: ['cmk', 'isolate' $CMK_ISOLATE, 'sh', '-c']
+      args: ['while :; do echo ${NAME}c0 ${ECHO_VARS}; sleep 1; done']"
+  [ "$CMDSPLIT" = "command_cmk" ] && echo "
+      command: ['cmk', 'isolate' $CMK_ISOLATE]
+      args: ['sh', '-c', 'while :; do echo ${NAME}c0 ${ECHO_VARS}; sleep 1; done']")
+      resources:
+        requests:
+          cpu: ${CPU}
+          $([ -z $EXCLCORES ] || echo "cmk.intel.com/exclusive-cores: '${EXCLCORES}'")
+        limits:
+          cpu: ${CPU}
+          $([ -z $EXCLCORES ] || echo "cmk.intel.com/exclusive-cores: '${EXCLCORES}'")

--- a/test/e2e/policies.test-suite/static-pools/cmk-tolerating-guaranteed.yaml.in
+++ b/test/e2e/policies.test-suite/static-pools/cmk-tolerating-guaranteed.yaml.in
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+spec:
+  tolerations:
+    - {'key': 'cmk', 'operator': 'Equal', 'value': 'true', 'effect': 'NoSchedule'}
+  containers:
+  $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
+  - name: ${NAME}c$(( contnum - 1 ))
+    image: busybox
+    command:
+      - sh
+      - -c
+      - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: ${CPU}
+        memory: '${MEM}'
+      limits:
+        cpu: ${CPU}
+        memory: '${MEM}'
+  "; done )
+  terminationGracePeriodSeconds: 1

--- a/test/e2e/policies.test-suite/static-pools/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/static-pools/cri-resmgr.cfg
@@ -1,0 +1,15 @@
+policy:
+  Active: static-pools
+  ReservedResources:
+    CPU: 750m
+  static-pools:
+    pools:
+      shared:
+        cpuLists:
+          - Cpuset: 0-7
+            Socket: 0
+          - Cpuset: 8-15
+            Socket: 1
+        exclusive: false
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy,stp

--- a/test/e2e/policies.test-suite/static-pools/distro.var
+++ b/test/e2e/policies.test-suite/static-pools/distro.var
@@ -1,0 +1,1 @@
+debian-sid

--- a/test/e2e/policies.test-suite/static-pools/n4c16/cri-resmgr-static-pools.cfg
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/cri-resmgr-static-pools.cfg
@@ -1,0 +1,10 @@
+policy:
+  Active: static-pools
+  ReservedResources:
+    CPU: 750m
+  static-pools:
+    ConfFilePath: "/etc/cmk/pools.conf"
+    LabelNode: true
+    TaintNode: true
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy,stp

--- a/test/e2e/policies.test-suite/static-pools/n4c16/py_consts.var.py
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/py_consts.var.py
@@ -1,0 +1,3 @@
+exclusive_cores={'node0/core0', 'node0/core1', 'node2/core0'}
+shared_cores={'node1/core2', 'node1/core3'}
+infra_cores={'node2/core1', 'node3/core2', 'node3/core3'}

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test00-node-status/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test00-node-status/code.var.sh
@@ -1,0 +1,29 @@
+# Test that the static-pools policy
+# 1. labels the node with cmk.intel.com/cmk-node
+# 2. advertises correct number of exclusive-cores resources
+# 3. taints the node
+
+# shellcheck disable=SC2148
+cri_resmgr_cfg="$TEST_DIR/../cri-resmgr-static-pools.cfg" static-pools-relaunch-cri-resmgr
+
+out ""
+out "### Verifying that node has cmk-node label"
+vm-run-until 'kubectl get nodes -o jsonpath="{.items[*].metadata.labels}" | grep \"cmk.intel.com/cmk-node\"\:\"true\"' ||
+    error "cmk.intel.com/cmk-node label missing"
+
+out ""
+out "### Verifying that amount exclusive cores on node matches /etc/cmk/pools.conf"
+vm-run-until 'kubectl get nodes -o jsonpath="{.items[*].status.allocatable}" | grep -q \"cmk.intel.com/exclusive-cores\"\:\"3\"' ||
+    error "expected 3 allocatable cmk.intel.com/exclusive-cores"
+
+out ""
+out "### Creating a pod that should not be scheduled due to node taint"
+( wait_t=2s create besteffort ) || {
+    echo "failed as expected due to node taint"
+}
+
+out ""
+out "### Verifying that scheduling normal pod failed"
+vm-command 'kubectl describe pods/pod0 | grep -E "FailedScheduling .*cmk: true"' || {
+    error "FailedScheduling expected but not found"
+}

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test01-exclusive-pods/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test01-exclusive-pods/code.var.sh
@@ -1,0 +1,61 @@
+# Test that exclusive-cores containers
+# 1. run on exclusive cores
+# 2. are pinned according to STP_POOL and STP_SOCKET_ID
+#    when "cmk isolate" is not used.
+# 3. all exclusive cores can be consumed with and without
+#    specifying STP_SOCKET_ID.
+
+# shellcheck disable=SC2148
+cri_resmgr_cfg="$TEST_DIR/../cri-resmgr-static-pools.cfg" static-pools-relaunch-cri-resmgr
+export STP_POOL=exclusive
+
+out ""
+out "### Creating exclusive CMK pod with 1 exclusive core"
+CPU=1000m STP_SOCKET_ID=1 EXCLCORES=1 create cmk-exclusive
+report allowed
+verify 'len(cores["pod0c0"]) == 1' \
+       'packages["pod0c0"] == {"package1"}'
+
+out ""
+out "### Deleting exclusive CMK pod"
+kubectl delete pods --all --now
+
+out ""
+out "### Creating exclusive CMK pod with 2 exclusive cores"
+CPU=1000m STP_SOCKET_ID=0 EXCLCORES=2 create cmk-exclusive
+report allowed
+verify 'len(cores["pod1c0"]) == 2' \
+       'packages["pod1c0"] == {"package0"}'
+
+out ""
+out "### Deleting exclusive CMK pod"
+kubectl delete pods --all --now
+
+out ""
+out "### Creating two exclusive CMK pods with 1 exclusive core each"
+n=2 CPU=1000m STP_SOCKET_ID=0 EXCLCORES=1 create cmk-exclusive
+report allowed
+verify 'len(cores["pod2c0"]) == 1' \
+       'len(cores["pod3c0"]) == 1' \
+       'disjoint_sets(cores["pod2c0"], cores["pod3c0"])' \
+       'packages["pod2c0"] == packages["pod3c0"] == {"package0"}'
+
+out ""
+out "### Creating one more exclusive CMK pods, consuming all exclusive cores"
+CPU=1000m STP_SOCKET_ID=1 EXCLCORES=1 create cmk-exclusive
+report allowed
+verify 'len(cores["pod2c0"]) == 1' \
+       'len(cores["pod3c0"]) == 1' \
+       'len(cores["pod4c0"]) == 1' \
+       'disjoint_sets(cores["pod2c0"], cores["pod3c0"], cores["pod4c0"])' \
+       'set.union(cores["pod2c0"], cores["pod3c0"], cores["pod4c0"]) == exclusive_cores'
+kubectl delete pods --all --now
+
+out ""
+out "### Test consuming all exclusive cores without specifying STP_SOCKET_ID"
+n=3 CPU=1000m STP_SOCKET_ID="" EXCLCORES=1 create cmk-exclusive
+verify 'len(cores["pod5c0"]) == 1' \
+       'len(cores["pod6c0"]) == 1' \
+       'len(cores["pod7c0"]) == 1' \
+       'disjoint_sets(cores["pod5c0"], cores["pod6c0"], cores["pod7c0"])' \
+       'set.union(cores["pod5c0"], cores["pod6c0"], cores["pod7c0"]) == exclusive_cores'

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test02-pods-without-cmk/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test02-pods-without-cmk/code.var.sh
@@ -1,0 +1,35 @@
+# Test that normal pods/containers scheduled on a CMK node
+# are running in the shared pool, yet there are not as many
+# CPUs as required.
+
+cri_resmgr_cfg="$TEST_DIR/../cri-resmgr-static-pools.cfg" static-pools-relaunch-cri-resmgr
+
+out ""
+out "### Creating a guaranteed pod, 1 CPU, goes to the shared bool"
+CPU=1 create cmk-tolerating-guaranteed
+report allowed
+verify 'cores["pod0c0"].issubset(shared_cores)'
+
+out ""
+out "### Creating next guaranteed pod, 2 CPUs, goes to the shared pool"
+CPU=2 create cmk-tolerating-guaranteed
+report allowed
+verify 'cores["pod0c0"].issubset(shared_cores)' \
+       'cores["pod1c0"].issubset(shared_cores)'
+
+out ""
+out "### Creating next guaranteed pod, 4 CPUs, goes to the shared pool"
+CPU=4 create cmk-tolerating-guaranteed
+report allowed
+verify 'cores["pod0c0"].issubset(shared_cores)' \
+       'cores["pod1c0"].issubset(shared_cores)' \
+       'cores["pod2c0"].issubset(shared_cores)'
+
+out ""
+out "### Creating next guaranteed pod, 8 CPUs, goes to the shared pool"
+CPU=6 create cmk-tolerating-guaranteed
+report allowed
+verify 'cores["pod0c0"].issubset(shared_cores)' \
+       'cores["pod1c0"].issubset(shared_cores)' \
+       'cores["pod2c0"].issubset(shared_cores)' \
+       'cores["pod3c0"].issubset(shared_cores)'

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test03-cmk-isolate/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test03-cmk-isolate/code.var.sh
@@ -1,0 +1,61 @@
+# Test that legacy exclusive-cores containers
+# 1. run on exclusive cores
+# 2. are pinned according to "cmk isolate" command
+#    parameters
+# 3. run without "cmk" existing on the image
+# 3. all exclusive cores can be consumed
+
+# shellcheck disable=SC2148
+cri_resmgr_cfg="$TEST_DIR/../cri-resmgr-static-pools.cfg" static-pools-relaunch-cri-resmgr
+export STP_POOL="" STP_SOCKET_ID=""
+
+export CMK_ISOLATE=", '--conf-dir=/etc/cmk.conf', '--pool=exclusive', '--socket-id=1'"
+out ""
+out "### Creating pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES=1 CMDSPLIT="command_all" create cmk-isolate
+report allowed
+verify 'len(cores["pod0c0"]) == 1' \
+       'cores["pod0c0"].issubset(exclusive_cores)' \
+       'packages["pod0c0"] == {"package1"}'
+
+export CMK_ISOLATE=", '--socket-id=0', '--pool=exclusive'"
+out ""
+out "### Creating pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=2000m EXCLCORES=2 CMDSPLIT="command_cmk_sh" create cmk-isolate
+report allowed
+verify 'len(cores["pod1c0"]) == 2' \
+       'cores["pod1c0"].issubset(exclusive_cores)' \
+       'packages["pod1c0"] == {"package0"}'
+
+export CMK_ISOLATE=", '--pool=shared'"
+out ""
+out "### Creating pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES="" CMDSPLIT="command_cmk" create cmk-isolate
+report allowed
+verify 'cores["pod2c0"] == shared_cores'
+
+export CMDSPLIT="command_cmk"
+
+export CMK_ISOLATE=", '--conf-dir=/etc/cmk.conf', '--pool=infra'"
+out ""
+out "### Creating pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES="" create cmk-isolate
+report allowed
+verify 'cores["pod3c0"] == infra_cores'
+
+out ""
+out "### Deleting only exclusive CMK pods, leave shared/infra running"
+kubectl delete pods/pod0 pods/pod1 --now
+
+export CMK_ISOLATE=", '--pool=exclusive'"
+out ""
+out "### Creating 3 exclusive pods 'cmk', 'isolate'$CMK_ISOLATE..."
+n=3 CPU=1000m EXCLCORES=1 create cmk-isolate
+report allowed
+verify 'len(cores["pod4c0"]) == 1' \
+       'len(cores["pod5c0"]) == 1' \
+       'len(cores["pod6c0"]) == 1' \
+       'disjoint_sets(cores["pod4c0"], cores["pod5c0"], cores["pod6c0"])' \
+       'cores["pod4c0"].issubset(exclusive_cores)' \
+       'cores["pod5c0"].issubset(exclusive_cores)' \
+       'cores["pod6c0"].issubset(exclusive_cores)'

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test04-cmk-isolate-noaffinity/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test04-cmk-isolate-noaffinity/code.var.sh
@@ -1,0 +1,64 @@
+# Test that cmk isolate --no-affinity is effective on every pool
+# with and without STP_POOL / STP_SOCKET_ID env vars.
+# Test that all exclusive cores can be consumed with --no-affinity.
+
+# shellcheck disable=SC2148
+cri_resmgr_cfg="$TEST_DIR/../cri-resmgr-static-pools.cfg" static-pools-relaunch-cri-resmgr
+export STP_POOL="" STP_SOCKET_ID="" CMDSPLIT="command_all"
+export ECHO_VARS='CMK_CPUS_ASSIGNED="$CMK_CPUS_ASSIGNED" CMK_CPUS_SHARED="$CMK_CPUS_SHARED" CMK_CPUS_INFRA="$CMK_CPUS_INFRA"'
+
+export CMK_ISOLATE=", '--conf-dir=/etc/cmk.conf', '--pool=exclusive', '--socket-id=0', '--no-affinity'"
+out ""
+out "### Creating no-affinity pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES=1 create cmk-isolate
+report allowed
+verify 'len(cores["pod0c0"]) == 8'
+cpus_assigned="$(kubectl logs pod0 | tail -n 1 | awk '{print $2}')"
+cpus_shared="$(kubectl logs pod0 | tail -n 1 | awk '{print $3}')"
+cpus_infra="$(kubectl logs pod0 | tail -n 1 | awk '{print $4}')"
+[ "$cpus_assigned" == "CMK_CPUS_ASSIGNED=0,1" ] ||
+    error "expected CMK_CPUS_ASSIGNED=0,1, got $cpus_assigned"
+[ "$cpus_shared" == "CMK_CPUS_SHARED=4-6,7" ] ||
+    error "expected CMK_CPUS_SHARED=4-6,7, got $cpus_shared"
+[ "$cpus_infra" == "CMK_CPUS_INFRA=10-15" ] ||
+    error "expected CMK_CPUS_INFRA=10-15, got $cpus_infra"
+
+export CMK_ISOLATE=", '--conf-dir=/etc/cmk.conf', '--pool=exclusive', '--socket-id=1', '--no-affinity'"
+out ""
+out "### Creating no-affinity pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES=1 STP_POOL="exclusive" STP_SOCKET_ID="1" create cmk-isolate
+report allowed
+verify 'len(cores["pod1c0"]) == 8'
+cpus_assigned="$(kubectl logs pod1 | tail -n 1 | awk '{print $2}')"
+[ "$cpus_assigned" == "CMK_CPUS_ASSIGNED=8,9" ] ||
+    error "expected CMK_CPUS_ASSIGNED=8,9, got $cpus_assigned"
+
+export CMK_ISOLATE=", '--conf-dir=/etc/cmk.conf', '--pool=exclusive', '--no-affinity'"
+out ""
+out "### Creating no-affinity pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES=1 STP_POOL="exclusive" create cmk-isolate
+report allowed
+verify 'len(cores["pod2c0"]) == 8'
+cpus_assigned="$(kubectl logs pod2 | tail -n 1 | awk '{print $2}')"
+[ "$cpus_assigned" == "CMK_CPUS_ASSIGNED=2,3" ] ||
+    error "expected CMK_CPUS_ASSIGNED=2,3, got $cpus_assigned"
+
+export CMK_ISOLATE=", '--no-affinity', '--pool=shared'"
+out ""
+out "### Creating no-affinity pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES="" create cmk-isolate
+report allowed
+verify 'len(cores["pod3c0"]) == 8'
+cpus_assigned="$(kubectl logs pod3 | tail -n 1 | awk '{print $2}')"
+[ "$cpus_assigned" == "CMK_CPUS_ASSIGNED=4-6,7" ] ||
+    error "expected CMK_CPUS_ASSIGNED=5-6,7, got $cpus_assigned"
+
+export CMK_ISOLATE=", '--pool=infra', '--no-affinity'"
+out ""
+out "### Creating no-affinity pod 'cmk', 'isolate'$CMK_ISOLATE..."
+CPU=1000m EXCLCORES="" create cmk-isolate
+report allowed
+verify 'len(cores["pod4c0"]) == 8'
+cpus_assigned="$(kubectl logs pod4 | tail -n 1 | awk '{print $2}')"
+[ "$cpus_assigned" == "CMK_CPUS_ASSIGNED=10-15" ] ||
+    error "expected CMK_CPUS_ASSIGNED=10-15 got $cpus_assigned"

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test05-negative-tests/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test05-negative-tests/code.var.sh
@@ -1,0 +1,68 @@
+
+# shellcheck disable=SC2148
+cri_resmgr_cfg="$TEST_DIR/../cri-resmgr-static-pools.cfg" static-pools-relaunch-cri-resmgr
+export STP_POOL=exclusive
+
+errmsg_zero_cores="static-pools: exclusive pool specified but the number of exclusive CPUs requested is 0"
+errmsg_non_existing_pool="static-pools: non-existent pool"
+errmsg_not_enough_exclcores="static-pools: not enough free cpu lists"
+
+out ""
+out "### Request cores from non-existing pool"
+( CPU=1000m STP_SOCKET_ID=0 EXCLCORES=1 STP_POOL=elusive wait_t=5s create cmk-exclusive )  &&
+    error "expected timeout, but pod launched with cores from non-existing pool"
+vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_non_existing_pool'" ||
+    error "cannot find expected error message from pod description"
+out "Failed as expected"
+
+kubectl delete pods --all --now || error "failed to delete pods"
+
+out ""
+out "### Request cores from non-existing socket"
+( CPU=1000m STP_SOCKET_ID=2 EXCLCORES=1 wait_t=5s create cmk-exclusive )  &&
+    error "expected timeout, but pod launched with cores from non-existing socket"
+vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_not_enough_exclcores'" ||
+    error "cannot find expected error message from pod description"
+out "Failed as expected"
+
+kubectl delete pods --all --now || error "failed to delete pods"
+
+out ""
+out "### Request exclusive pool but do not mention exclusive-cores"
+( CPU=1000m STP_SOCKET_ID=0 EXCLCORES='omit' wait_t=5s create cmk-exclusive )  &&
+    error "expected timeout, but pod launched without mentioning exclusive cores from the exclusive pool"
+vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_zero_cores'" ||
+    error "cannot find expected error message from pod description"
+out "Failed as expected"
+
+kubectl delete pods --all --now || error "failed to delete pods"
+
+out ""
+out "### Request 0 cores from exclusive pool"
+( CPU=1000m STP_SOCKET_ID=0 EXCLCORES=0 wait_t=5s create cmk-exclusive )  &&
+    error "expected timeout, but pod launched with 0 cores from the exclusive pool"
+vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_zero_cores'" ||
+    error "cannot find expected error message from pod description"
+out "Failed as expected"
+
+kubectl delete pods --all --now || error "failed to delete pods"
+
+out ""
+out "### Request more cores from socket 0 than available"
+( CPU=3000m STP_SOCKET_ID=0 EXCLCORES=3 wait_t=5s create cmk-exclusive ) &&
+    error "expected timeout, but pod got too many cores successfully"
+vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_not_enough_exclcores'" ||
+    error "cannot find expected error message from pod description"
+out "Failed as expected"
+
+kubectl delete pods --all --now || error "failed to delete pods"
+
+out ""
+out "### Request more cores from socket 1 than available"
+( CPU=1000m STP_SOCKET_ID=1 EXCLCORES=2 wait_t=5s create cmk-exclusive ) &&
+    error "expected timeout, but pod got too many cores successfully"
+vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_not_enough_exclcores'" ||
+    error "cannot find expected error message from pod description"
+out "Failed as expected"
+
+kubectl delete pods --all --now || error "failed to delete pods"

--- a/test/e2e/policies.test-suite/static-pools/n4c16/topology.var.json
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "packages": 2}
+]

--- a/test/e2e/policies.test-suite/static-pools/n4c16/vm-files/etc/cmk/pools.conf
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/vm-files/etc/cmk/pools.conf
@@ -1,0 +1,20 @@
+pools:
+  exclusive:
+    cpuLists:
+    - Cpuset: 8,9
+      Socket: 1
+    - Cpuset: 0,1
+      Socket: 0
+    - Cpuset: 2,3
+      Socket: 0
+    exclusive: true
+  shared:
+    cpuLists:
+    - Cpuset: 4-6,7
+      Socket: 0
+    exclusive: false
+  infra:
+    cpuLists:
+    - Cpuset: 10-15
+      Socket: 1
+    exclusive: false

--- a/test/e2e/policies.test-suite/static-pools/static-pools-lib.source.sh
+++ b/test/e2e/policies.test-suite/static-pools/static-pools-lib.source.sh
@@ -1,0 +1,25 @@
+# shellcheck disable=SC2148
+static-pools-relaunch-cri-resmgr() {
+    local webhook_running=0
+    out "# Relaunching cri-resmgr and agent, launch webhook if not already running"
+
+    vm-command-q "kubectl get mutatingwebhookconfiguration/cri-resmgr" >& /dev/null && {
+        webhook_running=1
+    }
+    # cleanup
+    terminate cri-resmgr
+    terminate cri-resmgr-agent
+    vm-command "rm -rf /var/lib/cri-resmgr"
+    extended-resources remove cmk.intel.com/exclusive-cpus >/dev/null
+
+    # launch again
+    launch cri-resmgr-agent
+    launch cri-resmgr
+    vm-run-until "! kubectl get node | grep NotReady" ||
+        error "kubectl node is NotReady after launching cri-resmgr-agent and cri-resmgr"
+    if [ "$webhook_running" == 0 ]; then
+        vm-command-q "[ -f webhook/webhook-deployment.yaml ]" ||
+            install cri-resmgr-webhook
+        launch cri-resmgr-webhook
+    fi
+}


### PR DESCRIPTION
Opening the first static-pools tests patch for comments & discussion:
- What would be the minimum features that you'd like to see tested as part of this commit?
- Do you see major issues with the test structure? For instance, unlike in memtier tests, here cri-resmgr, agent and webhook are restarted before every test execution.