### PR TITLE
e2e: faster ssh/scp by multiplexing socket

### DIFF
--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -165,6 +165,13 @@ host-wait-vm-ssh-server() {
     done
     echo "# VM SSH server  : ssh $VM_SSH_USER@$VM_IP"
 
+    if [ -d "$HOME/vms/data/$VM_NAME" ]; then
+        SSH_OPTS="$SSH_OPTS -o ControlMaster=auto -o ControlPath=$HOME/vms/data/$VM_NAME/ssh -o ControlPersist=30"
+        SSH="${SSH%% *} $SSH_OPTS"
+        SCP="${SCP%% *} $SSH_OPTS"
+        export SSH SSH_OPTS SCP
+    fi
+
     ssh-keygen -f "$HOME/.ssh/known_hosts" -R "$VM_IP" >/dev/null 2>&1
     retries=60
     retries_left=$retries

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -411,7 +411,7 @@ launch() { # script API
     target="$1"
     case $target in
         "cri-resmgr")
-            host-command "scp \"$cri_resmgr_cfg\" $VM_SSH_USER@$VM_IP:" || {
+            host-command "$SCP \"$cri_resmgr_cfg\" $VM_SSH_USER@$VM_IP:" || {
                 command-error "copying \"$cri_resmgr_cfg\" to VM failed"
             }
             vm-command "cat $(basename "$cri_resmgr_cfg")"
@@ -425,7 +425,7 @@ launch() { # script API
             }
             ;;
         "cri-resmgr-systemd")
-            host-command "scp \"$cri_resmgr_cfg\" $VM_SSH_USER@$VM_IP:" || {
+            host-command "$SCP \"$cri_resmgr_cfg\" $VM_SSH_USER@$VM_IP:" || {
                 command-error "copying \"$cri_resmgr_cfg\" to VM failed"
             }
             vm-command "cp \"$(basename "$cri_resmgr_cfg")\" /etc/cri-resmgr/fallback.cfg"
@@ -693,7 +693,7 @@ create() { # script API
         kind_count[$template_kind]=$(( ${kind_count[$template_kind]} + 1 ))
         local NAME="${template_kind}$(( ${kind_count[$template_kind]} - 1 ))" # the first pod is pod0
         eval "echo -e \"$(<"${template_file}")\"" | grep -v '^ *$' > "$OUTPUT_DIR/$NAME.yaml"
-        host-command "scp \"$OUTPUT_DIR/$NAME.yaml\" $VM_SSH_USER@$VM_IP:" || {
+        host-command "$SCP \"$OUTPUT_DIR/$NAME.yaml\" $VM_SSH_USER@$VM_IP:" || {
             command-error "copying \"$OUTPUT_DIR/$NAME.yaml\" to VM failed"
         }
         vm-command "cat $NAME.yaml"
@@ -973,7 +973,7 @@ else
 fi
 
 # Save logs
-host-command "scp $VM_SSH_USER@$VM_IP:cri-resmgr.output.txt \"$OUTPUT_DIR/\""
+host-command "$SCP $VM_SSH_USER@$VM_IP:cri-resmgr.output.txt \"$OUTPUT_DIR/\""
 
 # Cleanup
 if [ "$cleanup" == "0" ]; then


### PR DESCRIPTION
Benchmark results:

```
time distro=debian-sid code="exit 0" ./run_test.sh test
original: 5.8 s
fast ssh: 3.8 s

time distro=debian-sid code="vm-install-cri-resmgr-webhook" ./run_test.sh test
original: 23 s
fast ssh: 15 s
```
(The latter with PR #465 .)