### PR TITLE
e2e: fix vm-pipe-to-file

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -370,7 +370,7 @@ vm-pipe-to-file() { # script API
         shift
     fi
     cat > "$tmp"
-    vm-put-file --cleanup "$append" "$tmp" "$1"
+    vm-put-file --cleanup $append "$tmp" "$1"
 }
 
 vm-sed-file() { # script API


### PR DESCRIPTION
Fixes regression caused by double-quoting `$append` in commit a60565a69b4a2e548198a699cdbe63bd069b6ab2.

This causes failing proxy env setup when setting up new VM.