### PR TITLE
cross-build: don't ignore useradd errors, pass options as such.

### DIFF
--- a/dockerfiles/cross-build/Dockerfile.centos-7
+++ b/dockerfiles/cross-build/Dockerfile.centos-7
@@ -39,4 +39,4 @@ RUN mkdir /git && cd /git && wget $GIT_URLDIR/v$GIT_VERSION.tar.gz && \
     make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr install
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.centos-8
+++ b/dockerfiles/cross-build/Dockerfile.centos-8
@@ -28,4 +28,4 @@ RUN arch="$(rpm --eval %{_arch})"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.debian-10
+++ b/dockerfiles/cross-build/Dockerfile.debian-10
@@ -31,4 +31,4 @@ RUN arch="$(dpkg --print-architecture)"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.debian-sid
+++ b/dockerfiles/cross-build/Dockerfile.debian-sid
@@ -31,4 +31,4 @@ RUN arch="$(dpkg --print-architecture)"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -28,4 +28,4 @@ RUN arch="$(rpm --eval %{_arch})"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.suse-15.1
+++ b/dockerfiles/cross-build/Dockerfile.suse-15.1
@@ -29,4 +29,4 @@ RUN arch="$(rpm --eval %{_arch})"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.suse-15.2
+++ b/dockerfiles/cross-build/Dockerfile.suse-15.2
@@ -29,4 +29,4 @@ RUN arch="$(rpm --eval %{_arch})"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
@@ -31,4 +31,4 @@ RUN arch="$(dpkg --print-architecture)"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
@@ -32,4 +32,4 @@ RUN arch="$(dpkg --print-architecture)"; \
     go version
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
-    useradd -m -s /bin/bash $CREATE_USER $(echo $USER_OPTIONS | sed 's/__/ /g') || :
+    useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/scripts/build/docker-build-image
+++ b/scripts/build/docker-build-image
@@ -37,7 +37,7 @@ echo "  - options   : " "${PASSTHROUGH[@]}"
 docker build . \
        -f "$DOCKERFILE" -t "$IMAGE" \
        --build-arg "CREATE_USER=$USER" \
-       --build-arg USER_OPTIONS="-u__$(id -u)" \
+       --build-arg USER_OPTIONS="-u $(id -u)" \
        "${PASSTHROUGH[@]}" || exit 1
 
 if [ -n "$CONTAINER" ]; then


### PR DESCRIPTION
When building cross-build container images or cross-building packages
  - don't ignore errors from useradd
  - pass uid option to useradd without extra sed-trickery
