### PR TITLE
memtier: implement reserved CPUs pool

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache.go
@@ -86,6 +86,7 @@ func (p *policy) restoreConfig() bool {
 type cachedGrant struct {
 	Exclusive   string
 	Part        int
+	CPUType     cpuClass
 	Container   string
 	Pool        string
 	MemoryPool  string
@@ -98,7 +99,8 @@ type cachedGrant struct {
 func newCachedGrant(cg Grant) *cachedGrant {
 	ccg := &cachedGrant{}
 	ccg.Exclusive = cg.ExclusiveCPUs().String()
-	ccg.Part = cg.SharedPortion()
+	ccg.Part = cg.CPUPortion()
+	ccg.CPUType = cg.CPUType()
 	ccg.Container = cg.GetContainer().GetCacheID()
 	ccg.Pool = cg.GetCPUNode().Name()
 	ccg.MemoryPool = cg.GetMemoryNode().Name()
@@ -128,6 +130,7 @@ func (ccg *cachedGrant) ToGrant(policy *policy) (Grant, error) {
 	g := newGrant(
 		node,
 		container,
+		ccg.CPUType,
 		cpuset.MustParse(ccg.Exclusive),
 		ccg.Part,
 		ccg.MemType,

--- a/pkg/cri/resource-manager/policy/builtin/memtier/cache_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/cache_test.go
@@ -88,11 +88,11 @@ func TestAllocationMarshalling(t *testing.T) {
 	}{
 		{
 			name: "non-zero Exclusive",
-			data: []byte(`{"key1":{"Exclusive":"1","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{},"ColdStart":0}}`),
+			data: []byte(`{"key1":{"Exclusive":"1","Part":1,"CPUType":0,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{},"ColdStart":0}}`),
 		},
 		{
 			name: "zero Exclusive",
-			data: []byte(`{"key1":{"Exclusive":"","Part":1,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{},"ColdStart":0}}`),
+			data: []byte(`{"key1":{"Exclusive":"","Part":1,"CPUType":0,"Container":"1","Pool":"testnode","MemoryPool":"testnode","MemType":"DRAM,PMEM,HBM","Memset":"","MemoryLimit":{},"ColdStart":0}}`),
 		},
 	}
 	for _, tc := range tcases {
@@ -104,8 +104,8 @@ func TestAllocationMarshalling(t *testing.T) {
 							node: node{
 								name:    "testnode",
 								kind:    UnknownNode,
-								noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
-								freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
+								noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
+								freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
 							},
 						},
 					},

--- a/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/memtier-policy.go
@@ -375,6 +375,15 @@ func (p *policy) checkConstraints() error {
 	case resapi.Quantity:
 		qty := c.(resapi.Quantity)
 		p.reserveCnt = (int(qty.MilliValue()) + 999) / 1000
+		// Use CpuAllocator to pick reserved CPUs among
+		// allowed ones. Because using those CPUs is allowed,
+		// they remain (they are put back) in the allowed set.
+		cset, err := p.cpuAllocator.AllocateCpus(&p.allowed, p.reserveCnt, false)
+		p.allowed = p.allowed.Union(cset)
+		if err != nil {
+			log.Fatal("cannot reserve %dm CPUs for ReservedResources from AvailableResources: %s", qty.MilliValue(), err)
+		}
+		p.reserved = cset
 	}
 
 	return nil

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences_test.go
@@ -217,6 +217,7 @@ func TestCpuAllocationPreferences(t *testing.T) {
 		expectedFull     int
 		expectedFraction int
 		expectedIsolate  bool
+		expectedCpuType  cpuClass
 		expectedElevate  int
 		disabled         bool
 	}{
@@ -262,6 +263,7 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			},
 			pod:              &mockPod{},
 			expectedFraction: 2000,
+			expectedCpuType:  cpuReserved,
 		},
 		{
 			name: "return request's value for burstable QoS",
@@ -348,12 +350,13 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			if tc.disabled {
 				t.Skipf("The case '%s' is skipped", tc.name)
 			}
-			full, fraction, isolate, elevate := cpuAllocationPreferences(tc.pod, tc.container)
+			full, fraction, isolate, cpuType, elevate := cpuAllocationPreferences(tc.pod, tc.container)
 			if full != tc.expectedFull || fraction != tc.expectedFraction ||
-				isolate != tc.expectedIsolate || elevate != tc.expectedElevate {
-				t.Errorf("Expected (%v, %v, %v, %v), but got (%v, %v, %v, %v)",
-					tc.expectedFull, tc.expectedFraction, tc.expectedIsolate, tc.expectedElevate,
-					full, fraction, isolate, elevate)
+				isolate != tc.expectedIsolate || elevate != tc.expectedElevate ||
+				cpuType != tc.expectedCpuType {
+				t.Errorf("Expected (%v, %v, %v, %v, %v), but got (%v, %v, %v, %v, %v)",
+					tc.expectedFull, tc.expectedFraction, tc.expectedIsolate, tc.expectedCpuType, tc.expectedElevate,
+					full, fraction, isolate, cpuType, elevate)
 			}
 		})
 	}

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -337,11 +337,17 @@ func (p *policy) allocatePool(container cache.Container) (Grant, error) {
 
 	request := newRequest(container)
 
+	if p.root.FreeSupply().ReservedCPUs().IsEmpty() && request.CPUType() == cpuReserved {
+		// Fallback to allocating reserved CPUs from the shared pool
+		// if there are no reserved CPUs.
+		request.SetCPUType(cpuNormal)
+	}
+
 	// Assumption: in the beginning the CPUs and memory will be allocated from
 	// the same pool. This assumption can be relaxed later, requires separate
 	// (but connected) scoring of memory and CPU.
 
-	if container.GetNamespace() == kubernetes.NamespaceSystem {
+	if request.CPUType() == cpuNormal && container.GetNamespace() == kubernetes.NamespaceSystem {
 		pool = p.root
 	} else {
 		affinity := p.calculatePoolAffinities(request.GetContainer())
@@ -561,23 +567,34 @@ func (p *policy) applyGrant(grant Grant) {
 	log.Debug("* applying grant %s", grant)
 
 	container := grant.GetContainer()
+	cpuType := grant.CPUType()
 	exclusive := grant.ExclusiveCPUs()
+	reserved := grant.ReservedCPUs()
 	shared := grant.SharedCPUs()
-	portion := grant.SharedPortion()
+	cpuPortion := grant.SharedPortion()
 
 	cpus := ""
 	kind := ""
-	if exclusive.IsEmpty() {
-		cpus = shared.String()
-		kind = "shared"
-	} else {
-		kind = "exclusive"
-		if portion > 0 {
-			kind += "+shared"
-			cpus = exclusive.Union(shared).String()
+	if cpuType == cpuNormal {
+		if exclusive.IsEmpty() {
+			cpus = shared.String()
+			kind = "shared"
 		} else {
-			cpus = exclusive.String()
+			kind = "exclusive"
+			if cpuPortion > 0 {
+				kind += "+shared"
+				cpus = exclusive.Union(shared).String()
+			} else {
+				cpus = exclusive.String()
+			}
 		}
+	} else if cpuType == cpuReserved {
+		kind = "reserved"
+		cpus = reserved.String()
+		cpuPortion = grant.ReservedPortion()
+	} else {
+		log.Debug("unsupported granted cpuType %s", cpuType)
+		return
 	}
 
 	mems := ""
@@ -594,7 +611,7 @@ func (p *policy) applyGrant(grant Grant) {
 		}
 		container.SetCpusetCpus(cpus)
 		if exclusive.IsEmpty() {
-			container.SetCPUShares(int64(cache.MilliCPUToShares(portion)))
+			container.SetCPUShares(int64(cache.MilliCPUToShares(cpuPortion)))
 		} else {
 			// Notes:
 			//   Hmm... I think setting CPU shares according to the normal formula
@@ -608,7 +625,7 @@ func (p *policy) applyGrant(grant Grant) {
 			//   itself to the shared subset will not get properly weighted wrt. other
 			//   processes sharing the same CPUs.
 			//
-			container.SetCPUShares(int64(cache.MilliCPUToShares(portion)))
+			container.SetCPUShares(int64(cache.MilliCPUToShares(cpuPortion)))
 		}
 	}
 
@@ -646,8 +663,18 @@ func (p *policy) releasePool(container cache.Container) (Grant, bool) {
 func (p *policy) updateSharedAllocations(grant Grant) {
 	log.Debug("* updating shared allocations affected by %s", grant)
 
+	if grant.CPUType() == cpuReserved {
+		log.Debug("  this grant uses reserved CPUs, does not affect shared allocations")
+		return
+	}
+
 	for _, other := range p.allocations.grants {
 		if other.GetContainer().GetCacheID() == grant.GetContainer().GetCacheID() {
+			continue
+		}
+
+		if other.CPUType() == cpuReserved {
+			log.Debug("  => %s not affected (only reserved CPUs)...", other)
 			continue
 		}
 
@@ -837,8 +864,9 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 	depth1, depth2 := node1.RootDistance(), node2.RootDistance()
 	id1, id2 := node1.NodeID(), node2.NodeID()
 	score1, score2 := scores[id1], scores[id2]
-	isolated1, shared1 := score1.IsolatedCapacity(), score1.SharedCapacity()
-	isolated2, shared2 := score2.IsolatedCapacity(), score2.SharedCapacity()
+	cpuType := request.CPUType()
+	isolated1, reserved1, shared1 := score1.IsolatedCapacity(), score1.ReservedCapacity(), score1.SharedCapacity()
+	isolated2, reserved2, shared2 := score2.IsolatedCapacity(), score2.ReservedCapacity(), score2.SharedCapacity()
 	a1 := affinityScore(affinity, node1)
 	a2 := affinityScore(affinity, node2)
 
@@ -851,37 +879,46 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 	//
 	// Our scoring/score sorting algorithm is:
 	//
-	// 1) - insufficient isolated or shared capacity loses
+	// 1) - insufficient isolated, reserved or shared capacity loses
 	// 2) - if we have affinity, the higher affinity score wins
 	// 3) - if only one node matches the memory type request, it wins
 	// 4) - if we have topology hints
 	//       * better hint score wins
 	//       * for a tie, prefer the lower node then the smaller id
 	// 5) - if a node is lower in the tree it wins
-	// 6) - for isolated allocations
+	// 6) - for reserved allocations
+	//       * more unallocated reserved capacity per colocated container wins
+	// 7) - for (non-reserved) isolated allocations
 	//       * more isolated capacity wins
 	//       * for a tie, prefer the smaller id
-	// 7) - for exclusive allocations
+	// 8) - for (non-reserved) exclusive allocations
 	//       * more slicable (shared) capacity wins
 	//       * for a tie, prefer the smaller id
-	// 8) - for shared-only allocations
+	// 9) - for (non-reserved) shared-only allocations
 	//       * fewer colocated containers win
-	//       * for a tie prefer more shared capacity then the smaller id
+	//       * for a tie prefer more shared capacity
+	// 10) - lower id wins
 	//
 	// Before this comparison is reached, nodes with insufficient uncompressible resources
 	// (memory) have been filtered out.
 
 	// 1) a node with insufficient isolated or shared capacity loses
 	switch {
-	case (isolated2 < 0 && isolated1 >= 0) || (shared2 <= 0 && shared1 > 0):
+	case cpuType == cpuNormal && ((isolated2 < 0 && isolated1 >= 0) || (shared2 <= 0 && shared1 > 0)):
 		log.Debug("  => %s loses, insufficent isolated or shared", node2.Name())
 		return true
-	case (isolated1 < 0 && isolated2 >= 0) || (shared1 <= 0 && shared2 > 0):
+	case cpuType == cpuNormal && ((isolated1 < 0 && isolated2 >= 0) || (shared1 <= 0 && shared2 > 0)):
 		log.Debug("  => %s loses, insufficent isolated or shared", node1.Name())
+		return false
+	case cpuType == cpuReserved && reserved2 < 0 && reserved1 >= 0:
+		log.Debug("  => %s loses, insufficent reserved", node2.Name())
+		return true
+	case cpuType == cpuReserved && reserved1 < 0 && reserved2 >= 0:
+		log.Debug("  => %s loses, insufficent reserved", node1.Name())
 		return false
 	}
 
-	log.Debug("  - isolated/shared inusfficiency is a TIE")
+	log.Debug("  - isolated/reserved/shared insufficiency is a TIE")
 
 	// 2) higher affinity score wins
 	if a1 > a2 {
@@ -970,61 +1007,76 @@ func (p *policy) compareScores(request Request, pools []Node, scores map[int]Sco
 
 	log.Debug("  - depth is a TIE")
 
-	// 6) more isolated capacity wins
-	if request.Isolate() && (isolated1 > 0 || isolated2 > 0) {
-		if isolated1 > isolated2 {
+	if request.CPUType() == cpuReserved {
+		// 6) if requesting reserved CPUs, more reserved
+		//    capacity per colocated container wins. Reserved
+		//    CPUs cannot be precisely accounted as they run
+		//    also BestEffort containers that do not carry
+		//    information on their CPU needs.
+		if reserved1/(score1.Colocated()+1) > reserved2/(score2.Colocated()+1) {
 			return true
 		}
-		if isolated2 > isolated1 {
+		if reserved2/(score2.Colocated()+1) > reserved1/(score1.Colocated()+1) {
+			return false
+		}
+		log.Debug("  - reserved capacity is a TIE")
+	} else if request.CPUType() == cpuNormal {
+		// 7) more isolated capacity wins
+		if request.Isolate() && (isolated1 > 0 || isolated2 > 0) {
+			if isolated1 > isolated2 {
+				return true
+			}
+			if isolated2 > isolated1 {
+				return false
+			}
+
+			log.Debug("  => %s WINS based on equal isolated capacity, lower id",
+				map[bool]string{true: node1.Name(), false: node2.Name()}[id1 < id2])
+
+			return id1 < id2
+		}
+
+		// 8) more slicable shared capacity wins
+		if request.FullCPUs() > 0 && (shared1 > 0 || shared2 > 0) {
+			if shared1 > shared2 {
+				log.Debug("  => %s WINS on more slicable capacity", node1.Name())
+				return true
+			}
+			if shared2 > shared1 {
+				log.Debug("  => %s WINS on more slicable capacity", node2.Name())
+				return false
+			}
+
+			log.Debug("  => %s WINS based on equal slicable capacity, lower id",
+				map[bool]string{true: node1.Name(), false: node2.Name()}[id1 < id2])
+
+			return id1 < id2
+		}
+
+		// 9) fewer colocated containers win
+		if score1.Colocated() < score2.Colocated() {
+			log.Debug("  => %s WINS on colocation score", node1.Name())
+			return true
+		}
+		if score2.Colocated() < score1.Colocated() {
+			log.Debug("  => %s WINS on colocation score", node2.Name())
 			return false
 		}
 
-		log.Debug("  => %s WINS based on equal isolated capacity, lower id",
-			map[bool]string{true: node1.Name(), false: node2.Name()}[id1 < id2])
+		log.Debug("  - colocation score is a TIE")
 
-		return id1 < id2
-	}
-
-	// 7) more slicable shared capacity wins
-	if request.FullCPUs() > 0 && (shared1 > 0 || shared2 > 0) {
+		// more shared capacity wins
 		if shared1 > shared2 {
-			log.Debug("  => %s WINS on more slicable capacity", node1.Name())
+			log.Debug("  => %s WINS on more shared capacity", node1.Name())
 			return true
 		}
 		if shared2 > shared1 {
-			log.Debug("  => %s WINS on more slicable capacity", node2.Name())
+			log.Debug("  => %s WINS on more shared capacity", node2.Name())
 			return false
 		}
-
-		log.Debug("  => %s WINS based on equal slicable capacity, lower id",
-			map[bool]string{true: node1.Name(), false: node2.Name()}[id1 < id2])
-
-		return id1 < id2
 	}
 
-	// 8) fewer colocated containers win
-	if score1.Colocated() < score2.Colocated() {
-		log.Debug("  => %s WINS on colocation score", node1.Name())
-		return true
-	}
-	if score2.Colocated() < score1.Colocated() {
-		log.Debug("  => %s WINS on colocation score", node2.Name())
-		return false
-	}
-
-	log.Debug("  - colocation score is a TIE")
-
-	// more shared capacity wins
-	if shared1 > shared2 {
-		log.Debug("  => %s WINS on more shared capacity", node1.Name())
-		return true
-	}
-	if shared2 > shared1 {
-		log.Debug("  => %s WINS on more shared capacity", node2.Name())
-		return false
-	}
-
-	// lower id wins
+	// 10) lower id wins
 	log.Debug("  => %s WINS based on lower id",
 		map[bool]string{true: node1.Name(), false: node2.Name()}[id1 < id2])
 

--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools_test.go
@@ -146,8 +146,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -172,8 +172,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -198,8 +198,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 				},
 				&numanode{
@@ -207,8 +207,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      101,
 						name:    "testnode1",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -233,8 +233,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 				},
 				&numanode{
@@ -242,8 +242,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      101,
 						name:    "testnode1",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -252,8 +252,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      102,
 						name:    "testnode2",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 1, // system node id
 				},
@@ -436,9 +436,9 @@ func TestPoolCreation(t *testing.T) {
 			policy := CreateMemtierPolicy(policyOptions).(*policy)
 			log.EnableDebug(false)
 
-			if policy.root.GetSupply().SharableCPUs().Size()+policy.root.GetSupply().IsolatedCPUs().Size() != tc.expectedRootNodeCPUs {
+			if policy.root.GetSupply().SharableCPUs().Size()+policy.root.GetSupply().IsolatedCPUs().Size()+policy.root.GetSupply().ReservedCPUs().Size() != tc.expectedRootNodeCPUs {
 				t.Errorf("Expected %d CPUs, got %d", tc.expectedRootNodeCPUs,
-					policy.root.GetSupply().SharableCPUs().Size()+policy.root.GetSupply().IsolatedCPUs().Size())
+					policy.root.GetSupply().SharableCPUs().Size()+policy.root.GetSupply().IsolatedCPUs().Size()+policy.root.GetSupply().ReservedCPUs().Size())
 			}
 
 			for _, p := range policy.pools {
@@ -446,9 +446,9 @@ func TestPoolCreation(t *testing.T) {
 					if len(p.Children()) != 0 {
 						t.Errorf("Leaf node %v had %d children", p, len(p.Children()))
 					}
-					if p.GetSupply().SharableCPUs().Size()+p.GetSupply().IsolatedCPUs().Size() != tc.expectedLeafNodeCPUs {
+					if p.GetSupply().SharableCPUs().Size()+p.GetSupply().IsolatedCPUs().Size()+p.GetSupply().ReservedCPUs().Size() != tc.expectedLeafNodeCPUs {
 						t.Errorf("Expected %d CPUs, got %d (%s)", tc.expectedLeafNodeCPUs,
-							p.GetSupply().SharableCPUs().Size()+p.GetSupply().IsolatedCPUs().Size(),
+							p.GetSupply().SharableCPUs().Size()+p.GetSupply().IsolatedCPUs().Size()+p.GetSupply().ReservedCPUs().Size(),
 							p.GetSupply().DumpCapacity())
 					}
 				}
@@ -795,6 +795,21 @@ func TestAffinities(t *testing.T) {
 				memType:   memoryUnspec,
 				isolate:   false,
 				full:      3,
+				container: &mockContainer{},
+			},
+			affinities: map[string]int32{},
+			expected:   "NUMA node #2",
+		},
+		{
+			path: path.Join(dir, "sysfs", "server", "sys"),
+			name: "reserved - no affinities",
+			req: &request{
+				cpuType:   cpuReserved,
+				memReq:    10000,
+				memLim:    10000,
+				memType:   memoryUnspec,
+				isolate:   false,
+				full:      0,
 				container: &mockContainer{},
 			},
 			affinities: map[string]int32{},

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -35,10 +35,14 @@ type Supply interface {
 	Clone() Supply
 	// IsolatedCPUs returns the isolated cpuset in this supply.
 	IsolatedCPUs() cpuset.CPUSet
+	// ReservedCPUs returns the reserved cpuset in this supply.
+	ReservedCPUs() cpuset.CPUSet
 	// SharableCPUs returns the sharable cpuset in this supply.
 	SharableCPUs() cpuset.CPUSet
-	// Granted returns the locally granted CPU capacity in this supply.
-	Granted() int
+	// GrantedReserved returns the locally granted reserved CPU capacity in this supply.
+	GrantedReserved() int
+	// GrantedShared returns the locally granted shared CPU capacity in this supply.
+	GrantedShared() int
 	// GrantedMemory returns the locally granted memory capacity in this supply.
 	GrantedMemory(memoryType) uint64
 	// Cumulate cumulates the given supply into this one.
@@ -86,7 +90,10 @@ type Request interface {
 	GetContainer() cache.Container
 	// String returns a printable representation of this request.
 	String() string
-
+	// CPUType returns the type of requested CPU.
+	CPUType() cpuClass
+	// SetCPUType sets the type of requested CPU.
+	SetCPUType(cpuType cpuClass)
 	// FullCPUs return the number of full CPUs requested.
 	FullCPUs() int
 	// CPUFraction returns the amount of fractional milli-CPU requested.
@@ -112,8 +119,17 @@ type Grant interface {
 	// GetMemoryNode returns the node which granted memory capacity to
 	// the container.
 	GetMemoryNode() Node
+	// CPUType returns the type of granted CPUs
+	CPUType() cpuClass
+	// CPUPortion returns granted milli-CPUs of non-full CPUs of CPUType().
+	// CPUPortion() == ReservedPortion() + SharedPortion().
+	CPUPortion() int
 	// ExclusiveCPUs returns the exclusively granted non-isolated cpuset.
 	ExclusiveCPUs() cpuset.CPUSet
+	// ReservedCPUs returns the reserved granted cpuset.
+	ReservedCPUs() cpuset.CPUSet
+	// ReservedPortion() returns the amount of CPUs in milli-CPU granted.
+	ReservedPortion() int
 	// SharedCPUs returns the shared granted cpuset.
 	SharedCPUs() cpuset.CPUSet
 	// SharedPortion returns the amount of CPUs in milli-CPU granted.
@@ -166,6 +182,7 @@ type Score interface {
 	Request() Request
 
 	IsolatedCapacity() int
+	ReservedCapacity() int
 	SharedCapacity() int
 	Colocated() int
 	HintScores() map[string]float64
@@ -179,8 +196,10 @@ type memoryMap map[memoryType]uint64
 type supply struct {
 	node                 Node                // node supplying CPUs and memory
 	isolated             cpuset.CPUSet       // isolated CPUs at this node
+	reserved             cpuset.CPUSet       // reserved CPUs at this node
 	sharable             cpuset.CPUSet       // sharable CPUs at this node
-	granted              int                 // amount of shareable allocated
+	grantedReserved      int                 // amount of reserved CPUs allocated
+	grantedShared        int                 // amount of shareable CPUs allocated
 	mem                  memoryMap           // available memory for this node
 	grantedMem           memoryMap           // total memory granted
 	extraMemReservations map[Grant]memoryMap // how much memory each workload above has requested
@@ -194,6 +213,7 @@ type request struct {
 	full      int             // number of full CPUs requested
 	fraction  int             // amount of fractional CPU requested
 	isolate   bool            // prefer isolated exclusive CPUs
+	cpuType   cpuClass        // preferred CPU type (normal, reserved)
 
 	memReq  uint64     // memory request
 	memLim  uint64     // memory limit
@@ -221,7 +241,8 @@ type grant struct {
 	node           Node            // node CPU is supplied from
 	memoryNode     Node            // node memory is supplied from
 	exclusive      cpuset.CPUSet   // exclusive CPUs
-	portion        int             // milliCPUs granted from shared set
+	cpuType        cpuClass        // type of CPUs (normal, reserved, ...)
+	cpuPortion     int             // milliCPUs granted from CPUs of cpuType
 	memType        memoryType      // requested types of memory
 	memset         system.IDSet    // assigned memory nodes
 	allocatedMem   memoryMap       // memory limit
@@ -236,6 +257,7 @@ type score struct {
 	supply    Supply             // CPU supply (node)
 	req       Request            // CPU request (container)
 	isolated  int                // remaining isolated CPUs
+	reserved  int                // remaining reserved CPUs
 	shared    int                // remaining shared capacity
 	colocated int                // number of colocated containers
 	hints     map[string]float64 // hint scores
@@ -244,7 +266,8 @@ type score struct {
 var _ Score = &score{}
 
 // newSupply creates CPU supply for the given node, cpusets and existing grant.
-func newSupply(n Node, isolated, sharable cpuset.CPUSet, granted int, mem, grantedMem memoryMap) Supply {
+
+func newSupply(n Node, isolated, reserved, sharable cpuset.CPUSet, grantedReserved int, grantedShared int, mem, grantedMem memoryMap) Supply {
 	if mem == nil {
 		mem = createMemoryMap(0, 0, 0)
 	}
@@ -254,8 +277,10 @@ func newSupply(n Node, isolated, sharable cpuset.CPUSet, granted int, mem, grant
 	return &supply{
 		node:                 n,
 		isolated:             isolated.Clone(),
+		reserved:             reserved.Clone(),
 		sharable:             sharable.Clone(),
-		granted:              granted,
+		grantedReserved:      grantedReserved,
+		grantedShared:        grantedShared,
 		mem:                  mem,
 		grantedMem:           grantedMem,
 		extraMemReservations: make(map[Grant]memoryMap),
@@ -331,7 +356,7 @@ func (cs *supply) Clone() Supply {
 	for key, value := range cs.grantedMem {
 		grantedMem[key] = value
 	}
-	return newSupply(cs.node, cs.isolated, cs.sharable, cs.granted, mem, grantedMem)
+	return newSupply(cs.node, cs.isolated, cs.reserved, cs.sharable, cs.grantedReserved, cs.grantedShared, mem, grantedMem)
 }
 
 // IsolatedCpus returns the isolated CPUSet of this supply.
@@ -339,14 +364,24 @@ func (cs *supply) IsolatedCPUs() cpuset.CPUSet {
 	return cs.isolated.Clone()
 }
 
+// ReservedCpus returns the reserved CPUSet of this supply.
+func (cs *supply) ReservedCPUs() cpuset.CPUSet {
+	return cs.reserved.Clone()
+}
+
 // SharableCpus returns the sharable CPUSet of this supply.
 func (cs *supply) SharableCPUs() cpuset.CPUSet {
 	return cs.sharable.Clone()
 }
 
-// Granted returns the locally granted sharable CPU capacity.
-func (cs *supply) Granted() int {
-	return cs.granted
+// GrantedReserved returns the locally granted reserved CPU capacity.
+func (cs *supply) GrantedReserved() int {
+	return cs.grantedReserved
+}
+
+// GrantedShared returns the locally granted sharable CPU capacity.
+func (cs *supply) GrantedShared() int {
+	return cs.grantedShared
 }
 
 func (cs *supply) GrantedMemory(memType memoryType) uint64 {
@@ -363,8 +398,10 @@ func (cs *supply) Cumulate(more Supply) {
 	mcs := more.(*supply)
 
 	cs.isolated = cs.isolated.Union(mcs.isolated)
+	cs.reserved = cs.reserved.Union(mcs.reserved)
 	cs.sharable = cs.sharable.Union(mcs.sharable)
-	cs.granted += mcs.granted
+	cs.grantedReserved += mcs.grantedReserved
+	cs.grantedShared += mcs.grantedShared
 
 	for key, value := range mcs.mem {
 		cs.mem[key] += value
@@ -389,7 +426,6 @@ func (cs *supply) AccountAllocate(g Grant) {
 	exclusive := g.ExclusiveCPUs()
 	cs.isolated = cs.isolated.Difference(exclusive)
 	cs.sharable = cs.sharable.Difference(exclusive)
-
 	// TODO: same for memory
 }
 
@@ -407,7 +443,6 @@ func (cs *supply) AccountRelease(g Grant) {
 	sharable := grantcpus.Intersection(ncs.SharableCPUs())
 	cs.isolated = cs.isolated.Union(isolated)
 	cs.sharable = cs.sharable.Union(sharable)
-
 	// For memory the extra allocations be released elsewhere.
 }
 
@@ -496,38 +531,56 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 
 	cr := r.(*request)
 
+	full := cr.full
+	fraction := cr.fraction
+
+	if cr.cpuType == cpuReserved && full > 0 {
+		log.Warn("exclusive reserved CPUs not supported, allocating %d full CPUs as fractions", full)
+		fraction += full * 1000
+		full = 0
+	}
 	// allocate isolated exclusive CPUs or slice them off the sharable set
 	switch {
-	case cr.full > 0 && cs.isolated.Size() >= cr.full && cr.isolate:
-		exclusive, err = cs.takeCPUs(&cs.isolated, nil, cr.full)
+	case full > 0 && cs.isolated.Size() >= full && cr.isolate:
+		exclusive, err = cs.takeCPUs(&cs.isolated, nil, full)
 		if err != nil {
 			return nil, policyError("internal error: "+
 				"%s: can't take %d exclusive isolated CPUs from %s: %v",
-				cs.node.Name(), cr.full, cs.isolated, err)
+				cs.node.Name(), full, cs.isolated, err)
 		}
 
-	case cr.full > 0 && cs.AllocatableSharedCPU() > 1000*cr.full:
-		exclusive, err = cs.takeCPUs(&cs.sharable, nil, cr.full)
+	case full > 0 && cs.AllocatableSharedCPU() > 1000*full:
+		exclusive, err = cs.takeCPUs(&cs.sharable, nil, full)
 		if err != nil {
 			return nil, policyError("internal error: "+
 				"%s: can't take %d exclusive CPUs from %s: %v",
-				cs.node.Name(), cr.full, cs.sharable, err)
+				cs.node.Name(), full, cs.sharable, err)
 		}
 
-	case cr.full > 0:
+	case full > 0:
 		return nil, policyError("internal error: "+
 			"%s: can't slice %d exclusive CPUs from %s, %dm available",
-			cs.node.Name(), cr.full, cs.sharable, cs.AllocatableSharedCPU())
+			cs.node.Name(), full, cs.sharable, cs.AllocatableSharedCPU())
 	}
 
-	// allocate requested portion of the sharable set
-	if cr.fraction > 0 {
-		if cs.AllocatableSharedCPU() < cr.fraction {
-			return nil, policyError("internal error: "+
-				"%s: not enough sharable CPU for %dm, %dm available",
-				cs.node.Name(), cr.fraction, cs.sharable, cs.AllocatableSharedCPU())
+	if fraction > 0 {
+		if cr.cpuType == cpuNormal {
+			// allocate requested portion of shared CPUs
+			if cs.AllocatableSharedCPU() < fraction {
+				return nil, policyError("internal error: "+
+					"%s: not enough %dm sharable CPU for %dm, %dm available",
+					cs.node.Name(), fraction, cs.sharable, cs.AllocatableSharedCPU())
+			}
+			cs.grantedShared += fraction
+		} else if cr.cpuType == cpuReserved {
+			// allocate requested portion of reserved CPUs
+			if cs.AllocatableReservedCPU() < fraction {
+				return nil, policyError("internal error: "+
+					"%s: not enough reserved CPU: %dm requested, %dm available",
+					cs.node.Name(), fraction, cs.AllocatableReservedCPU())
+			}
+			cs.grantedReserved += fraction
 		}
-		cs.granted += cr.fraction
 	}
 
 	allocatedMem, err := cs.allocateMemory(cr)
@@ -542,7 +595,7 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 		memType = cr.memType
 	}
 
-	grant := newGrant(cs.node, cr.GetContainer(), exclusive, cr.fraction, memType, cr.memType, allocatedMem, coldStart)
+	grant := newGrant(cs.node, cr.GetContainer(), cr.cpuType, exclusive, fraction, memType, cr.memType, allocatedMem, coldStart)
 
 	grant.AccountAllocate()
 
@@ -574,7 +627,8 @@ func (cs *supply) ReleaseCPU(g Grant) {
 
 	cs.isolated = cs.isolated.Union(isolated)
 	cs.sharable = cs.sharable.Union(sharable)
-	cs.granted -= g.SharedPortion()
+	cs.grantedReserved -= g.ReservedPortion()
+	cs.grantedShared -= g.SharedPortion()
 
 	g.AccountRelease()
 }
@@ -620,27 +674,33 @@ func (cs *supply) SetExtraMemoryReservation(g Grant) {
 }
 
 func (cs *supply) Reserve(g Grant) error {
-	isolated := g.IsolatedCPUs()
-	exclusive := g.ExclusiveCPUs().Difference(isolated)
-	fraction := g.SharedPortion()
-
-	if !cs.isolated.Intersection(isolated).Equals(isolated) {
-		return policyError("can't reserve isolated CPUs (%s) of %s from %s",
-			isolated.String(), g.String(), cs.DumpAllocatable())
+	if g.CPUType() == cpuNormal {
+		isolated := g.IsolatedCPUs()
+		exclusive := g.ExclusiveCPUs().Difference(isolated)
+		sharedPortion := g.SharedPortion()
+		if !cs.isolated.Intersection(isolated).Equals(isolated) {
+			return policyError("can't reserve isolated CPUs (%s) of %s from %s",
+				isolated.String(), g.String(), cs.DumpAllocatable())
+		}
+		if !cs.sharable.Intersection(exclusive).Equals(exclusive) {
+			return policyError("can't reserve exclusive CPUs (%s) of %s from %s",
+				exclusive.String(), g.String(), cs.DumpAllocatable())
+		}
+		if cs.AllocatableSharedCPU() < 1000*exclusive.Size()+sharedPortion {
+			return policyError("can't reserve %d shared CPUs of %s from %s",
+				sharedPortion, g.String(), cs.DumpAllocatable())
+		}
+		cs.isolated = cs.isolated.Difference(isolated)
+		cs.sharable = cs.sharable.Difference(exclusive)
+		cs.grantedShared += sharedPortion
+	} else if g.CPUType() == cpuReserved {
+		sharedPortion := 1000*g.ExclusiveCPUs().Size() + g.SharedPortion()
+		if sharedPortion > 0 && cs.AllocatableReservedCPU() < sharedPortion {
+			return policyError("can't reserve %d reserved CPUs of %s from %s",
+				sharedPortion, g.String(), cs.DumpAllocatable())
+		}
+		cs.grantedReserved += sharedPortion
 	}
-	if !cs.sharable.Intersection(exclusive).Equals(exclusive) {
-		return policyError("can't reserve exclusive CPUs (%s) of %s from %s",
-			exclusive.String(), g.String(), cs.DumpAllocatable())
-	}
-
-	if cs.AllocatableSharedCPU() < 1000*exclusive.Size()+fraction {
-		return policyError("can't reserve %d fractional CPUs of %s from %s",
-			fraction, g.String(), cs.DumpAllocatable())
-	}
-
-	cs.isolated = cs.isolated.Difference(isolated)
-	cs.sharable = cs.sharable.Difference(exclusive)
-	cs.granted += fraction
 
 	g.AccountAllocate()
 
@@ -688,6 +748,11 @@ func (cs *supply) DumpCapacity() string {
 		cpu = fmt.Sprintf("isolated:%s", kubernetes.ShortCPUSet(cs.isolated))
 		sep = ", "
 	}
+	if !cs.reserved.IsEmpty() {
+		cpu += sep + fmt.Sprintf("reserved:%s (%dm)", kubernetes.ShortCPUSet(cs.reserved),
+			1000*cs.reserved.Size())
+		sep = ", "
+	}
 	if !cs.sharable.IsEmpty() {
 		cpu += sep + fmt.Sprintf("sharable:%s (%dm)", kubernetes.ShortCPUSet(cs.sharable),
 			1000*cs.sharable.Size())
@@ -720,22 +785,28 @@ func (cs *supply) DumpAllocatable() string {
 		cpu = fmt.Sprintf("isolated:%s", kubernetes.ShortCPUSet(cs.isolated))
 		sep = ", "
 	}
-
-	local_granted := cs.granted
-	total_granted := cs.node.GrantedSharedCPU()
+	if !cs.reserved.IsEmpty() {
+		cpu += sep + fmt.Sprintf("reserved:%s (allocatable: %dm)", kubernetes.ShortCPUSet(cs.reserved), cs.AllocatableReservedCPU())
+		sep = ", "
+		if cs.grantedReserved > 0 {
+			cpu += sep + fmt.Sprintf("grantedReserved:%dm", cs.grantedReserved)
+		}
+	}
+	local_grantedShared := cs.grantedShared
+	total_grantedShared := cs.node.GrantedSharedCPU()
 	if !cs.sharable.IsEmpty() {
 		cpu += sep + fmt.Sprintf("sharable:%s (", kubernetes.ShortCPUSet(cs.sharable))
 		sep = ""
-		if local_granted > 0 || total_granted > 0 {
-			cpu += fmt.Sprintf("granted:")
+		if local_grantedShared > 0 || total_grantedShared > 0 {
+			cpu += fmt.Sprintf("grantedShared:")
 			kind := ""
-			if local_granted > 0 {
-				cpu += fmt.Sprintf("%dm", local_granted)
+			if local_grantedShared > 0 {
+				cpu += fmt.Sprintf("%dm", local_grantedShared)
 				kind = "local"
 				sep = "/"
 			}
-			if total_granted > 0 {
-				cpu += sep + fmt.Sprintf("%dm", total_granted)
+			if total_grantedShared > 0 {
+				cpu += sep + fmt.Sprintf("%dm", total_grantedShared)
 				kind += sep + "subtree"
 			}
 			cpu += " " + kind
@@ -766,12 +837,12 @@ func (cs *supply) DumpAllocatable() string {
 // newRequest creates a new request for the given container.
 func newRequest(container cache.Container) Request {
 	pod, _ := container.GetPod()
-	full, fraction, isolate, elevate := cpuAllocationPreferences(pod, container)
+	full, fraction, isolate, cpuType, elevate := cpuAllocationPreferences(pod, container)
 	req, lim, mtype := memoryAllocationPreference(pod, container)
 	coldStart := time.Duration(0)
 
-	log.Debug("%s: CPU preferences: full=%v, fraction=%v, isolate=%v",
-		container.PrettyName(), full, fraction, isolate)
+	log.Debug("%s: CPU preferences: cpuType=%s, full=%v, fraction=%v, isolate=%v",
+		container.PrettyName(), cpuType, full, fraction, isolate)
 
 	if mtype == memoryUnspec {
 		mtype = defaultMemoryType
@@ -803,6 +874,7 @@ func newRequest(container cache.Container) Request {
 		full:      full,
 		fraction:  fraction,
 		isolate:   isolate,
+		cpuType:   cpuType,
 		memReq:    req,
 		memLim:    lim,
 		memType:   mtype,
@@ -836,6 +908,16 @@ func (cr *request) String() string {
 		return fmt.Sprintf("<CPU request "+
 			cr.container.PrettyName()+": shared: %d>", cr.fraction) + mem
 	}
+}
+
+// CPUType returns the requested type of CPU for the grant.
+func (cr *request) CPUType() cpuClass {
+	return cr.cpuType
+}
+
+// SetCPUType sets the requested type of CPU for the grant.
+func (cr *request) SetCPUType(cpuType cpuClass) {
+	cr.cpuType = cpuType
 }
 
 // FullCPUs return the number of full CPUs requested.
@@ -905,25 +987,30 @@ func (cs *supply) GetScore(req Request) Score {
 		part = 1
 	}
 
-	// calculate free shared capacity
+	score.reserved = cs.AllocatableReservedCPU()
 	score.shared = cs.AllocatableSharedCPU()
 
-	// calculate isolated node capacity CPU
-	if cr.isolate {
-		score.isolated = cs.isolated.Size() - full
-	}
+	if cr.CPUType() == cpuReserved {
+		// calculate free reserved capacity
+		score.reserved -= part
+	} else {
+		// calculate isolated node capacity CPU
+		if cr.isolate {
+			score.isolated = cs.isolated.Size() - full
+		}
 
-	// if we don't want isolated or there is not enough, calculate slicable capacity
-	if !cr.isolate || score.isolated < 0 {
-		score.shared -= 1000 * full
-	}
+		// if we don't want isolated or there is not enough, calculate slicable capacity
+		if !cr.isolate || score.isolated < 0 {
+			score.shared -= 1000 * full
+		}
 
-	// calculate fractional capacity
-	score.shared -= part
+		// calculate fractional capacity
+		score.shared -= part
+	}
 
 	// calculate colocation score
 	for _, grant := range cs.node.Policy().allocations.grants {
-		if grant.GetCPUNode().NodeID() == cs.node.NodeID() {
+		if cr.CPUType() == grant.CPUType() && grant.GetCPUNode().NodeID() == cs.node.NodeID() {
 			score.colocated++
 		}
 	}
@@ -954,6 +1041,23 @@ func (cs *supply) GetScore(req Request) Score {
 	}
 
 	return score
+}
+
+// AllocatableReservedCPU calculates the allocatable amount of reserved CPU of this supply.
+func (cs *supply) AllocatableReservedCPU() int {
+	if cs.reserved.Size() == 0 {
+		// This supply has no room for reserved (not even of zero-sized)
+		return -1
+	}
+	reserved := 1000*cs.reserved.Size() - cs.node.GrantedReservedCPU()
+	for node := cs.node.Parent(); !node.IsNil(); node = node.Parent() {
+		pSupply := node.FreeSupply()
+		pReserved := 1000*pSupply.ReservedCPUs().Size() - pSupply.GetNode().GrantedReservedCPU()
+		if pReserved < reserved {
+			reserved = pReserved
+		}
+	}
+	return reserved
 }
 
 // AllocatableSharedCPU calculates the allocatable amount of shared CPU of this supply.
@@ -1001,6 +1105,10 @@ func (score *score) IsolatedCapacity() int {
 	return score.isolated
 }
 
+func (score *score) ReservedCapacity() int {
+	return score.reserved
+}
+
 func (score *score) SharedCapacity() int {
 	return score.shared
 }
@@ -1014,12 +1122,12 @@ func (score *score) HintScores() map[string]float64 {
 }
 
 func (score *score) String() string {
-	return fmt.Sprintf("<CPU score: node %s, isolated:%d, shared:%d, colocated:%d, hints: %v>",
-		score.supply.GetNode().Name(), score.isolated, score.shared, score.colocated, score.hints)
+	return fmt.Sprintf("<CPU score: node %s, isolated:%d, reserved:%d, shared:%d, colocated:%d, hints: %v>",
+		score.supply.GetNode().Name(), score.isolated, score.reserved, score.shared, score.colocated, score.hints)
 }
 
 // newGrant creates a CPU grant from the given node for the container.
-func newGrant(n Node, c cache.Container, exclusive cpuset.CPUSet, portion int, initialMt, mt memoryType, allocatedMem memoryMap, coldStart time.Duration) Grant {
+func newGrant(n Node, c cache.Container, cpuType cpuClass, exclusive cpuset.CPUSet, cpuPortion int, initialMt, mt memoryType, allocatedMem memoryMap, coldStart time.Duration) Grant {
 	mems := n.GetMemset(initialMt)
 	if mems.Size() == 0 {
 		mems = n.GetMemset(memoryDRAM)
@@ -1032,8 +1140,9 @@ func newGrant(n Node, c cache.Container, exclusive cpuset.CPUSet, portion int, i
 		node:         n,
 		memoryNode:   n,
 		container:    c,
+		cpuType:      cpuType,
 		exclusive:    exclusive,
-		portion:      portion,
+		cpuPortion:   cpuPortion,
 		memType:      mt,
 		memset:       mems.Clone(),
 		allocatedMem: allocatedMem,
@@ -1061,19 +1170,45 @@ func (cg *grant) SetMemoryNode(n Node) {
 	cg.memset = n.GetMemset(cg.MemoryType())
 }
 
+// CPUType returns the requested type of CPU for the grant.
+func (cg *grant) CPUType() cpuClass {
+	return cg.cpuType
+}
+
+// CPUPortion returns granted milli-CPUs of non-full CPUs of CPUType().
+func (cg *grant) CPUPortion() int {
+	return cg.cpuPortion
+}
+
 // ExclusiveCPUs returns the non-isolated exclusive CPUSet in this grant.
 func (cg *grant) ExclusiveCPUs() cpuset.CPUSet {
 	return cg.exclusive
 }
 
-// SharedCPUs returns the shared CPUSet in this grant.
+// ReservedCPUs returns the reserved CPUSet in the supply of this grant.
+func (cg *grant) ReservedCPUs() cpuset.CPUSet {
+	return cg.node.GetSupply().ReservedCPUs()
+}
+
+// ReservedPortion returns the milli-CPU allocation for the reserved CPUSet in this grant.
+func (cg *grant) ReservedPortion() int {
+	if cg.cpuType == cpuReserved {
+		return cg.cpuPortion
+	}
+	return 0
+}
+
+// SharedCPUs returns the shared CPUSet in the supply of this grant.
 func (cg *grant) SharedCPUs() cpuset.CPUSet {
 	return cg.node.FreeSupply().SharableCPUs()
 }
 
 // SharedPortion returns the milli-CPU allocation for the shared CPUSet in this grant.
 func (cg *grant) SharedPortion() int {
-	return cg.portion
+	if cg.cpuType == cpuNormal {
+		return cg.cpuPortion
+	}
+	return 0
 }
 
 // ExclusiveCPUs returns the isolated exclusive CPUSet in this grant.
@@ -1098,30 +1233,31 @@ func (cg *grant) MemLimit() memoryMap {
 
 // String returns a printable representation of the CPU grant.
 func (cg *grant) String() string {
-	var isolated, exclusive, shared, sep string
-
+	var cpuType, isolated, exclusive, reserved, shared string
+	cpuType = fmt.Sprintf("cputype: %s", cg.cpuType)
 	isol := cg.IsolatedCPUs()
 	if !isol.IsEmpty() {
-		isolated = fmt.Sprintf("isolated: %s", isol)
-		sep = ", "
+		isolated = fmt.Sprintf(", isolated: %s", isol)
 	}
 	if !cg.exclusive.IsEmpty() {
-		exclusive = fmt.Sprintf("%sexclusive: %s", sep, cg.exclusive)
-		sep = ", "
+		exclusive = fmt.Sprintf(", exclusive: %s", cg.exclusive)
 	}
-	if cg.portion > 0 {
-		shared = fmt.Sprintf("%sshared: %s (%dm)", sep,
-			cg.node.FreeSupply().SharableCPUs(), cg.portion)
-		sep = ", "
+	if cg.ReservedPortion() > 0 {
+		reserved = fmt.Sprintf(", reserved: %s (%dm)",
+			cg.node.FreeSupply().ReservedCPUs(), cg.ReservedPortion())
+	}
+	if cg.SharedPortion() > 0 {
+		shared = fmt.Sprintf(", shared: %s (%dm)",
+			cg.node.FreeSupply().SharableCPUs(), cg.SharedPortion())
 	}
 
 	mem := cg.allocatedMem.String()
 	if mem != "" {
-		mem = sep + "MemLimit: " + mem
+		mem = ", MemLimit: " + mem
 	}
 
-	return fmt.Sprintf("<CPU grant for %s from %s: %s%s%s%s>",
-		cg.container.PrettyName(), cg.node.Name(), isolated, exclusive, shared, mem)
+	return fmt.Sprintf("<CPU grant for %s from %s: %s%s%s%s%s%s>",
+		cg.container.PrettyName(), cg.node.Name(), cpuType, isolated, exclusive, reserved, shared, mem)
 }
 
 func (cg *grant) AccountAllocate() {

--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test02-annotation-memory-type/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test02-annotation-memory-type/code.var.sh
@@ -1,16 +1,17 @@
 # Test that container memory is pinned according to memory-type annotation
 
-# pod0c0 runs on the first node, uses only dram
-# pod0c1 runs on the second node, uses only pmem
-# pod0c2 runs on the third node, uses dram+pmem
-# pod0c9 runs on the fourth node, no memory-type restrictions (use both)
+# pod0c0 runs on node 1, uses only dram
+# pod0c1 runs on node 2, uses only pmem
+# pod0c2 runs on node 3, uses dram+pmem
+# pod0c9 runs on root node (all non-reserved CPUs),
+#     no memory-type restrictions (=> use all memory nodes)
 MEM=250M MEMTYPEC0=dram MEMTYPEC1=pmem MEMTYPEC2=pmem,dram create memtype-guaranteed
-
-verify 'cpus["pod0c0"] == {"cpu0"}' \
-       'mems["pod0c0"] == {"node0"}' \
-       'cpus["pod0c1"] == {"cpu1"}' \
-       'mems["pod0c1"] == {"node7"}' \
-       'cpus["pod0c2"] == {"cpu2"}' \
-       'mems["pod0c2"] == {"node2", "node4"}' \
-       'cpus["pod0c9"] == {"cpu3"}' \
-       'mems["pod0c9"] == {"node3", "node5"}'
+report allowed
+verify 'cpus["pod0c0"] == {"cpu1"}' \
+       'mems["pod0c0"] == {"node1"}' \
+       'cpus["pod0c1"] == {"cpu2"}' \
+       'mems["pod0c1"] == {"node4"}' \
+       'cpus["pod0c2"] == {"cpu3"}' \
+       'mems["pod0c2"] == {"node3", "node5"}' \
+       'cpus["pod0c9"] == {"cpu1", "cpu2", "cpu3"}' \
+       'mems["pod0c9"] == {"node0", "node1", "node2", "node3", "node4", "node5", "node6", "node7"}'

--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test03-coldstart/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test03-coldstart/code.var.sh
@@ -32,8 +32,8 @@ echo "Wait that coldstart period is started for the pod"
 vm-run-until "$CRI_RESMGR_OUTPUT | grep 'coldstart: triggering coldstart for pod0:pod0c0'" ||
     error "cri-resmgr did not report triggering coldstart period"
 
-verify 'cores["pod0c0"] == {"node0/core0"}' \
-       "mems['pod0c0'] == {'node6'}" # PMEM node6 is the closest to CPU node0
+verify 'cores["pod0c0"] == {"node1/core0"}' \
+       "mems['pod0c0'] == {'node7'}"
 
 echo "Wait that the pod has finished memory allocation during cold period."
 vm-run-until "pgrep -f '^sh -c paused after cold_alloc'" >/dev/null ||
@@ -55,11 +55,11 @@ sleep 5s
 vm-run-until --timeout ${DURATION%s} "[ \$($CRI_RESMGR_OUTPUT | grep 'finishing coldstart period for pod0:pod0c0' | wc -l) -gt $coldstarts ]" ||
     error "cri-resmgr did not report finishing coldstart period within $DURATION"
 
-vm-command "$CRI_RESMGR_OUTPUT | grep 'pinning to memory 0,6'" ||
+vm-command "$CRI_RESMGR_OUTPUT | grep 'pinning to memory 1,7'" ||
     error "cri-resmgr did not report pinning to expected memory nodes"
 
-verify 'cores["pod0c0"] == {"node0/core0"}' \
-       'mems["pod0c0"] == {"node0", "node6"}'
+verify 'cores["pod0c0"] == {"node1/core0"}' \
+       'mems["pod0c0"] == {"node1", "node7"}'
 
 echo "Let the pod continue from cold_alloc to warm_alloc."
 vm-command 'kill -9 $(pgrep -f "^sh -c paused after cold_alloc")'

--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test04-dynamic-page-demotion/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test04-dynamic-page-demotion/code.var.sh
@@ -36,7 +36,7 @@ pages_per_second_per_process="$(awk '
 
 # After how many rounds (seconds) first migrations should be visible.
 first_migrations_visible="$(awk '
-    /PageScanInterval:/{gsub(/[^0-9]/, "", $2); print $2+1}
+    /PageScanInterval:/{gsub(/[^0-9]/, "", $2); print $2+3}
     ' < "$cri_resmgr_cfg")"
 
 # Expected migrated number of pages when fully migrated.

--- a/test/e2e/policies.test-suite/memtier/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/n4c16/test00-basic-placement/code.var.sh
@@ -29,7 +29,7 @@ kubectl delete pods --all --now
 
 # pod2: Test that 4 burstable containers not eligible for isolated/exclusive CPU allocation
 # gets evenly spread over NUMA nodes.
-CONTCOUNT=4 CPUREQ=3 CPULIM=4 create burstable
+CONTCOUNT=4 CPUREQ=2 CPULIM=4 create burstable
 report allowed
 verify \
     'disjoint_sets(cpus["pod2c0"], cpus["pod2c1"], cpus["pod2c2"], cpus["pod2c3"])' \

--- a/test/e2e/policies.test-suite/memtier/n4c16/test02-shrink-and-grow-shared/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/n4c16/test02-shrink-and-grow-shared/code.var.sh
@@ -28,13 +28,19 @@ report allowed
 
 # Next squeeze the besteffort containers to the minimum.
 
-# pod2: 4 guaranteed containers, each requiring 4 CPUs.
+# pod2: 4 guaranteed containers, each requiring 3 CPUs.
 CPU=3 CONTCOUNT=4 create guaranteed
 report allowed
 verify \
     'len(cpus["pod2c0"]) == len(cpus["pod2c1"]) == len(cpus["pod2c2"]) == len(cpus["pod2c3"]) == 3' \
     'disjoint_sets(cpus["pod2c0"], cpus["pod2c1"], cpus["pod2c2"], cpus["pod2c3"])'
 
-# pod3: 3 guaranteed containers, each requiring 1 CPU.
-CPU=1 CONTCOUNT=3 create guaranteed
+# pod3: 1 guaranteed container taking the last non-reserved CPU
+# that can be taken from shared pools.
+CPU=1 create guaranteed
 report allowed
+verify \
+    'disjoint_sets(
+         set.union(cpus["pod1c0"], cpus["pod1c1"]),
+         set.union(cpus["pod3c0"],
+                   cpus["pod2c0"], cpus["pod2c1"], cpus["pod2c2"], cpus["pod2c3"]))'

--- a/test/e2e/policies.test-suite/memtier/n4c16/test03-simple-affinity/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/n4c16/test03-simple-affinity/code.var.sh
@@ -49,21 +49,21 @@ CONTCOUNT=4 CPU=1 create guaranteed+affinity
 report allowed
 
 verify \
-    'nodes["pod0c0"] == {"node0"}' \
-    'nodes["pod0c1"] == {"node1"}' \
-    'nodes["pod0c2"] == {"node2"}' \
-    'nodes["pod0c3"] == {"node3"}'
+    'nodes["pod0c0"] == {"node1"}' \
+    'nodes["pod0c1"] == {"node2"}' \
+    'nodes["pod0c2"] == {"node3"}' \
+    'nodes["pod0c3"] == {"node0"}'
 
 kubectl delete pods --all --now
 
 # pod1
-# 4 containers, affinites [0,1], [2,3] => colocate c0,c1 in node0, c2,c3 in node1
+# 4 containers, affinites [0,1], [2,3] => colocate c0,c1 in node1, c2,c3 in node2
 CONTCOUNT=4 AFFINITIES="pod1c0:pod1c1 pod1c2:pod1c3" CPU=1 create guaranteed+affinity
 report allowed
 
 verify \
-    'nodes["pod1c0"] == nodes["pod1c1"] == {"node0"}' \
-    'nodes["pod1c2"] == nodes["pod1c3"] == {"node1"}'
+    'nodes["pod1c0"] == nodes["pod1c1"] == {"node1"}' \
+    'nodes["pod1c2"] == nodes["pod1c3"] == {"node2"}'
 
 kubectl delete pods --all --now
 
@@ -77,4 +77,3 @@ report allowed
 verify \
     'disjoint_sets(nodes["pod2c4"], nodes["pod2c0"], nodes["pod2c1"], nodes["pod2c2"])' \
     'disjoint_sets(nodes["pod2c5"], nodes["pod2c0"], nodes["pod2c2"], nodes["pod2c3"])'
-

--- a/test/e2e/policies.test-suite/memtier/n4c16/test05-reserved-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/memtier/n4c16/test05-reserved-resources/code.var.sh
@@ -1,0 +1,108 @@
+# Test that
+# - kube-system containers are pinned on Reserved CPUs.
+# - Reserved CPU allocation and releasing works.
+# - A pod cannot be launched if reserved CPU capacity in insufficient.
+
+AVAILABLE_CPU="cpuset:4-7,8-13"
+
+# This script will create pods to the kube-system namespace
+# that is not automatically cleaned up by the framework.
+# Make sure the namespace is clear when starting the test and clean it up
+# if exiting with success. Otherwise leave the pod running for
+# debugging in case of a failure.
+cleanup-kube-system() {
+    ( kubectl delete pods pod0 pod1 pod2 pod3 pod4 pod5 -n kube-system --now ) || true
+}
+cleanup-kube-system
+
+# Test launch failure, Reserved CPUs is not subset of Available CPUs
+terminate cri-resmgr
+RESERVED_CPU="cpuset:3,7,11,15"
+cri_resmgr_cfg=$(instantiate cri-resmgr-reserved.cfg)
+( launch cri-resmgr ) && error "unexpected success" || {
+    echo "Launch failed as expected"
+}
+
+# Test launch failure, there are more reserved CPUs than available CPUs
+terminate cri-resmgr
+RESERVED_CPU="11"
+cri_resmgr_cfg=$(instantiate cri-resmgr-reserved.cfg)
+( launch cri-resmgr ) && error "unexpected success" || {
+    echo "Launch failed as expected"
+}
+
+# Test that BestEffort containers are allowed to run on both Reserved
+# CPUs when the CPUs are on the same NUMA node.
+terminate cri-resmgr
+RESERVED_CPU="cpuset:10-11"
+cri_resmgr_cfg=$(instantiate cri-resmgr-reserved.cfg)
+launch cri-resmgr
+
+namespace=kube-system CONTCOUNT=3 create besteffort
+report allowed
+verify "cpus['pod0c0'] == cpus['pod0c1'] == cpus['pod0c2'] == {'cpu10', 'cpu11'}"
+kubectl delete -n kube-system pods pod0
+
+# Test that BestEffort containers are pinned and balanced to separate
+# Reserved CPUs when the CPUs are on different NUMA nodes.
+terminate cri-resmgr
+RESERVED_CPU="cpuset:7,11"
+cri_resmgr_cfg=$(instantiate cri-resmgr-reserved.cfg)
+launch cri-resmgr
+
+namespace=kube-system CONTCOUNT=4 create besteffort
+report allowed
+verify "len(cpus['pod1c0']) == 1" \
+       "len(cpus['pod1c1']) == 1" \
+       "len(cpus['pod1c2']) == 1" \
+       "len(cpus['pod1c3']) == 1" \
+       "set.intersection(cpus['pod1c0'], cpus['pod1c1'], cpus['pod1c2'], cpus['pod1c3']) == set()" \
+       "set.union(cpus['pod1c0'], cpus['pod1c1'], cpus['pod1c2'], cpus['pod1c3']) == {'cpu07', 'cpu11'}"
+
+# Test that kube-system pods are pinned to Reserved CPUs.
+# Check balancing to Reserved CPU groups on separate NUMA nodes.
+namespace=kube-system CPU=200m CONTCOUNT=4 create guaranteed
+report allowed
+verify "len(cpus['pod2c0']) == 1" \
+       "len(cpus['pod2c1']) == 1" \
+       "len(cpus['pod2c2']) == 1" \
+       "len(cpus['pod2c3']) == 1" \
+       "set.intersection(cpus['pod2c0'], cpus['pod2c1'], cpus['pod2c2'], cpus['pod2c3']) == set()" \
+       "set.union(cpus['pod2c0'], cpus['pod2c1'], cpus['pod2c2'], cpus['pod2c3']) == {'cpu07', 'cpu11'}"
+
+# Test requesting more reserved CPUs than available on single node
+# but what fits in the node tree.
+# pod2 already consumed 4 * 200m of reserved CPUs that have been balanced
+# so that at least 200m from both nodes have been consumed. There are
+# at most 800m reserved CPUs free on both nodes. Root node still has
+# 1200m free. That is, 1000m requesting, isolated-looking guaranteed
+# pod should fit in because reserved CPUs are not isolated.
+#
+# Run this twice to make sure allocated reserved CPUs are released correctly.
+for pod in pod3 pod4; do
+    namespace=kube-system CPU=1 CONTCOUNT=1 create guaranteed
+    verify "cpus['${pod}c0'] == {'cpu07', 'cpu11'}"
+    kubectl delete -n kube-system pods/$pod --now
+done
+
+# Test requesting more reserved CPUs than available in the system
+( wait_t=2s namespace=kube-system CPU=2 CONTCOUNT=1 create guaranteed ) && error "pod created but timeout expected" || {
+        echo "failed as expected"
+}
+vm-run-until "kubectl describe pod pod5 -n kube-system | grep 'not enough reserved CPU'" || {
+    error 'cannot find "not enough reserved CPU" when looking for reason why it is not running'
+}
+
+cleanup-kube-system
+
+# Test that the first available CPUs are reserved when reserving milli CPUs.
+# The number of reserved CPUs is the ceiling of the milli CPUs.
+reset counters
+terminate cri-resmgr
+RESERVED_CPU="2250m"
+cri_resmgr_cfg=$(instantiate cri-resmgr-reserved.cfg)
+launch cri-resmgr
+namespace=kube-system CPU=2 CONTCOUNT=1 create besteffort
+verify "cpus['pod0c0'] == {'cpu04', 'cpu05', 'cpu06'}"
+
+kubectl delete -n kube-system pods/pod0

--- a/test/e2e/policies.test-suite/memtier/n4c16/test05-reserved-resources/cri-resmgr-reserved.cfg.in
+++ b/test/e2e/policies.test-suite/memtier/n4c16/test05-reserved-resources/cri-resmgr-reserved.cfg.in
@@ -1,0 +1,8 @@
+policy:
+  Active: memtier
+  AvailableResources:
+    cpu: ${AVAILABLE_CPU}
+  ReservedResources:
+    cpu: ${RESERVED_CPU}
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy


### PR DESCRIPTION
    - Pin kube-system and BestEffort pods to Reserved CPUs when Reserved
      cpuset is defined.
    - If Reserved cpuset is not defined, keep earlier behavior: use
      shared CPUs.
    - A pod running on reserved CPUs is assigned to a NUMA node with most
      free reserved CPU resources per colocated reserved container.
    - Reserved CPUs cannot be exclusively allocated.
    - Introduce cpuType to pod-preferences to support handling processor
      flavors in the future.
    - Add e2e test for reserved CPUs.
