### PR TITLE
memtier: get rid of hand-rolled policy/pools in most of the test cases.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,8 +365,11 @@ ifndef WHAT
 	$(Q)$(GO_TEST) -race -coverprofile=coverage.txt -covermode=atomic \
 	    $(GO_MODULES)
 else
-	$(Q)cd $(WHAT) && \
-            $(GO_TEST) -v -cover -coverprofile cover.out || rc=1; \
+	$(Q)if [ -n '$(TESTS)' ]; then \
+	        run="-run $(TESTS)"; \
+	    fi; \
+	cd $(WHAT) && \
+            $(GO_TEST) $$run -v -cover -coverprofile cover.out || rc=1; \
             $(GO_CMD) tool cover -html=cover.out -o coverage.html; \
             rm cover.out; \
             echo "Coverage report: file://$$(realpath coverage.html)"; \

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -657,7 +657,7 @@ func (m *mockCache) EvaluateAffinity(*cache.Affinity) map[string]int32 {
 	}
 }
 func (m *mockCache) AddImplicitAffinities(map[string]*cache.ImplicitAffinity) error {
-	panic("unimplemented")
+	return nil
 }
 func (m *mockCache) GetActivePolicy() string {
 	panic("unimplemented")

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
@@ -693,21 +693,19 @@ func TestContainerMove(t *testing.T) {
 				panic(err)
 			}
 
-			policy := &policy{
-				sys:   sys,
-				cache: &mockCache{},
-				allocations: allocations{
-					grants: make(map[string]Grant),
+			reserved, _ := resapi.ParseQuantity("750m")
+			policyOptions := &policyapi.BackendOptions{
+				Cache:  &mockCache{},
+				System: sys,
+				Reserved: policyapi.ConstraintSet{
+					policyapi.DomainCPU: reserved,
 				},
 			}
-			policy.allowed = policy.sys.CPUSet().Difference(policy.sys.Offlined())
 
-			policy.allocations.policy = policy
+			log.EnableDebug(true)
+			policy := CreateMemtierPolicy(policyOptions).(*policy)
+			log.EnableDebug(false)
 
-			err = policy.buildPoolsByTopology()
-			if err != nil {
-				panic(err)
-			}
 			grant1, err := policy.allocatePool(tc.container1)
 			if err != nil {
 				panic(err)

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
@@ -953,16 +953,18 @@ func TestAffinities(t *testing.T) {
 				panic(err)
 			}
 
-			policy := &policy{
-				sys:   sys,
-				cache: &mockCache{},
+			reserved, _ := resapi.ParseQuantity("750m")
+			policyOptions := &policyapi.BackendOptions{
+				Cache:  &mockCache{},
+				System: sys,
+				Reserved: policyapi.ConstraintSet{
+					policyapi.DomainCPU: reserved,
+				},
 			}
-			policy.allowed = policy.sys.CPUSet().Difference(policy.sys.Offlined())
 
-			err = policy.buildPoolsByTopology()
-			if err != nil {
-				panic(err)
-			}
+			log.EnableDebug(true)
+			policy := CreateMemtierPolicy(policyOptions).(*policy)
+			log.EnableDebug(false)
 
 			affinities := map[int]int32{}
 			for name, weight := range tc.affinities {


### PR DESCRIPTION
Get rid of the most of the cases where tests hand-rolled policy/pools instead of using the official policy 'constructor' for this.