### PR TITLE
rdt: use root class as a fallback to missing classes

### DIFF
--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -169,12 +169,18 @@ func (ctl *rdtctl) assign(c cache.Container) error {
 		class = rdt.RootClassName
 	case cache.RDTClassPodQoS:
 		if ctl.noQoSClasses {
-			return nil
+			class = rdt.RootClassName
+		} else {
+			class = string(c.GetQOSClass())
 		}
-		class = string(c.GetQOSClass())
 	}
 
-	return ctl.assignClass(c, class)
+	err := ctl.assignClass(c, class)
+	if err != nil && class != rdt.RootClassName {
+		log.Warn("%v; falling back to system root class", err)
+		return ctl.assignClass(c, rdt.RootClassName)
+	}
+	return err
 }
 
 // assignClass assigns all processes/threads in a container to the specified class


### PR DESCRIPTION
Assign container to the system root class if the class assignment fails.
The most probable reason is that the class specified for it is missing.
Otherwise the unassigned container(s) will inherit the resctrl group of
the container runtime itself which we want to avoid.  The system root
class is guaranteed to exist and is the obvious fallback default.

Supplements #581 