### PR TITLE
Kata container support

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -84,3 +84,4 @@ policying container resource allocations. Next, you could see:
 - [Setup](setup.md) for details on setup and usage
 - [Node Agent](node-agent.md) for seting up cri-resmgr-agent for dynamic configuration and more
 - [Webhook](webhook.md) for setting up our resource-annotating webhook
+- [Kata support](setup.md#kata-containers) for setting up CRI-RM with Kata containers

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -286,6 +286,46 @@ provided [sample configuration](/sample-configs/cri-full-message-dump.cfg)
 for doing this.
 
 
+## Kata Containers
+
+[Kata Containers](https://katacontainers.io/) is an open source container runtime, 
+building lightweight virtual machines that seamlessly plug into the containers ecosystem.
+
+In order to enable Kata container in a Kubernetes-CRI-RM stack, both Kubernetes 
+and the Container Runtime need to be aware of the new runtime environment:
+
+  * The Container Runtime can only be CRI-O or containerd, and will need to
+   have the runtimes enabled in their configuration files.
+  * Kubernetes will also have to be made aware of the CRI-O/containerd runtimes via a "RuntimeClass" [resource](https://kubernetes.io/docs/concepts/containers/runtime-class/) 
+
+After these prerequisites are satisfied, the configuration file for the target  Kata Container, will have to have the flag "SandboxCgroupOnly" set to true. As of Kata 2.0 this is the only way Kata containers can work with the Kubernetes cgroup naming conventions.
+
+   ```toml
+   ...
+   # If enabled, the runtime will add all the kata processes inside one dedicated cgroup.
+   # The container cgroups in the host are not created, just one single cgroup per sandbox.
+   # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
+   # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+   # The sandbox cgroup is constrained if there is no container type annotation.
+   # See: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
+   sandbox_cgroup_only=true
+   ...
+   ``` 
+
+### Reference
+
+If you have a pre-existing Kubernetes cluster, for an easy deployement follow this [document](https://github.com/kata-containers/packaging/blob/master/kata-deploy/README.md#kubernetes-quick-start).
+
+
+Starting from scratch:
+
+   * [Kata installation guide](https://github.com/kata-containers/kata-containers/tree/2.0-dev/docs/install#manual-installation)
+   * [Kata Containers + CRI-O](https://github.com/kata-containers/documentation/blob/master/how-to/run-kata-with-k8s.md)
+   * [Kata Containers + containerd](https://github.com/kata-containers/documentation/blob/master/how-to/containerd-kata.md)
+   * [Kubernetes Runtime Class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
+   * [Cgroup and Kata containers](https://github.com/kata-containers/kata-containers/blob/stable-2.0.0/docs/design/host-cgroups.md)
+
+
 ## Using Docker as the Runtime
 
 If you must use `docker` as the runtime then the proxying setup is slightly more

--- a/pkg/cri/resource-manager/control/page-migrate/demoter.go
+++ b/pkg/cri/resource-manager/control/page-migrate/demoter.go
@@ -249,7 +249,7 @@ func resetDirtyBit(pid string) error {
 
 // resetDirtyBit unsets soft-dirty bits for all processes in a container.
 func (d *demoter) resetDirtyBit(c *container) error {
-	pids, err := utils.GetProcessesInContainer(c.GetCgroupParentDir(), c.GetID())
+	pids, err := utils.GetProcessesInContainer(c.GetCgroupParentDir(), c.GetPodID(), c.GetID())
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func (d *demoter) getPagesForContainer(c *container, sourceNodes system.IDSet) (
 		pages:        make(map[int][]page, 0),
 		longestRange: 0,
 	}
-	pids, err := utils.GetProcessesInContainer(c.GetCgroupParentDir(), c.GetID())
+	pids, err := utils.GetProcessesInContainer(c.GetCgroupParentDir(), c.GetPodID(), c.GetID())
 	if err != nil {
 		return pagePool{}, err
 	}

--- a/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
+++ b/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
@@ -73,6 +73,7 @@ type migration struct {
 type container struct {
 	cacheID    string
 	id         string
+	podID      string
 	prettyName string
 	parentDir  string
 	pm         *cache.PageMigrate
@@ -170,6 +171,7 @@ func (m *migration) insertContainer(cc cache.Container) error {
 	c := &container{
 		cacheID:    cc.GetCacheID(),
 		id:         cc.GetID(),
+		podID:      cc.GetPodID(),
 		prettyName: cc.PrettyName(),
 		parentDir:  pod.GetCgroupParentDir(),
 		pm:         pm.Clone(),
@@ -210,6 +212,11 @@ func (m *migration) deleteContainer(cc cache.Container) error {
 // GetCacheID replicates the respective cache.Container function.
 func (c *container) GetCacheID() string {
 	return c.cacheID
+}
+
+// GetPodID replicates the respective cache.Container function.
+func (c *container) GetPodID() string {
+	return c.podID
 }
 
 // GetID replicates the respective cache.Container function.

--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -175,7 +175,7 @@ func (ctl *rdtctl) assign(c cache.Container) error {
 		return rdtError("%q: failed to get pod", c.PrettyName())
 	}
 
-	pids, err := utils.GetTasksInContainer(pod.GetCgroupParentDir(), c.GetID())
+	pids, err := utils.GetTasksInContainer(pod.GetCgroupParentDir(), c.GetID(), c.GetPodID())
 	if err != nil {
 		return rdtError("%q: failed to get process list: %v", c.PrettyName(), err)
 	}

--- a/pkg/utils/cgroups.go
+++ b/pkg/utils/cgroups.go
@@ -80,7 +80,7 @@ func isProcess(processID string) bool {
 	return true
 }
 
-func getTasksInContainer(cgroupParentDir, containerID string, onlyProcesses bool) ([]string, error) {
+func getTasksInContainer(cgroupParentDir, podID, containerID string, onlyProcesses bool) ([]string, error) {
 	var entries []string
 
 	// Find Cpuset sub-cgroup directory of this container
@@ -92,6 +92,7 @@ func getTasksInContainer(cgroupParentDir, containerID string, onlyProcesses bool
 			filepath.Join(CpusetCgroupDir, cgroupParentDir, "crio-"+containerID+".scope"),
 			filepath.Join(CpusetCgroupDir, cgroupParentDir, "docker-"+containerID+".scope"),
 			filepath.Join(CpusetCgroupDir, cgroupParentDir, containerID),
+			filepath.Join(CpusetCgroupDir, cgroupParentDir, "kata_"+podID),
 		}
 		for _, d := range dirs {
 			info, err := os.Stat(d)
@@ -130,11 +131,12 @@ func getTasksInContainer(cgroupParentDir, containerID string, onlyProcesses bool
 }
 
 // GetProcessesInContainer gets the IDs of all processes in the container.
-func GetProcessesInContainer(cgroupParentDir, containerID string) ([]string, error) {
-	return getTasksInContainer(cgroupParentDir, containerID, true)
+func GetProcessesInContainer(cgroupParentDir, podID, containerID string) ([]string, error) {
+	return getTasksInContainer(cgroupParentDir, podID, containerID, true)
 }
 
 // GetTasksInContainer gets the IDs of all tasks in the container.
-func GetTasksInContainer(cgroupParentDir, containerID string) ([]string, error) {
-	return getTasksInContainer(cgroupParentDir, containerID, false)
+func GetTasksInContainer(cgroupParentDir, podID, containerID string) ([]string, error) {
+	return getTasksInContainer(cgroupParentDir, podID, containerID, false)
+
 }


### PR DESCRIPTION
This branch adds support for Kata containers in CRI-RM, particularly detection and classification support for the cgroup and RDT controllers.

The solution proposed should solve issue #564 