### PR TITLE
control/rdt: implement operating modes

### DIFF
--- a/docs/policy/rdt.md
+++ b/docs/policy/rdt.md
@@ -36,11 +36,31 @@ the builtin policies do that.
 
 ## Configuration
 
-The RDT configuration in CRI-RM is a two-level hierarchy consisting of
+### Operating Modes
+
+The RDT controller supports three operating modes, controlled by
+`rdt.options.mode` configuration option.
+
+- Disabled: RDT controller is effectively disabled and containers will not be
+  assigned and no monitoring groups will be created. Upon activation of this
+  mode all CRI-RM specific control and monitoring groups from the resctrl
+  filesystem are removed.
+- Discovery: RDT controller detects existing non-CRI-RM specific classes from
+  the resctrl filesystem and uses these. The configuration of the discovered
+  classes is considered read-only and it will not be altered. Upon activation
+  of this mode all CRI-RM specific control groups from the resctrl filesystem
+  are removed.
+- Full: Full operating mode. The controller manages the configuration of the
+  resctrl filesystem according to the rdt class definitions in the CRI-RM
+  configiration. This is the default operating mode.
+
+### RDT Classes
+
+The RDT class configuration in CRI-RM is a two-level hierarchy consisting of
 partitions and classes. It specifies a set of partitions each having a set of
 classes.
 
-### Partitions
+#### Partitions
 
 Partitions represent a logical grouping of the underlying classes, each
 partition specifying a portion of the available resources (L3/MB) which will be
@@ -49,7 +69,7 @@ cache allocation - i.e. no overlap on the cache ways between partitions is
 allowed. However, by technology, MB allocations are not exclusive. Thus, it is
 possible to assign all partitions 100% of memory bandwidth, for example.
 
-### Classes
+#### Classes
 
 Classes represent the actual RDT classes containers are assigned to. In
 contrast to partitions, cache allocation between classes under a specific
@@ -76,6 +96,8 @@ data:
   rdt: |+
     # Common options
     options:
+      # One of Full, Discovery or Disabled
+      mode: Full
       # Set to true to disable creation of monitoring groups
       monitoringDisabled: false
       l3:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0
-	github.com/intel/goresctrl v0.0.0-20201217135246-82f290c9ec06
+	github.com/intel/goresctrl v0.0.0-20201221180043-c1bbf3a22bce
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/intel/goresctrl v0.0.0-20201217135246-82f290c9ec06 h1:4RUY0k5RJMUto/UkaCX7KNqXnKlq2YO4heglLSUtqac=
-github.com/intel/goresctrl v0.0.0-20201217135246-82f290c9ec06/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
+github.com/intel/goresctrl v0.0.0-20201221180043-c1bbf3a22bce h1:T9NS/TAXUa6BCc/0lKtYLKaoyqMcky3avaK5Rn4kaa4=
+github.com/intel/goresctrl v0.0.0-20201221180043-c1bbf3a22bce/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -297,6 +297,8 @@ data:
   rdt: |+
     # Common options
     options:
+      # Mode must be one of Full, Discovery or Disabled. Defaults to Full.
+      mode: Full
       monitoringDisabled: false
       l3:
         optional: true


### PR DESCRIPTION
Add a new 'mode' rdt config option to control the operation mode of the
controller. There are three possible modes:

- Disabled:  RDT controller is effectively disabled and containers will
             not be assigned. When activating this mode, the controller
             applies an empty rdt configuration removing all cri-rm
             specific groups from the resctrl filesystem.
- Discovery: RDT controller detects existing non-cri-rm specific
             classes from the resctrl filesystem and uses these.
             CRI-RM will treat the configuration of these as read-only
             and does not alter it.  Similarly to 'Disabled' mode, all
             cri-rm specific groups from the resctrl filesystem are
             dropped when this mode is activated.
- Full:      Full operating mode. RDT controller behaves like
             previously. This is the default.

Depends on https://github.com/intel/goresctrl/pull/21
