### PR TITLE
e2e,demo: check SSH key in/load SSH key to agent.

### DIFF
--- a/demo/lib/command.bash
+++ b/demo/lib/command.bash
@@ -10,6 +10,10 @@
 # command-start and command-end set environment variables:
 # COMMAND, COMMAND_STATUS, COMMAND_OUTPUT
 
+# These exports force ssh-* to fail instead of prompting for a passphrase.
+export DISPLAY=bogus-none
+export SSH_ASKPASS=/bin/false
+SSH_KEY="${HOME}/.ssh/id_rsa"
 SSH_OPTS="-o StrictHostKeyChecking=No"
 SSH="ssh $SSH_OPTS"
 SCP="scp $SSH_OPTS"

--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -197,3 +197,12 @@ host-delete-vm() {
         command-error "deleting govm \"$VM_NAME\" failed"
     }
 }
+
+host-is-encrypted-ssh-key() {
+    ssh-keygen -y -f "$1" < /dev/null >& /dev/null
+    if [ $? != 0 ]; then
+        return 0
+    else
+        return 1
+    fi
+}


### PR DESCRIPTION
During the environment check, in addition to checking the mere existence of a stock SSH public key
  - check if the corresponding private key is loaded to the agent,
  - try loading it if it is not loaded yet,
  - give up with an error message instructing the user what to do, if loading the key fails

Without this patch, if an encrypted/password-protected key is not loaded to the agent yet, the test
framework just sits in a loop forever, waiting for ssh'ing to the VM to eventually succeed, without
giving the user an indication about the real problem.