### PR TITLE
static-pools: drop all cmdline flags

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static-pools/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/flags.go
@@ -15,57 +15,35 @@
 package stp
 
 import (
-	"flag"
 	"github.com/intel/cri-resource-manager/pkg/config"
 )
-
-// CRI resource manager command line options related to STP policy
-type options struct {
-	confFile        string
-	confDir         string
-	createNodeLabel bool
-	createNodeTaint bool
-}
 
 // conf captures our runtime configurable parameters.
 type conf struct {
 	// Pools defines our set of pools in use.
 	Pools map[string]poolConfig `json:"pools,omitempty"`
+	// ConfDirPath is the filesystem path to the legacy configuration directry structure.
+	ConfDirPath string
+	// ConfFilePath is the filesystem path to the legacy configuration file.
+	ConfFilePath string
 	// LabelNode controls whether backwards-compatible CMK node label is created.
 	LabelNode bool
 	// TaintNode controls whether backwards-compatible CMK node taint is created.
 	TaintNode bool
 }
 
-// STP policy command line options and runtime configuration with their defaults.
-var opt = defaultOptions().(*options)
+// STP policy runtime configuration with their defaults.
 var cfg = defaultConfig().(*conf)
-
-// defaultOptions returns a new options instance, all initialized to defaults.
-func defaultOptions() interface{} {
-	return &options{
-		confFile:        "",
-		confDir:         "/etc/cmk",
-		createNodeLabel: defaultConfig().(*conf).LabelNode,
-		createNodeTaint: defaultConfig().(*conf).TaintNode,
-	}
-}
 
 // defaultConfig returns a new conf instance, all initialized to defaults.
 func defaultConfig() interface{} {
 	return &conf{
-		Pools:     make(map[string]poolConfig),
-		LabelNode: false,
-		TaintNode: false,
+		Pools:       make(map[string]poolConfig),
+		ConfDirPath: "/etc/cmk",
 	}
 }
 
 // Register us for command line option processing and configuration management.
 func init() {
-	flag.StringVar(&opt.confFile, "static-pools-conf-file", "", "STP pool configuration file")
-	flag.StringVar(&opt.confDir, "static-pools-conf-dir", "/etc/cmk", "STP pool configuration directory")
-	flag.BoolVar(&opt.createNodeLabel, "static-pools-create-cmk-node-label", false, "Create CMK-related node label for backwards compatibility")
-	flag.BoolVar(&opt.createNodeTaint, "static-pools-create-cmk-node-taint", false, "Create CMK-related node taint for backwards compatibility")
-
 	config.Register(PolicyPath, PolicyDescription, cfg, defaultConfig)
 }

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/node.go
@@ -50,7 +50,7 @@ func (stp *stp) updateNode(conf conf) error {
 	}
 
 	// Manage legacy node label
-	if opt.createNodeLabel {
+	if conf.LabelNode {
 		stp.Info("creating CMK node label")
 		err := stp.agent.SetLabels(map[string]string{cmkLegacyNodeLabelName: "true"}, -1)
 		if err != nil {
@@ -77,12 +77,12 @@ func (stp *stp) updateNode(conf conf) error {
 	cmkTaints := []core_v1.Taint{legacyTaint}
 	_, tainted := stp.agent.FindTaintIndex(nodeTaints, &legacyTaint)
 
-	if !tainted && opt.createNodeTaint {
+	if !tainted && conf.TaintNode {
 		if err := stp.agent.SetTaints(cmkTaints, -1); err != nil {
 			return stpError("failed to set legacy node taint: %v", err)
 		}
 	}
-	if tainted && !opt.createNodeTaint {
+	if tainted && !conf.TaintNode {
 		if err := stp.agent.RemoveTaints(cmkTaints, -1); err != nil {
 			return stpError("failed to clear legacy node taint: %v", err)
 		}

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -92,17 +92,18 @@ func CreateStpPolicy(opts *policy.BackendOptions) policy.Backend {
 	stp.Info("creating policy...")
 
 	// Read STP configuration
-	if len(opt.confDir) > 0 {
-		stp.conf, err = readConfDir(opt.confDir)
+	if len(cfg.ConfDirPath) > 0 {
+		stp.conf, err = readConfDir(cfg.ConfDirPath)
 		if err != nil {
 			stp.Warn("failed to read configuration directory: %v", err)
 		}
 	}
-	if len(opt.confFile) > 0 {
+	if len(cfg.ConfFilePath) > 0 {
 		if stp.conf != nil {
-			stp.Info("Overriding configuration from -static-pools-conf-dir with -static-pools-conf-file")
+			stp.Info("Overriding configuration from %q with configuration from %q",
+				cfg.ConfDirPath, cfg.ConfFilePath)
 		}
-		stp.conf, err = readConfFile(opt.confFile)
+		stp.conf, err = readConfFile(cfg.ConfFilePath)
 		if err != nil {
 			stp.Warn("failed to read configuration directory: %v", err)
 		}
@@ -280,8 +281,6 @@ func (stp *stp) configNotify(event config.Event, source config.Source) error {
 		return err
 	}
 
-	opt.createNodeLabel = cfg.LabelNode
-	opt.createNodeTaint = cfg.TaintNode
 	stp.conf = cfg
 	stp.Info("config updated successfully")
 	stp.Debug("new policy configuration:\n%s", utils.DumpJSON(stp.conf))

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -31,8 +31,17 @@ data:
     static:
       RelaxedIsolation: true
     static-pools:
-      # This is an example configuration for static-pools policy.
-      # The imaginary example system here consists of 4 sockets, 4 cores, 2 threads each.
+      # Filesystem path to legacy configuration directory structure
+      ConfDirPath: "/etc/cmk"
+      # Filesystem path to legacy configuration file
+      ConfFilePath: ""
+      # Whether to create CMK node label
+      LabelNode: false
+      # Whether to create CMK node taint
+      TaintNode: false
+      # Pool configuration.
+      # The imaginary example system below consists of 4 sockets, 4 cores, 2
+      # threads each.
       pools:
         exclusive:
           # 6 exclusive cores, 3 on sockets 1, 2 and 3 each


### PR DESCRIPTION
Drop all command line flags specific to the static-pools policy. Add new
configuration options for legacy pool config filesystem paths.

After this patch all settings are taken from the configuration system,
making configuration simpler to maintain and understand.

Add examples of all config options to the sample configmap.