### PR TITLE
Improve CPU prioritization

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -109,6 +109,9 @@ type mockCPU struct {
 func (c *mockCPU) BaseFrequency() uint64 {
 	return 0
 }
+func (c *mockCPU) EPP() system.EPP {
+	return system.EPPUnknown
+}
 func (c *mockCPU) ID() system.ID {
 	return system.ID(0)
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -94,6 +94,9 @@ type mockCPU struct {
 func (c *mockCPU) BaseFrequency() uint64 {
 	return c.baseFrequency
 }
+func (c *mockCPU) EPP() system.EPP {
+	return system.EPPUnknown
+}
 func (c *mockCPU) ID() system.ID {
 	return c.id
 }

--- a/pkg/sysfs/utils.go
+++ b/pkg/sysfs/utils.go
@@ -79,6 +79,9 @@ func readSysfsEntry(base, entry string, ptr interface{}, args ...interface{}) (s
 			return "", sysfsError(path, "%v", err)
 		}
 		return buf, nil
+	case *EPP:
+		*ptr.(*EPP) = EPPFromString(buf)
+		return buf, nil
 	}
 
 	return "", sysfsError(path, "unsupported sysfs entry type %T", ptr)


### PR DESCRIPTION
Improve detection of high priority CPUs. Examine
cpufreq/enenrgy_performance_profile setting of each CPU at system
discovery. All other than the least performance-oriented CPUs are
considered as prioritized. Some examples:
- if all cpus have the same epp value none will be flagged as prioritied
- cpus 0,1 are 'balance_performance', 2,3 are 'balance_power' and 4,5
  are 'power' -> cpus 0-3 are flagger as priority cpus

Implements #552 