### PR TITLE
release 0.4: backport documentation theme fixes

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,7 +5,7 @@
     <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
       <span class="rst-current-version" data-toggle="rst-current-version">
         <span class="fa fa-book"> GitHub Pages</span>
-        {{ version }}
+        {{ versions_menu_this_version }}
         <span class="fa fa-caret-down"></span>
       </span>
       <div class="rst-other-versions">

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,15 +5,15 @@
     <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
       <span class="rst-current-version" data-toggle="rst-current-version">
         <span class="fa fa-book"> GitHub Pages</span>
-        v: {{ version }}
+        {{ version }}
         <span class="fa fa-caret-down"></span>
       </span>
       <div class="rst-other-versions">
         <dl id="versions">
           <dt>{{ _('Versions') }}</dt>
-          <dt>
         </dl>
         <dl>
+          <dt>
           <a href="/cri-resource-manager/releases">all releases</a>
           </dt>
         </dl>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,9 @@ release = getenv("BUILD_VERSION", default="unknown")
 
 # Versions to show in the version menu
 if getenv('VERSIONS_MENU'):
-    html_context = {'versions_menu': True}
+    html_context = {
+        'versions_menu': True,
+        'versions_menu_this_version': getenv('VERSIONS_MENU_THIS_VERSION', version)}
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/releases/conf.py
+++ b/docs/releases/conf.py
@@ -23,7 +23,9 @@ author = 'various'
 # Versions to show in the version menu
 version = "all releases"
 if os.getenv('VERSIONS_MENU'):
-    html_context = {'versions_menu': True}
+    html_context = {
+        'versions_menu': True,
+        'versions_menu_this_version': version}
 
 
 # -- General configuration ---------------------------------------------------

--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -117,6 +117,7 @@ build_subdir=${build_subdir:-devel}
 echo "Updating site version subdir: '$build_subdir'"
 export SITE_BUILDDIR="$build_dir/$build_subdir"
 export VERSIONS_MENU=1
+export VERSIONS_MENU_THIS_VERSION=$build_subdir
 
 make html
 


### PR DESCRIPTION
Two backports from master:
- minor fixes in html template customization (#537)
- use 'release branch' as the current version in versions menu (#538)