### PR TITLE
e2e: allow user override for VM_SSH_USER over distro-ssh-user

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -35,7 +35,11 @@ vm-image-url() {
 }
 
 vm-ssh-user() {
-    distro-ssh-user
+    if [ -n "$VM_SSH_USER" ]; then
+        echo "$VM_SSH_USER"
+    else
+        distro-ssh-user
+    fi
 }
 
 vm-check-env() {


### PR DESCRIPTION
- Enables running tests on real hardware servers instead of virtual machines.
- Example: VM_IP=servername VM_SSH_USER=username distro=distroname test/e2e/run.sh interactive