### PR TITLE
control/rdt: empty class implies root class

### DIFF
--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -168,7 +168,7 @@ func (ctl *rdtctl) isImplicitlyDisabled() bool {
 func (ctl *rdtctl) assign(c cache.Container) error {
 	class := c.GetRDTClass()
 	if class == "" {
-		return nil
+		class = rdt.RootClassName
 	}
 
 	if ctl.isImplicitlyDisabled() && cache.IsPodQOSClassName(class) {


### PR DESCRIPTION
Assign container to the "system root" class if containers RDTClass is
set to an empty string. Root is the default for new containers that do
not have any class set so we should set (back) to root if class is
changed to empty.