### PR TITLE
e2e: fix handling many matching containers in topology reporting

### DIFF
--- a/demo/lib/topology.py
+++ b/demo/lib/topology.py
@@ -54,7 +54,7 @@ import sys
 
 _bash_topology_dump = """for cpu in /sys/devices/system/cpu/cpu[0-9]*; do cpu_id=${cpu#/sys/devices/system/cpu/cpu}; echo "cpu p:$(< ${cpu}/topology/physical_package_id) d:$(< ${cpu}/topology/die_id) n:$(basename  ${cpu}/node* | sed 's:node::g') c:$(< ${cpu}/topology/core_id) t:$(< ${cpu}/topology/thread_siblings) cpu:${cpu_id}" ; done;  for node in /sys/devices/system/node/node[0-9]*; do node_id=${node#/sys/devices/system/node/node}; echo "dist n:$node_id d:$(< $node/distance)"; echo "mem n:$node_id s:$(awk '/MemTotal/{print $4/1024}' < $node/meminfo)"; done"""
 
-_bash_res_allowed = r"""for process in '%s'; do for pid in $(pgrep -f $process); do name=$(cat /proc/$pid/cmdline | tr '\0 ' '\n' | grep -E "^$process"); [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ] && echo "${name}/${pid} $(awk '/Cpus_allowed:/{c=$2}/Mems_allowed:/{m=$2}END{print "c:"c" m:"m}' < /proc/$pid/status)"; done; done"""
+_bash_res_allowed = r"""for process in '%s'; do for pid in $(pgrep -f $process); do name=$(cat /proc/$pid/cmdline | tr '\0 ' '\n' | grep -E "^$process" | head -n 1); [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ] && echo "${name}/${pid} $(awk '/Cpus_allowed:/{c=$2}/Mems_allowed:/{m=$2}END{print "c:"c" m:"m}' < /proc/$pid/status)"; done; done"""
 
 def error(msg, exit_status=1):
     """Print error message and exit."""


### PR DESCRIPTION
If there happened to be multiple podXcY's in cmdline, reporting resources allowed for the pid broke up. We're happy with just the first match.