### PR TITLE
static-pools: re-load legacy config on config update

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -90,33 +90,7 @@ func CreateStpPolicy(opts *policy.BackendOptions) policy.Backend {
 
 	stp.Info("creating policy...")
 
-	// Read legacy pools configuration
-	if len(cfg.ConfDirPath) > 0 {
-		p, err := readConfDir(cfg.ConfDirPath)
-		if err != nil {
-			stp.Warn("failed to read configuration directory: %v", err)
-		} else {
-			cfg.Pools = p
-		}
-	}
-	if len(cfg.ConfFilePath) > 0 {
-		p, err := readConfFile(cfg.ConfFilePath)
-		if err != nil {
-			stp.Warn("failed to read configuration file: %v", err)
-		} else {
-			if cfg.Pools != nil || len(cfg.Pools) > 0 {
-				stp.Info("Overriding pool configuration from %q with configuration from %q",
-					cfg.ConfDirPath, cfg.ConfFilePath)
-			}
-			cfg.Pools = p
-		}
-	}
-
-	stp.conf = cfg
-
 	config.GetModule(PolicyPath).AddNotify(stp.configNotify)
-
-	stp.DebugBlock("  configuration ", "%s", utils.DumpJSON(stp.conf))
 
 	return stp
 }
@@ -133,14 +107,13 @@ func (stp *stp) Description() string {
 
 // Start prepares this policy for accepting allocation/release requests.
 func (stp *stp) Start(add []cache.Container, del []cache.Container) error {
-	var err error
-
 	if stp.conf == nil {
-		return stpError("cannot start without any configuration")
+		if err := stp.setConfig(cfg); err != nil {
+			return err
+		}
 	}
 
-	err = stp.updateNode(*stp.conf)
-	if err != nil {
+	if err := stp.updateNode(*stp.conf); err != nil {
 		stp.Fatal("%v", err)
 	}
 
@@ -149,7 +122,7 @@ func (stp *stp) Start(add []cache.Container, del []cache.Container) error {
 	}
 	stp.Debug("retrieved stp container states from cache:\n%s", utils.DumpJSON(*stp.getContainerRegistry()))
 
-	if err = stp.Sync(add, del); err != nil {
+	if err := stp.Sync(add, del); err != nil {
 		return err
 	}
 
@@ -282,13 +255,48 @@ func (stp *stp) Introspect(*introspect.State) {
 func (stp *stp) configNotify(event config.Event, source config.Source) error {
 	stp.Info("configuration %s", event)
 
+	if err := stp.setConfig(cfg); err != nil {
+		return err
+	}
+
+	stp.Info("config updated successfully")
+
+	return nil
+}
+
+func (stp *stp) setConfig(cfg *conf) error {
+	// Read legacy pools configuration if the given config has no pools configured
+	if cfg.Pools == nil || len(cfg.Pools) == 0 {
+		if len(cfg.ConfDirPath) > 0 {
+			stp.Debug("Reading legacy configuration directory tree %q", cfg.ConfDirPath)
+			p, err := readConfDir(cfg.ConfDirPath)
+			if err != nil {
+				stp.Warn("failed to read configuration directory: %v", err)
+			} else {
+				cfg.Pools = p
+			}
+		}
+		if len(cfg.ConfFilePath) > 0 {
+			stp.Debug("Reading legacy configuration file %q", cfg.ConfFilePath)
+			p, err := readConfFile(cfg.ConfFilePath)
+			if err != nil {
+				stp.Warn("failed to read configuration file: %v", err)
+			} else {
+				if cfg.Pools != nil || len(cfg.Pools) > 0 {
+					stp.Info("Overriding pool configuration from %q with configuration from %q",
+						cfg.ConfDirPath, cfg.ConfFilePath)
+				}
+				cfg.Pools = p
+			}
+		}
+	}
+
 	if err := stp.verifyConfig(cfg); err != nil {
 		return err
 	}
 
 	stp.conf = cfg
-	stp.Info("config updated successfully")
-	stp.Debug("new policy configuration:\n%s", utils.DumpJSON(stp.conf))
+	stp.Debug("policy configuration:\n%s", utils.DumpJSON(stp.conf))
 
 	return nil
 }


### PR DESCRIPTION
Change the handling of pools configuration.

First, respect the legacy config path (ConfDirPath, ConfFilePath)
specified in the dynamic configuration. If these settings change we
try to (re-)load the legacy config from the given location.

Second, the pools config priority should now be more consistent and
evident. The priority in descending order is:
1. dynamic configuration
2. leagcy config file
3. legacy config directory structure