### PR TITLE
memtier: honor allowed CPUs in resource discovery.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/node.go
@@ -451,7 +451,7 @@ func (n *numanode) GetPhysicalNodeIDs() []system.ID {
 func (n *numanode) DiscoverSupply() Supply {
 	log.Debug("discovering CPU available at node %s...", n.Name())
 
-	noderes := n.sysnode.CPUSet()
+	noderes := n.sysnode.CPUSet().Intersection(n.policy.allowed)
 	meminfo, err := n.sysnode.MemoryInfo()
 	if err != nil {
 		log.Error("Couldn't get memory info for node %s", n.Name())
@@ -595,7 +595,7 @@ func (n *dienode) DiscoverSupply() Supply {
 				log.Error("node has an unknown memory type/combination")
 			}
 		}
-		diecpus := n.syspkg.DieCPUSet(n.id)
+		diecpus := n.syspkg.DieCPUSet(n.id).Intersection(n.policy.allowed)
 		isolated := diecpus.Intersection(n.policy.isolated)
 		sharable := diecpus.Difference(isolated)
 		n.noderes = newSupply(n, isolated, sharable, 0, mem, createMemoryMap(0, 0, 0))
@@ -714,7 +714,7 @@ func (n *socketnode) DiscoverSupply() Supply {
 				log.Error("node has an unknown memory type/combination")
 			}
 		}
-		sockcpus := n.syspkg.CPUSet()
+		sockcpus := n.syspkg.CPUSet().Intersection(n.policy.allowed)
 		isolated := sockcpus.Intersection(n.policy.isolated)
 		sharable := sockcpus.Difference(isolated)
 		n.noderes = newSupply(n, isolated, sharable, 0, mem, createMemoryMap(0, 0, 0))

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
@@ -404,6 +404,7 @@ func TestPoolCreation(t *testing.T) {
 				sys:   sys,
 				cache: &mockCache{},
 			}
+			policy.allowed = policy.sys.CPUSet().Difference(policy.sys.Offlined())
 
 			err = policy.buildPoolsByTopology()
 			if err != nil {
@@ -486,11 +487,12 @@ func TestWorkloadPlacement(t *testing.T) {
 			path: path.Join(dir, "sysfs", "server", "sys"),
 			name: "workload placement on a server system leaf node",
 			req: &request{
-				memReq:    10000,
-				memLim:    10000,
-				memType:   memoryUnspec,
-				isolate:   false,
-				full:      27, // 28: fully exhaustin the shared CPU subpool is is disallowed
+				memReq:  10000,
+				memLim:  10000,
+				memType: memoryUnspec,
+				isolate: false,
+				full:    27, // 28: fully exhausting the shared CPU subpool is disallowed
+
 				container: &mockContainer{},
 			},
 			expectedRemainingNodes: []int{0, 1, 2, 3, 4, 5, 6},
@@ -536,6 +538,7 @@ func TestWorkloadPlacement(t *testing.T) {
 				sys:   sys,
 				cache: &mockCache{},
 			}
+			policy.allowed = policy.sys.CPUSet().Difference(policy.sys.Offlined())
 
 			err = policy.buildPoolsByTopology()
 			if err != nil {
@@ -689,6 +692,8 @@ func TestContainerMove(t *testing.T) {
 					grants: make(map[string]Grant),
 				},
 			}
+			policy.allowed = policy.sys.CPUSet().Difference(policy.sys.Offlined())
+
 			policy.allocations.policy = policy
 
 			err = policy.buildPoolsByTopology()
@@ -946,6 +951,7 @@ func TestAffinities(t *testing.T) {
 				sys:   sys,
 				cache: &mockCache{},
 			}
+			policy.allowed = policy.sys.CPUSet().Difference(policy.sys.Offlined())
 
 			err = policy.buildPoolsByTopology()
 			if err != nil {


### PR DESCRIPTION
If a cpuset is given among `AvailableResources`, use it as a bounding set during CPU resource discovery.