### PR TITLE
benchmark: add memtier_benchmark for memcached/redis

### DIFF
--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/cri-resmgr.cfg
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/cri-resmgr.cfg
@@ -1,0 +1,6 @@
+policy:
+  Active: memtier
+  ReservedResources:
+    CPU: 750m
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/memtier-benchmark.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/memtier-benchmark.yaml.in
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: memtier-benchmark
+spec:
+  template:
+    metadata:
+      annotations:
+        cri-resource-manager.intel.com/${AFFINITY}: |+
+          memtier-benchmark:
+            - scope:
+                key: pod/name
+                operator: Matches
+                values:
+                  - redis-*
+              match:
+                key: name
+                operator: Equals
+                values:
+                  - redis
+              weight: 10
+    spec:
+      containers:
+        - name: memtier-benchmark
+          image: redislabs/memtier_benchmark:edge
+          args: ['${ARGS// /\', \'}']
+          $(if [ "$CPU" != "0" ]; then echo "
+          resources:
+            requests:
+              cpu: ${CPU}
+              memory: '${MEM}'
+            limits:
+              cpu: ${CPULIM}
+              memory: '${MEMLIM}'
+          "; fi)
+      restartPolicy: Never

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/n4c16/test01-memtier-stress-ng/code.var.sh
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/n4c16/test01-memtier-stress-ng/code.var.sh
@@ -1,0 +1,82 @@
+# Redis parameters
+REDIS_PASS=abc123xyz
+
+# Background load parameters
+STRESS_NG_CPUS=16 # workers per container
+STRESS_NG_CONTS=8 # number of containers per pod
+STRESS_NG_PODS=2 # number of pods
+
+# BG_* are background loads
+# CPU turbo licence level 2 (causes big drop on GHz) cannot be reached with stress-ng, but could be implemented with
+# 1. ["avx-turbo", "--test=avx512_vlzcnt_t", "--min-threads=1", "--max-threads=1", "--iters=0"]
+# 2. ["avx-turbo", "--test=avx512_vlzcnt_t", "--min-threads=1", "--max-threads=1", "--iters=0"]
+# License level observed with:
+# sudo perf stat --pid $(pidof avx-turbo) -e core_power.lvl0_turbo_license,core_power.lvl1_turbo_license,core_power.lvl2_turbo_license -- sleep 1
+# In the following: "IPC" == Instructions Per Cycle
+BG_NOLOAD=""
+# BG_AVX_LL0="stress-ng --ipsec-mb $STRESS_NG_CPUS --ipsec-mb-feature avx512" # AVX, causing CPU turbo license level 0
+# BG_AVX_LL1="stress-ng --ipsec-mb $STRESS_NG_CPUS --ipsec-mb-feature avx512" # AVX, causing CPU turbo license level 1
+BG_SHM="stress-ng --shm $STRESS_NG_CPUS" # shared memory, memory bound (not causing 100% CPU load), IPC ~0.01-0.19
+BG_MEMCPY="stress-ng --memcpy $STRESS_NG_CPUS" # memory bound; IPC =~ 0.15
+BG_STREAM="stress-ng --stream $STRESS_NG_CPUS" # IPC =~ 0.49
+BG_CPUJMP="stress-ng --cpu $STRESS_NG_CPUS --cpu-method jmp" # IPC ~3.6
+BG_CPUALL="stress-ng --cpu $STRESS_NG_CPUS" # IPC ~1.8
+
+# BM_* are benchmarks
+bm_stress_ng_iters=10000
+BM_MEMTIER="memtier-benchmark --server=redis-service --authenticate=$REDIS_PASS" # this is special case
+# BM_MEMCPY="stress-ng --memcpy 1 --memcpy-ops $bm_stress_ng_iters" # IPC ~0.15
+# BM_STREAM="stress-ng --stream 1 --stream-ops $bm_stress_ng_iters" # IPC ~0.49
+# BM_JMP="stress-ng --cpu 1 --cpu-method jmp --cpu-ops $bm_stress_ng_iters" # IPC ~3.6
+# BM_FFT="stress-ng --cpu 1 --cpu-method fft --cpu-ops $bm_stress_ng_iters" # IPC ~2.3
+# BM_AVX_LL0="stress-ng --ipsec-mb 1 --ipsec-mb-feature avx2 --ipsec-mb-ops $bm_stress_ng_iters"
+# BM_AVX_LL2="stress-ng --ipsec-mb 1 --ipsec-mb-feature avx512 --ipsec-mb-ops $bm_stress_ng_iters"
+
+# Clean up
+vm-command "kubectl delete jobs --all --now; kubectl delete deployment redis; kubectl delete service redis-service; kubectl delete secret redis; kubectl delete pods --all --now; true"
+
+# Setup Redis
+wait="" create redis-secret
+CPU=4 MEM=32G CPULIM=8 MEMLIM=64G NAME=redis wait="Available" create redis
+NAME=redis-service wait="" create redis-service
+
+for bg_cmd in "${!BG_@}"; do
+    # Reset counters in order to keep creating pod0...
+    reset counters
+
+    benchmark_output_dir="$OUTPUT_DIR/benchmark/$bg_cmd"
+    mkdir -p "$benchmark_output_dir"
+
+    # Start background noise
+    if [[ "${!bg_cmd}" == "stress-ng "* ]]; then
+        n="$STRESS_NG_PODS" ARGS="${!bg_cmd#stress-ng }" CONTCOUNT="$STRESS_NG_CONTS" CPU=50m MEM=50M CPULIM=$STRESS_NG_CPUS MEMLIM=1G wait_t=240s create stress-ng
+        # Stabilize
+        ( vm-run-until --timeout 60 "sh -c 'uptime; exit 1'" ) || echo "expected timeout"
+    fi
+
+    for bm_cmd in "${!BM_@}"; do
+        for CPU in 4; do
+            # Run benchmark
+            if [[ "${!bm_cmd}" == "memtier-benchmark "* ]]; then
+                AFFINITY=affinity CPU="$CPU" MEM="16G" CPULIM="$CPU" MEMLIM="24G" NAME=memtier-benchmark ARGS="${!bm_cmd#memtier-benchmark }" wait="Complete" wait_t="10m" create memtier-benchmark
+                memtier_benchmark_pod="$(kubectl get pods | awk '/memtier-benchmark-/{print $1}')"
+                kubectl logs "$memtier_benchmark_pod" | grep -A7 'ALL STATS' | tee "$benchmark_output_dir/$bm_cmd-affinity-cpu-$CPU.txt"
+                kubectl delete jobs --all --now
+
+                # AFFINITY=anti-affinity CPU="$CPU" MEM="16G" NAME=memtier-benchmark ARGS="${!bm_cmd#memtier-benchmark }" wait="Complete" wait_t="10m" create memtier-benchmark
+                # memtier_benchmark_pod="$(kubectl get pods | awk '/memtier-benchmark-/{print $1}')"
+                # kubectl logs "$memtier_benchmark_pod" | grep -A7 'ALL STATS' | tee "$benchmark_output_dir/$bm_cmd-antiaffinity-cpu-$CPU.txt"
+                # kubectl delete jobs --all --now
+
+            elif [[ "${!bm_cmd}" == "stress-ng "* ]]; then
+                CPU="$CPU" MEM="200M" CPULIM="$STRESS_NG_CPUS" MEM="400M" NAME=stress-ng-benchmark ARGS="${!bm_cmd#stress-ng }" wait="Complete" wait_t="10m" create stress-ng-benchmark
+                stress_ng_benchmark_pod="$(kubectl get pods | awk '/stress-ng-benchmark-/{print $1}')"
+                kubectl logs "$stress_ng_benchmark_pod" | tee "$benchmark_output_dir/$bm_cmd-cpu-$CPU.txt"
+                kubectl delete jobs --all --now
+            fi
+        done
+    done
+
+    # Stop background noise
+    ( kubectl delete pods -l e2erole=bgload --now )
+done

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/n4c16/test01-memtier-stress-ng/post-process.sh
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/n4c16/test01-memtier-stress-ng/post-process.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Usage: VAR=VALUE post-process.sh output-CRICONFIGNAME1 output-CRICONFIGNAME2...
+# VARs:
+#   normalize=1..  # normalizes plotted values so that the smallest is 1.00
+#   normalize=0..1 # normalizes plotted to values between 0.0 and 1.0
+#                  # if normalize="", values are not normalized
+#   maxy=MAXY      # maximum value on the Y axis
+#   ytrans=log2    # logarithmic Y axis, the default ytrans is 'identity'
+#   save=PREFIX    # create PREFIX.svg and PREFIX.csv. The default is 'plot'.
+
+normalize="${normalize:-}"
+maxy="${maxy:-}"
+ytrans="${ytrans:-identity}"
+save="${save:-plot}"
+
+(
+    for out_path in "$@"; do (
+        benchmark_dir=$out_path/benchmark
+        out_dir="$(basename "$out_path")"
+        cd "$benchmark_dir" || exit
+        for bgload in *; do (
+            cd "$bgload" || exit
+            for memtier_results in BM_MEMTIER-*; do
+                p50latency=\$6
+                p99latency=\$7
+                p999latency=\$8
+                awk "/Totals/{print \"$out_dir $bgload $memtier_results \"$p50latency\" \"$p99latency\" \"$p999latency}" < "$memtier_results"
+            done
+        ); done
+    ); done
+) > total-latencies.txt
+
+sed -e 's/output-//g' -e 's/BG_//g' -e 's/BM_MEMTIER-//g' -e 's/-cpu-[0-9]*.txt//g' < total-latencies.txt | awk '{print $1" "$2" "$3" "$4" "$5" "$6}' | grep -v ' antiaffinity' > data.txt
+
+cat > plot.R <<EOF
+library(ggplot2)
+library(svglite)
+d <- read.table(file="data.txt")
+names(d) <- c("cri_conf", "bg_load", "annotations", "p5", "p99", "p999")
+
+if ("$normalize" == "1..") {
+    smallest_value = min(d[c("p5", "p99", "p999")])
+    d[c("p5", "p99", "p999")] = d[c("p5", "p99", "p999")] / smallest_value
+    cat("normalized to 1.., the smallest value was", smallest_value, "\n")
+    latency_unit = "the fastest is 1.0"
+} else if ("$normalize" == "0..1") {
+    smallest_value = min(d[c("p5", "p99", "p999")])
+    largest_value = max(d[c("p5", "p99", "p999")])
+    distance = largest_value - smallest_value
+    d[c("p5", "p99", "p999")] = (d[c("p5", "p99", "p999")] - smallest_value) / distance
+    cat("normalized to 0..1 the smallest value was", smallest_value, "and the largest", largest_value, "\n")
+    latency_unit = "normalized between 0..1"
+} else if ("$normalize" == "") {
+    cat("not normalizing values\n")
+    latency_unit = "ms"
+} else {
+    stop("invalid 'normalize' value")
+}
+
+if ("$maxy" == "") {
+    maxy=NA
+} else {
+    maxy=as.double("$maxy")
+    cat("liming y axis to", maxy, "\n")
+}
+
+d[c("p5", "p99", "p999")] = round(d[c("p5", "p99", "p999")], 2)
+image = (
+    ggplot(d, aes(x=bg_load, group=cri_conf, shape=cri_conf), ylim=c(0, maxy))
+    + ggtitle("Memtier_benchmark total latencies with plain CRI and CRI-RM")
+    + ylab(paste("Latency (", latency_unit, ")", sep=""))
+    + xlab("Background load (stress-ng)")
+    + labs(linetype="Percentiles")
+    + labs(color="CRI layer")
+    + geom_line(aes(color=cri_conf, linetype="50 %", y=p5))
+    + geom_line(aes(color=cri_conf, linetype="99 %", y=p99))
+    + geom_line(aes(color=cri_conf, linetype="99.9 %", y=p999))
+    + scale_x_discrete(limits=c("NOLOAD", "SHM", "CPUALL", "CPUJMP", "MEMCPY", "STREAM"))
+    + scale_y_continuous(limits=c(NA, maxy), trans='$ytrans')
+    )
+# print full data matrix
+d
+print("saving $save.csv")
+write.csv(d, file="$save.csv", row.names=FALSE)
+print("saving $save.svg")
+ggsave(file="$save.svg", plot=image)
+EOF
+Rscript plot.R

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/n4c16/topology.var.json
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/n4c16/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "packages": 2}
+]

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/redis-secret.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/redis-secret.yaml.in
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis
+data:
+  REDIS_PASS: $(base64 -w0 <<< "$REDIS_PASS")
+type: Opaque

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/redis-service.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/redis-service.yaml.in
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: $NAME
+  labels:
+    app: redis
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+  selector:
+    app: redis

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/redis.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/redis.yaml.in
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: redis
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis
+          imagePullPolicy: IfNotPresent
+          args: ['--requirepass', '$REDIS_PASS']
+          ports:
+            - containerPort: 6379
+              name: redis
+          env:
+            - name: MASTER
+              value: 'true'
+            - name: REDIS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: redis
+                  key: REDIS_PASS
+          resources:
+            requests:
+              cpu: ${CPU}
+              memory: '${MEM}'
+            limits:
+              cpu: ${CPULIM}
+              memory: '${MEMLIM}'

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng-benchmark.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng-benchmark.yaml.in
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stress-ng-benchmark
+spec:
+  template:
+    spec:
+      containers:
+        - name: ${NAME}c$(( contnum - 1 ))
+          image: alexeiled/stress-ng
+          args: ['${ARGS// /\', \'}']
+          imagePullPolicy: IfNotPresent
+          $(if [ "$CPU" != "0" ]; then echo "
+          resources:
+            requests:
+              cpu: ${CPU}
+              memory: '${MEM}'
+            limits:
+              cpu: ${CPULIM}
+              memory: '${MEMLIM}'
+          "; fi)
+      restartPolicy: Never

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng.yaml.in
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+    e2erole: bgload
+spec:
+  containers:
+  $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
+  - name: ${NAME}c$(( contnum - 1 ))
+    image: alexeiled/stress-ng
+    args: ['${ARGS// /\', \'}']
+    imagePullPolicy: IfNotPresent
+    $(if [ "$CPU" != "0" ]; then echo "
+    resources:
+      requests:
+        cpu: ${CPU}
+        memory: '${MEM}'
+      limits:
+        cpu: ${CPULIM}
+        memory: '${MEMLIM}'
+    "; fi)
+  "; done )
+  terminationGracePeriodSeconds: 1

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -837,11 +837,16 @@ create() { # script API
                 if [ "$image" = "IMAGE" ]; then
                     continue
                 fi
-                image="${image##*/}"
+                local notopdir_image="${image#*/}"
+                local norepo_image="${image##*/}"
                 if [ "$tag" = "latest" ]; then
                     pulled_images_on_vm+=("$image")
+                    pulled_images_on_vm+=("$notopdir_image")
+                    pulled_images_on_vm+=("$norepo_image")
                 fi
                 pulled_images_on_vm+=("$image:$tag")
+                pulled_images_on_vm+=("$notopdir_image:$tag")
+                pulled_images_on_vm+=("$norepo_image:$tag")
             done <<< "$COMMAND_OUTPUT"
         fi
         for image in $images; do

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -805,6 +805,7 @@ create() { # script API
     local image
     local tag
     local errormsg
+    local default_name=${NAME:-""}
     if [ -z "$n" ]; then
         local n=1
     fi
@@ -818,7 +819,11 @@ create() { # script API
     fi
     for _ in $(seq 1 $n); do
         kind_count[$template_kind]=$(( ${kind_count[$template_kind]} + 1 ))
-        local NAME="${template_kind}$(( ${kind_count[$template_kind]} - 1 ))" # the first pod is pod0
+        if [ -n "$default_name" ]; then
+            local NAME="$default_name"
+        else
+            local NAME="${template_kind}$(( ${kind_count[$template_kind]} - 1 ))" # the first pod is pod0
+        fi
         eval "echo -e \"$(<"${template_file}")\"" | grep -v '^ *$' > "$OUTPUT_DIR/$NAME.yaml"
         host-command "$SCP \"$OUTPUT_DIR/$NAME.yaml\" $VM_SSH_USER@$VM_IP:" || {
             command-error "copying \"$OUTPUT_DIR/$NAME.yaml\" to VM failed"


### PR DESCRIPTION
The initial version of this benchmark needs configuring depending on the hardware where it runs on. Current `CPU`/`CPULIM` values in `code.var.sh` are suitable for testing on servers with ~50..200 CPU cores.