### PR TITLE
e2e: catch last cri-resmgr output line if process disappeared

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -468,6 +468,8 @@ launch() { # script API
                 command-error "launching cri-resmgr failed with FATAL ERROR"
             }
             vm-command "pidof cri-resmgr" >/dev/null 2>&1 || {
+                echo "cri-resmgr last output line:"
+                vm-command-q "tail -n 1 cri-resmgr.output.txt"
                 command-error "launching cri-resmgr failed, cannot find cri-resmgr PID"
             }
             ;;


### PR DESCRIPTION
This helped catching cri-resmgr config errors that blocked launching it, as they did not appear as FATAL ERRORs in the output. The latter are already catched right above this addition in the code.