### PR TITLE
policy,memtier: better handling of bounding resource set for CPUs.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/coldstart_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/coldstart_test.go
@@ -103,7 +103,7 @@ func TestColdStart(t *testing.T) {
 				t.Errorf("failed to build topology pool")
 			}
 
-			grant, err := policy.allocatePool(tc.container)
+			grant, err := policy.allocatePool(tc.container, "")
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/coldstart_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/coldstart_test.go
@@ -94,7 +94,7 @@ func TestColdStart(t *testing.T) {
 				allocations: allocations{
 					grants: make(map[string]Grant, 0),
 				},
-				options: policyapi.BackendOptions{},
+				options: &policyapi.BackendOptions{},
 			}
 			policy.allocations.policy = policy
 			policy.options.SendEvent = sendEvent

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -465,7 +465,7 @@ func (p *policy) allocatePool(container cache.Container) (Grant, error) {
 }
 
 // Apply the result of allocation to the requesting container.
-func (p *policy) applyGrant(grant Grant) error {
+func (p *policy) applyGrant(grant Grant) {
 	log.Debug("* applying grant %s", grant)
 
 	container := grant.GetContainer()
@@ -527,18 +527,16 @@ func (p *policy) applyGrant(grant Grant) error {
 	} else {
 		log.Debug("  => not pinning memory, memory set is empty...")
 	}
-
-	return nil
 }
 
 // Release resources allocated by this grant.
-func (p *policy) releasePool(container cache.Container) (Grant, bool, error) {
+func (p *policy) releasePool(container cache.Container) (Grant, bool) {
 	log.Debug("* releasing resources allocated to %s", container.PrettyName())
 
 	grant, ok := p.allocations.grants[container.GetCacheID()]
 	if !ok {
 		log.Debug("  => no grant found, nothing to do...")
-		return nil, false, nil
+		return nil, false
 	}
 
 	log.Debug("  => releasing grant %s...", grant)
@@ -549,11 +547,11 @@ func (p *policy) releasePool(container cache.Container) (Grant, bool, error) {
 	delete(p.allocations.grants, container.GetCacheID())
 	p.saveAllocations()
 
-	return grant, true, nil
+	return grant, true
 }
 
 // Update shared allocations effected by agrant.
-func (p *policy) updateSharedAllocations(grant Grant) error {
+func (p *policy) updateSharedAllocations(grant Grant) {
 	log.Debug("* updating shared allocations affected by %s", grant)
 
 	for _, other := range p.allocations.grants {
@@ -580,8 +578,6 @@ func (p *policy) updateSharedAllocations(grant Grant) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 // setDemotionPreferences sets the dynamic demotion preferences a container.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -240,7 +240,7 @@ func (p *policy) checkHWTopology() error {
 }
 
 // Pick a pool and allocate resource from it to the container.
-func (p *policy) allocatePool(container cache.Container) (Grant, error) {
+func (p *policy) allocatePool(container cache.Container, poolHint string) (Grant, error) {
 	var pool Node
 
 	request := newRequest(container)
@@ -268,7 +268,22 @@ func (p *policy) allocatePool(container cache.Container) (Grant, error) {
 				container.PrettyName())
 		}
 
-		pool = pools[0]
+		if poolHint != "" {
+			for idx, p := range pools {
+				if p.Name() == poolHint {
+					log.Debug("* using hinted pool %q (#%d best fit)", poolHint, idx+1)
+					pool = p
+					break
+				}
+			}
+			if pool == nil {
+				log.Debug("* cannot use hinted pool %q", poolHint)
+			}
+		}
+
+		if pool == nil {
+			pool = pools[0]
+		}
 	}
 
 	supply := pool.FreeSupply()
@@ -551,12 +566,18 @@ func (p *policy) releasePool(container cache.Container) (Grant, bool) {
 }
 
 // Update shared allocations effected by agrant.
-func (p *policy) updateSharedAllocations(grant Grant) {
-	log.Debug("* updating shared allocations affected by %s", grant)
+func (p *policy) updateSharedAllocations(grant *Grant) {
+	if grant != nil {
+		log.Debug("* updating shared allocations affected by %s", (*grant).String())
+	} else {
+		log.Debug("* updating shared allocations")
+	}
 
 	for _, other := range p.allocations.grants {
-		if other.GetContainer().GetCacheID() == grant.GetContainer().GetCacheID() {
-			continue
+		if grant != nil {
+			if other.GetContainer().GetCacheID() == (*grant).GetContainer().GetCacheID() {
+				continue
+			}
 		}
 
 		if other.SharedPortion() == 0 && !other.ExclusiveCPUs().IsEmpty() {

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
@@ -706,19 +706,19 @@ func TestContainerMove(t *testing.T) {
 			policy := CreateMemtierPolicy(policyOptions).(*policy)
 			log.EnableDebug(false)
 
-			grant1, err := policy.allocatePool(tc.container1)
+			grant1, err := policy.allocatePool(tc.container1, "")
 			if err != nil {
 				panic(err)
 			}
 			fmt.Printf("grant 1 memsets: dram %s, pmem %s\n", grant1.GetMemoryNode().GetMemset(memoryDRAM), grant1.GetMemoryNode().GetMemset(memoryPMEM))
 
-			grant2, err := policy.allocatePool(tc.container2)
+			grant2, err := policy.allocatePool(tc.container2, "")
 			if err != nil {
 				panic(err)
 			}
 			fmt.Printf("grant 2 memsets: dram %s, pmem %s\n", grant2.GetMemoryNode().GetMemset(memoryDRAM), grant2.GetMemoryNode().GetMemset(memoryPMEM))
 
-			grant3, err := policy.allocatePool(tc.container3)
+			grant3, err := policy.allocatePool(tc.container3, "")
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -105,6 +105,8 @@ type Request interface {
 type Grant interface {
 	// Clone creates a copy of this grant.
 	Clone() Grant
+	// RefetchNodes updates the stored cpu and memory nodes of this grant by name.
+	RefetchNodes() error
 	// GetContainer returns the container CPU capacity is granted to.
 	GetContainer() cache.Container
 	// GetCPUNode returns the node that granted CPU capacity to the container.
@@ -1020,6 +1022,21 @@ func (cg *grant) Clone() Grant {
 		allocatedMem: cg.MemLimit(),
 		coldStart:    cg.ColdStart(),
 	}
+}
+
+// RefetchNodes updates the stored cpu and memory nodes of this grant by name.
+func (cg *grant) RefetchNodes() error {
+	node, ok := cg.node.Policy().nodes[cg.node.Name()]
+	if !ok {
+		return policyError("failed to refetch grant cpu node %s", cg.node.Name())
+	}
+	memoryNode, ok := cg.memoryNode.Policy().nodes[cg.memoryNode.Name()]
+	if !ok {
+		return policyError("failed to refetch grant memory node %s", cg.memoryNode.Name())
+	}
+	cg.node = node
+	cg.memoryNode = memoryNode
+	return nil
 }
 
 // GetContainer returns the container this grant is valid for.

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -103,6 +103,8 @@ type Request interface {
 
 // Grant represents CPU and memory capacity allocated to a container from a node.
 type Grant interface {
+	// Clone creates a copy of this grant.
+	Clone() Grant
 	// GetContainer returns the container CPU capacity is granted to.
 	GetContainer() cache.Container
 	// GetCPUNode returns the node that granted CPU capacity to the container.
@@ -1002,6 +1004,21 @@ func newGrant(n Node, c cache.Container, exclusive cpuset.CPUSet, portion int, i
 		memset:       mems.Clone(),
 		allocatedMem: allocatedMem,
 		coldStart:    coldStart,
+	}
+}
+
+// Clone creates a copy of this grant.
+func (cg *grant) Clone() Grant {
+	return &grant{
+		node:         cg.GetCPUNode(),
+		memoryNode:   cg.GetMemoryNode(),
+		container:    cg.GetContainer(),
+		exclusive:    cg.ExclusiveCPUs(),
+		portion:      cg.SharedPortion(),
+		memType:      cg.MemoryType(),
+		memset:       cg.Memset().Clone(),
+		allocatedMem: cg.MemLimit(),
+		coldStart:    cg.ColdStart(),
 	}
 }
 

--- a/pkg/cri/resource-manager/policy/flags.go
+++ b/pkg/cri/resource-manager/policy/flags.go
@@ -34,6 +34,8 @@ const (
 	NullPolicy = "null"
 	// NullPolicyDescription is the description for the null policy.
 	NullPolicyDescription = "A policy to bypass local policy processing."
+	// ConfigPath is the configuration module path for the generic policy layer.
+	ConfigPath = "policy"
 )
 
 // Options captures our configurable parameters.
@@ -222,5 +224,6 @@ func defaultOptions() interface{} {
 
 // Register us for configuration handling.
 func init() {
-	config.Register("policy", "Generic policy layer.", opt, defaultOptions)
+	config.Register(ConfigPath, "Generic policy layer.", opt, defaultOptions,
+		config.WithNotify(configNotify))
 }


### PR DESCRIPTION
This PR attempts to implement proper handling of the bounding/allowed CPU set
for the `memtier` policy. The patch set

- adds support for reading the bounding CPU set from a cgroup directory
- falls back to reallocating containers if reinstating allocations fails
- triggers rebuilding the topology pool if the reserved or allowed CPU set changes

Detecting a mismatch between the configuration of kubelet (`--cgroup-root`) and
CRI Resource Manager is not part of this patch set. 
