### PR TITLE
control/rdt: fix and simplify handling of implicit disabling

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -59,6 +59,9 @@ const (
 	// ToptierLimitKey is the pod annotation key for specifying container top tier memory limits.
 	ToptierLimitKey = "toptierlimit" + "." + kubernetes.ResmgrKeyNamespace
 
+	// RDTClassPodQoS denotes that the RDTClass should be taken from PodQosClass
+	RDTClassPodQoS = "/PodQos"
+
 	// ToptierLimitUnset is the reserved value for indicating unset top tier limits.
 	ToptierLimitUnset int64 = -1
 

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -189,7 +189,7 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 func (c *container) setDefaults() error {
 	class, ok := c.GetEffectiveAnnotation(RDTClassKey)
 	if !ok {
-		class = string(c.GetQOSClass())
+		class = RDTClassPodQoS
 	}
 	c.SetRDTClass(class)
 

--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -158,12 +158,14 @@ func (ctl *rdtctl) checkIdle() bool {
 // assign assigns all processes/threads in a container to an RDT class.
 func (ctl *rdtctl) assign(c cache.Container) error {
 	class := c.GetRDTClass()
-	if class == "" {
+	switch class {
+	case "":
 		class = rdt.RootClassName
-	}
-
-	if ctl.idle && cache.IsPodQOSClassName(class) {
-		return nil
+	case cache.RDTClassPodQoS:
+		if ctl.idle {
+			return nil
+		}
+		class = string(c.GetQOSClass())
 	}
 
 	cls, ok := rdt.GetClass(class)


### PR DESCRIPTION
- Take into account that the system root class always exists if rdt has
been initialized, even if the configuration contains no classes.
- Remove the special handling for class names matching Pod QoS class
names. Either the controller is disabled or not, the controller should
be agnostic to the class name.