### PR TITLE
memtier: unify syntax for annotated preferences

### DIFF
--- a/docs/policy/memtier.md
+++ b/docs/policy/memtier.md
@@ -40,10 +40,19 @@ The `memtier` policy knows of three kinds of memory: `DRAM`, `PMEM`, and
   * HBM (high-bandwidth memory) is high speed memory, typically found
     on some special-purpose computing systems.
 
-In order to configure a pod to use a certain memory type, use
-`cri-resource-manager.intel.com/memory-type` annotation in the pod spec.
-For example, to make a container request both `PMEM` and `DRAM` memory
+In order to configure a container to use a certain memory type, use the
+`memory-type.cri-resource-manager.intel.com` effective annotation in the pod
+spec. For example, to make `container1` request both `PMEM` and `DRAM` memory
 types, you could use pod metadata such as this:
+
+```
+metadata:
+  annotations:
+    memory-type.cri-resource-manager.intel.com/container.container1: dram,pmem
+```
+
+Alternatively, you can use the following deprecated syntax to achieve the same,
+but support for this syntax is subject to be dropped in a future release:
 
 ```
 metadata:
@@ -64,6 +73,18 @@ controller is added to the workload only after the cold start timeout is
 done. The effect of this is that allocated large unused memory areas of
 memory don't need to be migrated to PMEM, because it was allocated there to
 begin with. Cold start is configured like this in the pod metadata:
+
+```
+metadata:
+  annotations:
+    memory-type.cri-resource-manager.intel.com/container.container1: dram,pmem
+    cold-start.cri-resource-manager.intel.com/container.container1: |
+      duration: 60s
+```
+
+Again, alternatively you can use the following deprecated annotation syntax to
+achieve the same, but support for this syntax is subject to be dropped in a
+future release:
 
 ```
 metadata:

--- a/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/mocks_test.go
@@ -329,8 +329,12 @@ func (m *mockContainer) GetResmgrAnnotationKeys() []string {
 func (m *mockContainer) GetResmgrAnnotation(string, interface{}) (string, bool) {
 	panic("unimplemented")
 }
-func (m *mockContainer) GetEffectiveAnnotation(string) (string, bool) {
-	panic("unimplemented")
+func (m *mockContainer) GetEffectiveAnnotation(key string) (string, bool) {
+	pod, ok := m.GetPod()
+	if !ok {
+		return "", false
+	}
+	return pod.GetEffectiveAnnotation(key, m.name)
 }
 func (m *mockContainer) GetAnnotations() map[string]string {
 	panic("unimplemented")
@@ -529,6 +533,7 @@ type mockPod struct {
 	returnValue2FotGetResmgrAnnotation bool
 	coldStartTimeout                   time.Duration
 	coldStartContainerName             string
+	annotations                        map[string]string
 }
 
 func (m *mockPod) GetInitContainers() []cache.Container {
@@ -591,8 +596,15 @@ func (m *mockPod) GetResmgrAnnotation(key string) (string, bool) {
 func (m *mockPod) GetResmgrAnnotationObject(string, interface{}, func([]byte, interface{}) error) (bool, error) {
 	panic("unimplemented")
 }
-func (m *mockPod) GetEffectiveAnnotation(string, string) (string, bool) {
-	panic("unimplemented")
+func (m *mockPod) GetEffectiveAnnotation(key, container string) (string, bool) {
+	if v, ok := m.annotations[key+"/container."+container]; ok {
+		return v, true
+	}
+	if v, ok := m.annotations[key+"/pod"]; ok {
+		return v, true
+	}
+	v, ok := m.annotations[key]
+	return v, ok
 }
 func (m *mockPod) GetCgroupParentDir() string {
 	panic("unimplemented")

--- a/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/resources.go
@@ -849,11 +849,11 @@ func newRequest(container cache.Container) Request {
 		if err != nil {
 			log.Error("Failed to parse cold start preference")
 		} else {
-			if parsedColdStart.duration > 0 {
+			if parsedColdStart.Duration > 0 {
 				if coldStartOff {
 					log.Error("coldstart disabled (movable non-DRAM memory zones present)")
 				} else {
-					coldStart = parsedColdStart.duration
+					coldStart = time.Duration(parsedColdStart.Duration)
 				}
 			}
 		}


### PR DESCRIPTION
Prefer using the 'effective' syntax for isolated exclusive CPU, shared CPU, memory type
and cold start period annotated preferences. Remove support for 'elevation' in shared CPU
annotations. It was never implemented.