### PR TITLE
memtier: omit meaningless NUMA nodes from pool tree.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pools.go
@@ -53,6 +53,12 @@ func (p *policy) buildPoolsByTopology() error {
 			dieCnt += n
 		}
 	}
+
+	// don't create nodes for NUMA nodes if we have a single NUMA node per socket.
+	if nodeCnt == socketCnt && memNodeCnt == 0 {
+		nodeCnt = 0
+	}
+
 	poolCnt := socketCnt + dieCnt + nodeCnt - memNodeCnt + map[bool]int{false: 0, true: 1}[socketCnt > 1]
 
 	p.nodes = make(map[string]Node, poolCnt)


### PR DESCRIPTION
If we have only a single NUMA node per socket, NUMA
nodes are equivalent to sockets from the HW topology
point of view. In this case, don't insert pool nodes
representing NUMA nodes into the tree at all.