### PR TITLE
test/functional: prevent read/write data race in klog.

### DIFF
--- a/test/functional/e2e_test.go
+++ b/test/functional/e2e_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/dump"
 	"google.golang.org/grpc"
 	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
 
 const (
@@ -39,6 +41,9 @@ const (
 )
 
 func init() {
+	rate := logger.Rate{Limit: logger.Every(1 * time.Minute)}
+	logger.SetGrpcLogger("grpc", &rate)
+
 	if err := os.MkdirAll(testDir, 0700); err != nil {
 		fmt.Printf("unable to create %q: %+v\n", testDir, err)
 	}


### PR DESCRIPTION
Prevent grpc from triggering read/write data race (concurrent klog flag.Set()
by our klogcontrol and klogging connection complaints by default grpc log)
by overriding the grpc logger.

Should fix the latest test failures in #546 