### PR TITLE
memtier: fix updating containers after shared pool changes.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -1032,7 +1032,7 @@ func (cg *grant) ExclusiveCPUs() cpuset.CPUSet {
 
 // SharedCPUs returns the shared CPUSet in this grant.
 func (cg *grant) SharedCPUs() cpuset.CPUSet {
-	return cg.node.GetSupply().SharableCPUs()
+	return cg.node.FreeSupply().SharableCPUs()
 }
 
 // SharedPortion returns the milli-CPU allocation for the shared CPUSet in this grant.


### PR DESCRIPTION
Skip updating the container that triggered the change in
the shared subset of CPUs. Properly update the cpuset
of any affected container to the union of its exclusive and
shared CPUs.