### PR TITLE
e2e: fix setting up debug environment to debian-sid vm

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -138,6 +138,8 @@ screen-install-cri-resmgr() {
 screen-install-cri-resmgr-debugging() {
     speed=60 out "### Installing cri-resmgr debugging enablers"
     vm-install-golang
+    vm-install-pkg git
+    vm-install-pkg rsync
     vm-command "go get github.com/go-delve/delve/cmd/dlv" || {
         command-error "installing delve failed"
     }


### PR DESCRIPTION
- vm=VM_NAME test/e2e/run.sh debug
  fixed to work with vm's created with distro=debian-sid