### PR TITLE
e2e: set imagePullPolicy on every test pod

### DIFF
--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/memtier-benchmark.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/memtier-benchmark.yaml.in
@@ -23,6 +23,7 @@ spec:
       containers:
         - name: memtier-benchmark
           image: redislabs/memtier_benchmark:edge
+          imagePullPolicy: IfNotPresent
           args: ['${ARGS// /\', \'}']
           $(if [ "$CPU" != "0" ]; then echo "
           resources:

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng-benchmark.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng-benchmark.yaml.in
@@ -8,8 +8,8 @@ spec:
       containers:
         - name: ${NAME}c$(( contnum - 1 ))
           image: alexeiled/stress-ng
-          args: ['${ARGS// /\', \'}']
           imagePullPolicy: IfNotPresent
+          args: ['${ARGS// /\', \'}']
           $(if [ "$CPU" != "0" ]; then echo "
           resources:
             requests:

--- a/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng.yaml.in
+++ b/test/e2e/benchmarks.test-suite/memtier_benchmark/stress-ng.yaml.in
@@ -10,8 +10,8 @@ spec:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
     image: alexeiled/stress-ng
-    args: ['${ARGS// /\', \'}']
     imagePullPolicy: IfNotPresent
+    args: ['${ARGS// /\', \'}']
     $(if [ "$CPU" != "0" ]; then echo "
     resources:
       requests:

--- a/test/e2e/besteffort.yaml.in
+++ b/test/e2e/besteffort.yaml.in
@@ -9,10 +9,10 @@ spec:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
     image: busybox
+    imagePullPolicy: IfNotPresent
     command:
       - sh
       - -c
       - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
-    imagePullPolicy: IfNotPresent
   "; done )
   terminationGracePeriodSeconds: 1

--- a/test/e2e/burstable.yaml.in
+++ b/test/e2e/burstable.yaml.in
@@ -9,11 +9,11 @@ spec:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
     image: busybox
+    imagePullPolicy: IfNotPresent
     command:
       - sh
       - -c
       - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
-    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: ${CPUREQ}

--- a/test/e2e/guaranteed.yaml.in
+++ b/test/e2e/guaranteed.yaml.in
@@ -9,11 +9,11 @@ spec:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
     image: busybox
+    imagePullPolicy: IfNotPresent
     command:
       - sh
       - -c
       - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
-    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: ${CPU}

--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test02-annotation-memory-type/memtype-guaranteed.yaml.in
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test02-annotation-memory-type/memtype-guaranteed.yaml.in
@@ -12,6 +12,7 @@ spec:
     $(for CONT in 0 1 2; do echo "
     - name: ${NAME}c${CONT}
       image: busybox
+      imagePullPolicy: IfNotPresent
       command: ['sh', '-c', 'echo ${NAME}c${CONT} \$(sleep inf)']
       resources:
         requests:
@@ -23,6 +24,7 @@ spec:
     "; done)
     - name: ${NAME}c9
       image: busybox
+      imagePullPolicy: IfNotPresent
       command: ['sh', '-c', 'echo ${NAME}c9 \$(sleep inf)']
       resources:
         requests:

--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test03-coldstart/bb-coldstart.yaml.in
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test03-coldstart/bb-coldstart.yaml.in
@@ -12,6 +12,7 @@ spec:
   containers:
     - name: ${NAME}c0
       image: busybox
+      imagePullPolicy: IfNotPresent
       command:
         - sh
         - -c

--- a/test/e2e/policies.test-suite/memtier/c4pmem4/test04-dynamic-page-demotion/bb-memload.yaml.in
+++ b/test/e2e/policies.test-suite/memtier/c4pmem4/test04-dynamic-page-demotion/bb-memload.yaml.in
@@ -12,6 +12,7 @@ spec:
   containers:
     - name: ${NAME}c0
       image: busybox
+      imagePullPolicy: IfNotPresent
       command:
         - sh
         - -c
@@ -25,6 +26,7 @@ spec:
           memory: $(( ${WORN%M} * 1024 * 1024 / $BSIZE + 100000 ))k
     - name: ${NAME}c1
       image: busybox
+      imagePullPolicy: IfNotPresent
       command:
         - sh
         - -c
@@ -38,6 +40,7 @@ spec:
           memory: $(( ${WMRN%M} * 1024 * 1024 / $BSIZE + 100000 ))k
     - name: ${NAME}c2
       image: busybox
+      imagePullPolicy: IfNotPresent
       command:
         - sh
         - -c
@@ -51,6 +54,7 @@ spec:
           memory: $(( ${WORM%M} * 1024 * 1024 / $BSIZE + 100000 ))k
     - name: ${NAME}c3
       image: busybox
+      imagePullPolicy: IfNotPresent
       command:
         - sh
         - -c

--- a/test/e2e/policies.test-suite/memtier/n4c16/test03-simple-affinity/guaranteed+affinity.yaml.in
+++ b/test/e2e/policies.test-suite/memtier/n4c16/test03-simple-affinity/guaranteed+affinity.yaml.in
@@ -13,11 +13,11 @@ spec:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
     image: busybox
+    imagePullPolicy: IfNotPresent
     command:
       - sh
       - -c
       - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
-    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: ${CPU}

--- a/test/e2e/policies.test-suite/static-pools/cmk-exclusive.yaml.in
+++ b/test/e2e/policies.test-suite/static-pools/cmk-exclusive.yaml.in
@@ -14,6 +14,7 @@ spec:
   containers:
     - name: ${NAME}c0
       image: busybox
+      imagePullPolicy: IfNotPresent
       env:
 $([ -z $STP_POOL ] || echo "
         - name: STP_POOL

--- a/test/e2e/policies.test-suite/static-pools/cmk-isolate.yaml.in
+++ b/test/e2e/policies.test-suite/static-pools/cmk-isolate.yaml.in
@@ -14,6 +14,7 @@ spec:
   containers:
     - name: ${NAME}c0
       image: busybox
+      imagePullPolicy: IfNotPresent
       env:
 $([ -z $STP_POOL ] || echo "
         - name: STP_POOL

--- a/test/e2e/policies.test-suite/static-pools/cmk-tolerating-guaranteed.yaml.in
+++ b/test/e2e/policies.test-suite/static-pools/cmk-tolerating-guaranteed.yaml.in
@@ -11,11 +11,11 @@ spec:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
   - name: ${NAME}c$(( contnum - 1 ))
     image: busybox
+    imagePullPolicy: IfNotPresent
     command:
       - sh
       - -c
       - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
-    imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: ${CPU}


### PR DESCRIPTION
- Missing imagePullPolicy can cause false negative results.
- Tests pull images only IfNotPresent.
- Reorder lines in pod yamls so that "image" is followed by
  "imagePullPolicy".