### PR TITLE
static-pools: take only pools from legacy config

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static-pools/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/flags.go
@@ -21,7 +21,7 @@ import (
 // conf captures our runtime configurable parameters.
 type conf struct {
 	// Pools defines our set of pools in use.
-	Pools map[string]poolConfig `json:"pools,omitempty"`
+	Pools pools `json:"pools,omitempty"`
 	// ConfDirPath is the filesystem path to the legacy configuration directry structure.
 	ConfDirPath string
 	// ConfFilePath is the filesystem path to the legacy configuration file.
@@ -38,7 +38,7 @@ var cfg = defaultConfig().(*conf)
 // defaultConfig returns a new conf instance, all initialized to defaults.
 func defaultConfig() interface{} {
 	return &conf{
-		Pools:       make(map[string]poolConfig),
+		Pools:       make(pools),
 		ConfDirPath: "/etc/cmk",
 	}
 }

--- a/sample-configs/static-pools-policy.conf.example
+++ b/sample-configs/static-pools-policy.conf.example
@@ -1,6 +1,9 @@
 # This is an example configuration file for the builtin cmk policy
 # The imaginary example system here consists of 4 sockets, 4 cores (8
 # multithreaded CPUs)
+#
+# NOTE: only pools configuration may be specified in this file. Other
+# configuration options must be set through the dynamic configration system
 pools:
   exclusive:
     # 6 exclusive cores, 3 on sockets 1, 2 and 3 each


### PR DESCRIPTION
When reading legacy config (dir or file) from the filesystem only change
the pools in the active configuration. Do not override other config
options which are specified via the dynamic configuration system.

Based on top of #475 