### PR TITLE
memtier: honor CPU isolation opt-out preference.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -462,7 +462,7 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 
 	// allocate isolated exclusive CPUs or slice them off the sharable set
 	switch {
-	case cr.full > 0 && cs.isolated.Size() >= cr.full:
+	case cr.full > 0 && cs.isolated.Size() >= cr.full && cr.isolate:
 		exclusive, err = cs.takeCPUs(&cs.isolated, nil, cr.full)
 		if err != nil {
 			return nil, policyError("internal error: "+
@@ -733,6 +733,9 @@ func newRequest(container cache.Container) Request {
 	full, fraction, isolate, elevate := cpuAllocationPreferences(pod, container)
 	req, lim, mtype := memoryAllocationPreference(pod, container)
 	coldStart := time.Duration(0)
+
+	log.Debug("%s: CPU preferences: full=%v, fraction=%v, isolate=%v",
+		container.PrettyName(), full, fraction, isolate)
 
 	if mtype == memoryUnspec {
 		mtype = defaultMemoryType


### PR DESCRIPTION
If a pod/container is annotated to opt out from isolated exclusive CPU allocation, or that is the configured memtier default and the pod/container is not annotated otherwise, honor this setting when allocating resources.