### PR TITLE
docs: use an explicit version of recommonmark

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==3.2.1
 sphinx_rtd_theme
-recommonmark
+recommonmark==0.7.1
 sphinx-markdown-tables


### PR DESCRIPTION
Make sure to use the same version everywhere in order to have the same
bugs everywhere.

Bump from v0.6.x to v0.7.x fixes an issue with links to external
markdown (.md) files.