### PR TITLE
control/rdt: do forceful rdt (re-)configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0
-	github.com/intel/goresctrl v0.0.0-20201216151002-453bb7ae55ff
+	github.com/intel/goresctrl v0.0.0-20201217135246-82f290c9ec06
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/intel/goresctrl v0.0.0-20201216151002-453bb7ae55ff h1:kn9yRJfTKvIZv1o8g5RDW+1EgFFerM8vpudy0OR6+bQ=
-github.com/intel/goresctrl v0.0.0-20201216151002-453bb7ae55ff/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
+github.com/intel/goresctrl v0.0.0-20201217135246-82f290c9ec06 h1:4RUY0k5RJMUto/UkaCX7KNqXnKlq2YO4heglLSUtqac=
+github.com/intel/goresctrl v0.0.0-20201217135246-82f290c9ec06/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -76,7 +76,7 @@ func (ctl *rdtctl) Start(cache cache.Cache, client client.Client) error {
 		return rdtError("failed to initialize RDT controls: %v", err)
 	}
 
-	if err := rdt.SetConfig(&ctl.opt.Config); err != nil {
+	if err := rdt.SetConfig(&ctl.opt.Config, true); err != nil {
 		// Just print an error. A config update later on may be valid.
 		log.Error("failed apply initial configuration: %v", err)
 	}
@@ -254,7 +254,7 @@ func (ctl *rdtctl) configNotify(event pkgcfg.Event, source pkgcfg.Source) error 
 
 	// Copy goresctrl specific part from our extended options
 	ctl.opt.Config.Options = ctl.opt.Options.Options
-	if err := rdt.SetConfig(&ctl.opt.Config); err != nil {
+	if err := rdt.SetConfig(&ctl.opt.Config, true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Causes obsolete resctrl groups to be deleted even if they are not empty.
Prevents configuration errors in case non-empty classes would be removed
from the config. Makes it possible e.g. to switch rdt to "implicitly
disabled mode" even if there are some running containers. This behavior
is justified as we now re-assign containers on every re-configure event
and containers will get correctly assigned if/when their rdt class
becomes available.