### PR TITLE
memtier: more regular annotation interpretation for CPU allocation preferences.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/memtier/pod-preferences_test.go
@@ -316,7 +316,11 @@ func TestCpuAllocationPreferences(t *testing.T) {
 					},
 				},
 			},
-			pod: &mockPod{},
+			pod: &mockPod{
+				returnValueFotGetQOSClass: corev1.PodQOSBurstable,
+			},
+			expectedFraction: 1000,
+			expectedIsolate:  false,
 		},
 		{
 			name: "return request's value for system container",
@@ -328,7 +332,9 @@ func TestCpuAllocationPreferences(t *testing.T) {
 					},
 				},
 			},
-			pod:              &mockPod{},
+			pod: &mockPod{
+				returnValueFotGetQOSClass: corev1.PodQOSBurstable,
+			},
 			expectedFraction: 2000,
 			expectedCpuType:  cpuReserved,
 		},
@@ -358,7 +364,8 @@ func TestCpuAllocationPreferences(t *testing.T) {
 			pod: &mockPod{
 				returnValueFotGetQOSClass: corev1.PodQOSGuaranteed,
 			},
-			expectedFull: 2,
+			expectedFull:    2,
+			expectedIsolate: opt.PreferIsolated,
 		},
 		{
 			name: "return request's value for guaranteed QoS and isolate",


### PR DESCRIPTION
This PR is based on/requires PR #588.

Update the interpretation of shared/isolated CPU opt-in and opt-out annotations
(and global policy defaults) to produce less irregular and hopefully more intuitive
CPU allocation preferences.

TODO/Question:
Would it provide better usability to use a single explicit non-boolean annotation
(for instance `cpu-preferences`) to express all CPU allocation preferences ?
