### PR TITLE
memtier/c4pmem4/test03-coldstart: don't jump the gun.

### DIFF
--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test03-coldstart/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test03-coldstart/code.var.sh
@@ -49,9 +49,10 @@ else
     echo "### Verified: PMEM memory consumed during cold period: $PMEM_COLD_CONSUMED kB, pod script allocated: ${COLD_ALLOC%kB} kB"
 fi
 
+coldstarts=$(vm-command-q "$CRI_RESMGR_OUTPUT | grep 'finishing coldstart period for pod0:pod0c0' | wc -l")
 echo "Wait that cri-resmgr finishes coldstart period within 5s + $DURATION."
 sleep 5s
-vm-run-until --timeout ${DURATION%s} "$CRI_RESMGR_OUTPUT | grep 'finishing coldstart period for pod0:pod0c0'" ||
+vm-run-until --timeout ${DURATION%s} "[ \$($CRI_RESMGR_OUTPUT | grep 'finishing coldstart period for pod0:pod0c0' | wc -l) -gt $coldstarts ]" ||
     error "cri-resmgr did not report finishing coldstart period within $DURATION"
 
 vm-command "$CRI_RESMGR_OUTPUT | grep 'pinning to memory 0,6'" ||


### PR DESCRIPTION
Don't let previous cold start triggers in the log
fool us into thinking that the pending cold start
period would be over.