### PR TITLE
control/rdt: add option to disable rdt monitoring

### DIFF
--- a/docs/policy/rdt.md
+++ b/docs/policy/rdt.md
@@ -76,6 +76,8 @@ data:
   rdt: |+
     # Common options
     options:
+      # Set to true to disable creation of monitoring groups
+      monitoringDisabled: false
       l3:
         # Make this false if CAT must be available
         optional: true

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0
-	github.com/intel/goresctrl v0.0.0-20201123171612-0d2cbe434ecd
+	github.com/intel/goresctrl v0.0.0-20201216151002-453bb7ae55ff
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/intel/goresctrl v0.0.0-20201123171612-0d2cbe434ecd h1:27s0UKxFUeKgmpwK8j774m1rza3s6ZeVGVOP8wY351s=
-github.com/intel/goresctrl v0.0.0-20201123171612-0d2cbe434ecd/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
+github.com/intel/goresctrl v0.0.0-20201216151002-453bb7ae55ff h1:kn9yRJfTKvIZv1o8g5RDW+1EgFFerM8vpudy0OR6+bQ=
+github.com/intel/goresctrl v0.0.0-20201216151002-453bb7ae55ff/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -297,6 +297,7 @@ data:
   rdt: |+
     # Common options
     options:
+      monitoringDisabled: false
       l3:
         optional: true
       mb:


### PR DESCRIPTION
TODO: Remove existing monitoring groups when changing from enabled to disabled. However, for symmetry, assign() should be called on all existing containers on re-configure.

Based on #567 

Also requires https://github.com/intel/goresctrl/pull/16