### PR TITLE
docs: minor fixes in html template customization

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,15 +5,15 @@
     <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
       <span class="rst-current-version" data-toggle="rst-current-version">
         <span class="fa fa-book"> GitHub Pages</span>
-        v: {{ version }}
+        {{ version }}
         <span class="fa fa-caret-down"></span>
       </span>
       <div class="rst-other-versions">
         <dl id="versions">
           <dt>{{ _('Versions') }}</dt>
-          <dt>
         </dl>
         <dl>
+          <dt>
           <a href="/cri-resource-manager/releases">all releases</a>
           </dt>
         </dl>


### PR DESCRIPTION
- remove 'v:' prefix from the version menu in order to avoid displaying
  something like "v: v0.4.1"
- correct usage of `<dt>` tag