### PR TITLE
Deprecated prototype of podpools: policy for pod-granularity workload placement. See PR 598 for official version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage.txt
 /_build
 /_work
 *.stamp
+test/e2e/**/output

--- a/docs/policy/index.rst
+++ b/docs/policy/index.rst
@@ -5,6 +5,7 @@ Policies
    :maxdepth: 1
 
    memtier.md
+   podpools.md
    topology-aware.md
    static-pools.md
    container-affinity.md

--- a/docs/policy/podpools.md
+++ b/docs/policy/podpools.md
@@ -1,0 +1,94 @@
+# Podpools Policy
+
+## Overview
+
+The podpools policy implements pod-level workload placement. It
+assigns all containers of a pod to the same CPU pool. The number of
+CPUs in a pool depends on the type of the pool and is configurable by
+user.
+
+## Deployment
+
+### Install cri-resmgr
+
+Deploy cri-resmgr on each node as you would for any other policy. See
+[installation](../installation.md) for more details.
+
+## Configuration
+
+The policy is configured using the yaml-based configuration system of CRI-RM.
+See [setup and usage](../setup.md#setting-up-cri-resource-manager) for more
+details on managing the configuration.
+
+At minimum, you need to specify the active policy in the
+configuration, and define at least one pod pool type. For example, the
+following configuration dedicates 95 % of non-reserved CPUs on the
+node to be used by `dualcpu` pool type. Every pool instance of that
+type (`dualcpu[0]`, `dualcpu[1]`, ...) contains two exclusive
+CPUs. They are used by containers of pods assigned to the pool, and
+those containers cannot use other CPUs.
+
+```yaml
+policy:
+  Active: podpools
+  podpools:
+    poolTypes:
+      - name: dualcpu
+        typeResources:
+          cpu: 95 %
+        resources:
+          cpu: 2
+        capacity:
+          pod: 1
+  ...
+```
+
+See the [sample configmap](/sample-configs/podpools-policy.cfg)
+for a complete example.
+
+### Debugging
+
+In order to enable more verbose logging for the podpools policy enable
+policy debug from the CRI-RM global config:
+
+```yaml
+logger:
+  Debug: policy
+```
+
+## Running Pods in Podpools
+
+The podpools policy assigns a pod to a pod pool instance if the pod
+has annotation
+
+```yaml
+pooltype.podpools.cri-resource-manager.intel.com: POOLTYPENAME
+```
+
+An example Pod spec for running a workload in a `dualcpu` pool
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podpools-test
+  annotations:
+    pooltype.podpools.cri-resource-manager.intel.com: dualcpu
+spec:
+  containers:
+  - name: testcont0
+    image: busybox
+    command:
+      - "sh"
+      - "-c"
+      - "while :; do grep _allowed_list /proc/self/status; sleep 5; done"
+  - name: testcont1
+    image: busybox
+    command:
+      - "sh"
+      - "-c"
+      - "while :; do grep _allowed_list /proc/self/status; sleep 5; done"
+```
+
+If a pod is not annotated, it will be run on shared CPUs. Shared CPUs
+are not reserved and do not belong to any pod pool instance.

--- a/pkg/cri/resource-manager/builtin-policies.go
+++ b/pkg/cri/resource-manager/builtin-policies.go
@@ -18,6 +18,7 @@ import (
 	// List of builtin policies
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/memtier"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/none"
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/podpools"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-plus"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-pools"

--- a/pkg/cri/resource-manager/policy/builtin/podpools/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/podpools/flags.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podpools
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+)
+
+// PodpoolsOptions contains configuration options specific to this policy.
+type PodpoolsOptions struct {
+	// PinCPU controls pinning containers to CPUs.
+	PinCPU bool `json:"pinCPU",omitempty`
+	// PinMemory controls pinning containers to memory nodes.
+	PinMemory bool `json:"pinMemory",omitempty`
+	// PoolTypes contains types of pools.
+	PoolTypes []*PoolType `json:"poolTypes,omitempty"`
+}
+
+// PoolType contains configuration of a pool type.
+type PoolType struct {
+	Name string `json:"name"`
+	// TypeResource defines host resources to be consumed by this pool type.
+	TypeResources PoolResources `json:"typeResources,omitempty"`
+	// Resources defines resources in each pool of this type. The
+	// number of pools is floor(TypeResources/Resources).
+	Resources PoolResources `json:"resources"`
+	// Capacity defines the (pod) capacity of each pool.
+	Capacity PoolCapacity `json:"capacity"` // Capacity per pool
+	// FillOrder defines how the capacity of pod pools is filled.
+	FillOrder FillOrder `json:"fillOrder"`
+}
+
+// PoolResources contains resources of a pool type or a pool instance.
+type PoolResources struct {
+	CPU string `json:"cpu"`
+}
+
+// PoolCapacity contains the capacity of a pool instance.
+type PoolCapacity struct {
+	Pod int `json:"pod"`
+}
+
+// FillOrder specifies the order in which pool instances should be filled.
+type FillOrder int
+
+const (
+	FillBalanced FillOrder = iota
+	FillPacked
+	FillFirstFree
+)
+
+var fillOrderNames = map[FillOrder]string{
+	FillBalanced:  "Balanced",
+	FillPacked:    "Packed",
+	FillFirstFree: "FirstFree",
+}
+
+// String stringifies a FillOrder
+func (fo FillOrder) String() string {
+	if fon, ok := fillOrderNames[fo]; ok {
+		return fon
+	}
+	return fmt.Sprintf("#UNNAMED-FILLORDER(%d)", int(fo))
+}
+
+// MarshalJSON marshals the enum as a quoted json string
+func (fo FillOrder) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(fmt.Sprintf("%q", fo))
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (fo *FillOrder) UnmarshalJSON(b []byte) error {
+	var fillOrderName string
+	err := json.Unmarshal(b, &fillOrderName)
+	if err != nil {
+		return err
+	}
+	for foID, foName := range fillOrderNames {
+		if foName == fillOrderName {
+			*fo = foID
+			return nil
+		}
+	}
+	return podpoolsError("invalid fill order %q", fillOrderName)
+}
+
+// defaultPodpoolsOptions returns a new PodpoolsOptions instance, all initialized to defaults.
+func defaultPodpoolsOptions() interface{} {
+	return &PodpoolsOptions{
+		PinCPU:    true,
+		PinMemory: true,
+	}
+}
+
+// Our runtime configuration.
+var podpoolsOptions = defaultPodpoolsOptions().(*PodpoolsOptions)
+
+// Register us for configuration handling.
+func init() {
+	pkgcfg.Register(PolicyPath, PolicyDescription, podpoolsOptions, defaultPodpoolsOptions)
+}

--- a/pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
@@ -1,0 +1,523 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podpools
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	resapi "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/utils"
+)
+
+const (
+	// PolicyName is the name used to activate this policy.
+	PolicyName = "podpools"
+	// PolicyDescription is a short description of this policy.
+	PolicyDescription = "Pod-granularity workload placement"
+	// PolicyPath is the path of this policy in the configuration hierarchy.
+	PolicyPath = "policy." + PolicyName
+	// poolTypeKey is a pod annotation key, the value is a pool type.
+	poolTypeKey = "pooltype." + PolicyName + "." + kubernetes.ResmgrKeyNamespace
+	// reservedPoolTypeName is the name of the pool type of reserved CPUs.
+	reservedPoolTypeName = "reserved"
+	// sharedPoolTypeName is the name of the pool type of shared CPUs.
+	sharedPoolTypeName = "shared"
+)
+
+type podpools struct {
+	options          *policyapi.BackendOptions
+	ppoptions        PodpoolsOptions
+	cch              cache.Cache
+	allowed          cpuset.CPUSet             // bounding set of CPUs we're allowed to use
+	reserved         cpuset.CPUSet             // system-/kube-reserved CPUs
+	reservedPoolType *PoolType                 // built-in type of pool of reserved CPUs
+	sharedPoolType   *PoolType                 // built-in type of pool of shared CPUs
+	pools            []*Pool                   // pools for pods, reserved, shared and user-defined
+	cpuAllocator     cpuallocator.CPUAllocator // CPU allocator used by the policy
+}
+
+type Pool struct {
+	Type            *PoolType
+	Instance        int
+	CPUs            cpuset.CPUSet
+	Mems            sysfs.IDSet
+	FullPodCapacity int
+	// PodIDs maps pod ID to list of container IDs
+	// len(PodIDs) is the number of pods in the pool.
+	// len(PodIDs[podID]) is the number of containers of podID
+	// currently assigned to the pool.
+	// FullPodCapacity - len(PodIDs) is free pod capacity.
+	PodIDs map[string][]string
+}
+
+var log logger.Logger = logger.NewLogger("policy")
+var _ policy.Backend = &podpools{}
+
+func (pool Pool) String() string {
+	podCount := len(pool.PodIDs)
+	contCount := 0
+	for _, contIDs := range pool.PodIDs {
+		contCount += len(contIDs)
+	}
+	s := fmt.Sprintf("%s{capacity.pod: %d, pods:%d, containers:%d}",
+		pool.PrettyName(), pool.FullPodCapacity, podCount, contCount)
+	return s
+}
+
+func (pool Pool) PrettyName() string {
+	return fmt.Sprintf("%s[%d]", pool.Type.Name, pool.Instance)
+}
+
+// CreatePodpoolsPolicy creates a new policy instance.
+func CreatePodpoolsPolicy(policyOptions *policy.BackendOptions) policy.Backend {
+	p := &podpools{
+		options: policyOptions,
+		cch:     policyOptions.Cache,
+		reservedPoolType: &PoolType{
+			Name:      reservedPoolTypeName,
+			FillOrder: FillBalanced,
+		},
+		sharedPoolType: &PoolType{
+			Name:      sharedPoolTypeName,
+			FillOrder: FillBalanced,
+		},
+		cpuAllocator: cpuallocator.NewCPUAllocator(policyOptions.System),
+	}
+	log.Info("creating %s policy...", PolicyName)
+	// Handle common policy options: AvailableResources and ReservedResources.
+	// p.allowed: CPUs available for the policy
+	if allowed, ok := policyOptions.Available[policyapi.DomainCPU]; ok {
+		p.allowed = allowed.(cpuset.CPUSet)
+	} else {
+		// Available CPUs not specified, default to all on-line CPUs.
+		p.allowed = policyOptions.System.CPUSet().Difference(policyOptions.System.Offlined())
+	}
+	// p.reserved: CPUs reserved for kube-system pods, subset of p.allowed.
+	p.reserved = cpuset.NewCPUSet()
+	if reserved, ok := p.options.Reserved[policyapi.DomainCPU]; ok {
+		switch v := reserved.(type) {
+		case cpuset.CPUSet:
+			p.reserved = p.allowed.Intersection(v)
+		case resapi.Quantity:
+			reserveCnt := (int(v.MilliValue()) + 999) / 1000
+			cpus, err := p.cpuAllocator.AllocateCpus(&p.allowed, reserveCnt, false)
+			if err != nil {
+				log.Fatal("failed to allocate reserved CPUs: %s", err)
+			}
+			p.reserved = cpus
+			p.allowed = p.allowed.Union(cpus)
+		}
+	}
+	if p.reserved.IsEmpty() {
+		log.Fatal("%s cannot run without reserved CPUs that are also AvailableResources", PolicyName)
+	}
+	// Handle policy-specific options
+	log.Debug("creating %s configuration", PolicyName)
+	if err := p.setConfig(podpoolsOptions); err != nil {
+		log.Fatal("failed to create %s policy: %v", PolicyName, err)
+	}
+
+	pkgcfg.GetModule(PolicyPath).AddNotify(p.configNotify)
+
+	return p
+}
+
+// Name returns the name of this policy.
+func (p *podpools) Name() string {
+	return PolicyName
+}
+
+// Description returns the description for this policy.
+func (p *podpools) Description() string {
+	return PolicyDescription
+}
+
+// Start prepares this policy for accepting allocation/release requests.
+func (p *podpools) Start(add []cache.Container, del []cache.Container) error {
+	log.Info("%s policy started", PolicyName)
+	return nil
+}
+
+// Sync synchronizes the active policy state.
+func (p *podpools) Sync(add []cache.Container, del []cache.Container) error {
+	log.Debug("synchronizing state...")
+	for _, c := range del {
+		p.ReleaseResources(c)
+	}
+	for _, c := range add {
+		p.AllocateResources(c)
+	}
+	return nil
+}
+
+// AllocateResources is a resource allocation request for this policy.
+func (p *podpools) AllocateResources(c cache.Container) error {
+	log.Debug("allocating container %s...", c.PrettyName())
+	// Assign container to correct pool.
+	if pool := p.allocatePool(c); pool != nil {
+		p.assignContainer(c, pool)
+	} else {
+		// Cannot assign container to any of the pooled CPUs.
+		return podpoolsError("cannot find CPUs to run container %s - no shared or reserved CPUs available")
+	}
+	return nil
+}
+
+// ReleaseResources is a resource release request for this policy.
+func (p *podpools) ReleaseResources(c cache.Container) error {
+	pool := p.allocatedPool(c)
+	if pool == nil {
+		log.Debug("ReleaseResources: pool-less container %s, nothing to release", c.PrettyName())
+		return nil
+	}
+	log.Debug("releasing container %s from pool %s", c, pool)
+	podID := c.GetPodID()
+	pool.PodIDs[podID] = removeString(pool.PodIDs[podID], c.GetCacheID())
+	if len(pool.PodIDs[podID]) == 0 {
+		log.Debug("all containers removed, free pool allocation %s", pool.PrettyName())
+		// All containers of the pod removed from the pool.
+		// Free the pool for other pods.
+		delete(pool.PodIDs, podID)
+	}
+	log.Debug("pool after release: %s", pool)
+	return nil
+}
+
+// UpdateResources is a resource allocation update request for this policy.
+func (p *podpools) UpdateResources(c cache.Container) error {
+	log.Debug("(not) updating container %s...", c.PrettyName())
+	return nil
+}
+
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (p *podpools) Rebalance() (bool, error) {
+	log.Debug("(not) rebalancing containers...")
+	return false, nil
+}
+
+// HandleEvent handles policy-specific events.
+func (p *podpools) HandleEvent(*events.Policy) (bool, error) {
+	log.Debug("(not) handling event...")
+	return false, nil
+}
+
+// ExportResourceData provides resource data to export for the container.
+func (p *podpools) ExportResourceData(c cache.Container) map[string]string {
+	return nil
+}
+
+// Introspect provides data for external introspection.
+func (p *podpools) Introspect(*introspect.State) {
+	return
+}
+
+// allocatedPool returns a pool already allocated for the pod of a container.
+func (p *podpools) allocatedPool(c cache.Container) *Pool {
+	podID := c.GetPodID()
+	pools := filterPools(p.pools,
+		func(pl *Pool) bool { _, ok := pl.PodIDs[podID]; return ok })
+	if len(pools) == 0 {
+		return nil
+	}
+	return pools[0]
+}
+
+// allocatePool returns a pool allocated for the pod of a container.
+func (p *podpools) allocatePool(c cache.Container) *Pool {
+	if pool := p.allocatedPool(c); pool != nil {
+		return pool
+	}
+	poolType := p.getPoolType(c)
+	if poolType == nil {
+		return nil
+	}
+	// Try to find a suitable pool and allocate it for the pod of
+	// the container.
+	podID := c.GetPodID()
+	// A pool must be of correct type and have capacity left for at least one pod.
+	pools := filterPools(p.pools,
+		func(pl *Pool) bool {
+			return poolType.Name == pl.Type.Name && (pl.FullPodCapacity > len(pl.PodIDs) || pl.FullPodCapacity == -1)
+		})
+	// Sort pools according to pool type fill order so that the
+	// first pool in the list is the preferred one.
+	switch poolType.FillOrder {
+	case FillBalanced:
+		sort.Slice(pools, func(i, j int) bool {
+			return len(pools[i].PodIDs) < len(pools[j].PodIDs)
+		})
+	case FillPacked:
+		sort.Slice(pools, func(i, j int) bool {
+			return len(pools[i].PodIDs) > len(pools[j].PodIDs)
+		})
+	case FillFirstFree:
+		// FirstFree is already the first of the pools list.
+	}
+	if len(pools) == 0 {
+		log.Warn("cannot find free pool of type %q needed by container %s", poolType.Name, c.PrettyName())
+		return nil
+	}
+	// Found a suitable pool. Allocate it for the pod.
+	pool := pools[0]
+	pool.PodIDs[podID] = []string{}
+	log.Debug("allocated pool %s[%d] for container %s", pool.Type.Name, pool.Instance, c.PrettyName())
+	return pool
+}
+
+func (p *podpools) configNotify(event pkgcfg.Event, source pkgcfg.Source) error {
+	log.Info("configuration %s", event)
+	if err := p.setConfig(podpoolsOptions); err != nil {
+		log.Error("config update failed: %v", err)
+		return err
+	}
+	log.Info("config updated successfully")
+	return nil
+}
+
+// getPoolTypeName returns the name of the pool type for a container.
+func (p *podpools) getPoolTypeName(c cache.Container) string {
+	if poolTypeName, ok := c.GetEffectiveAnnotation(poolTypeKey); ok {
+		return poolTypeName
+	}
+	if c.GetNamespace() == "kube-system" {
+		return reservedPoolTypeName
+	}
+	return sharedPoolTypeName
+}
+
+// getPoolType returns the type of the pool for a container.
+func (p *podpools) getPoolType(c cache.Container) *PoolType {
+	poolTypeName := p.getPoolTypeName(c)
+	if poolTypeName == reservedPoolTypeName {
+		return p.reservedPoolType
+	}
+	if poolTypeName == sharedPoolTypeName {
+		return p.sharedPoolType
+	}
+	for _, poolType := range p.ppoptions.PoolTypes {
+		if poolType.Name == poolTypeName {
+			return poolType
+		}
+	}
+	return nil
+}
+
+// setConfig takes new pool configuration into use.
+func (p *podpools) setConfig(ppoptions *PodpoolsOptions) error {
+	// Instantiate pools for pods
+	p.pools = []*Pool{}
+	reservedPool := Pool{
+		Type:            p.reservedPoolType,
+		Instance:        0,
+		CPUs:            p.reserved,
+		Mems:            p.closestMems(p.reserved),
+		FullPodCapacity: -1,
+		PodIDs:          make(map[string][]string),
+	}
+	p.pools = append(p.pools, &reservedPool)
+	// The shared pool used reserved CPUs by default. If CPUs are
+	// left over after constructing user-defined pools, those will
+	// be used as shared instead.
+	sharedPool := Pool{
+		Type:            p.sharedPoolType,
+		Instance:        0,
+		CPUs:            reservedPool.CPUs,
+		Mems:            reservedPool.Mems,
+		FullPodCapacity: -1,
+		PodIDs:          make(map[string][]string),
+	}
+	p.pools = append(p.pools, &sharedPool)
+	// Create user-defined pools
+	freeCpus := p.allowed.Clone()
+	freeCpus = freeCpus.Difference(p.reserved)
+	nonReservedCpuCount := freeCpus.Size()
+	poolCpus := cpuset.NewCPUSet()
+	for _, poolType := range ppoptions.PoolTypes {
+		cpusPerPoolType, err := parseCountOrPercentage(poolType.TypeResources.CPU, nonReservedCpuCount)
+		if err != nil {
+			return podpoolsError("invalid typeResources.cpu %q in pool %q: %w",
+				poolType.TypeResources.CPU, poolType.Name, err)
+		}
+		cpusPerPool, err := parseCountOrPercentage(poolType.Resources.CPU, cpusPerPoolType)
+		if err != nil {
+			return podpoolsError("invalid resources.cpu %q in pool %q: %w",
+				poolType.Resources.CPU, poolType.Name, err)
+		}
+		poolCount := cpusPerPoolType / cpusPerPool
+		log.Debug("allocating at most %d out of %d non-reserved CPUs for %d pools of type %q",
+			cpusPerPoolType, freeCpus.Size(), poolCount, poolType.Name)
+		for poolIndex := 0; poolIndex < poolCount; poolIndex++ {
+			if cpusPerPool > freeCpus.Size() {
+				return podpoolsError("ran out of CPUs when trying to allocate %d CPUs for pool %s[%d]",
+					cpusPerPool, poolType.Name, poolIndex)
+			}
+			cpus, err := p.cpuAllocator.AllocateCpus(&freeCpus, cpusPerPool, false)
+			if err != nil {
+				return podpoolsError("could not allocate %d CPUs for pool %d of poolType %q: %w",
+					cpusPerPool, poolIndex, poolType.Name, err)
+			}
+			mems := p.closestMems(cpus)
+			pool := Pool{
+				Type:            poolType,
+				Instance:        poolIndex,
+				CPUs:            cpus,
+				Mems:            mems,
+				FullPodCapacity: poolType.Capacity.Pod,
+				PodIDs:          make(map[string][]string),
+			}
+			p.pools = append(p.pools, &pool)
+			poolCpus = poolCpus.Union(cpus)
+		}
+	}
+	if freeCpus.Size() > 0 {
+		log.Debug("%d unused CPUs are used as the shared pool.", freeCpus.Size())
+		p.pools[1].CPUs = freeCpus
+		p.pools[1].Mems = p.closestMems(freeCpus)
+	} else {
+		log.Debug("All non-reserved CPUs allocated to user-defined pools. Shared and reserved pools run on the same CPUs.")
+	}
+	log.Debug("%s policy pools:", PolicyName)
+	for index, pool := range p.pools {
+		log.Info("- pool %d: %s[%d] cpuset: %s, mem nodes: %s, pod capacity: %d",
+			index, pool.Type.Name, pool.Instance, pool.CPUs, pool.Mems, pool.FullPodCapacity)
+	}
+	log.Debug("new %s configuration:\n%s", PolicyName, utils.DumpJSON(ppoptions))
+	p.ppoptions = *ppoptions
+	return nil
+}
+
+// closestMems returns memory node IDs good for pinning containers
+// that run on given CPUs
+func (p *podpools) closestMems(cpus cpuset.CPUSet) sysfs.IDSet {
+	mems := sysfs.NewIDSet()
+	sys := p.options.System
+	for _, nodeID := range sys.NodeIDs() {
+		if !cpus.Intersection(sys.Node(nodeID).CPUSet()).IsEmpty() {
+			mems.Add(nodeID)
+		}
+	}
+	return mems
+}
+
+// filterPools returns pools for which the test function returns true
+func filterPools(pools []*Pool, test func(*Pool) bool) (ret []*Pool) {
+	for _, pool := range pools {
+		if test(pool) {
+			ret = append(ret, pool)
+		}
+	}
+	return
+}
+
+// parseCountOrPercentage parses number or percentage from string
+func parseCountOrPercentage(s string, maxCount int) (int, error) {
+	var n int
+	if strings.HasSuffix(s, "%") {
+		ps := strings.TrimSpace(strings.TrimSuffix(s, "%"))
+		n64, err := strconv.ParseInt(ps, 0, 32)
+		if err != nil {
+			return 0, err
+		}
+		n = int(n64) * maxCount / 100
+	} else {
+		n64, err := strconv.ParseInt(s, 0, 32)
+		if err != nil {
+			return 0, err
+		}
+		n = int(n64)
+	}
+	if n > maxCount {
+		return 0, podpoolsError("value (%d) exceeds maximum (%d)", n, maxCount)
+	}
+	return n, nil
+}
+
+func (p *podpools) assignContainer(c cache.Container, pool *Pool) {
+	log.Info("assigning container %s to pool %s[%d]", c.PrettyName(), pool.Type.Name, pool.Instance)
+	podID := c.GetPodID()
+	pool.PodIDs[podID] = append(pool.PodIDs[podID], c.GetCacheID())
+	p.pinCpuMem(c, pool.CPUs, pool.Mems)
+
+	// Check CPU booking in this pool. Print warning on overbooking.
+	cpuAvail := pool.CPUs.Size() * 1000
+	cpuRequested := 0
+	containers := 0
+	for _, cids := range pool.PodIDs {
+		for _, cid := range cids {
+			for _, container := range p.cch.GetContainers() {
+				if container.GetCacheID() == cid {
+					if reqCpu, ok := container.GetResourceRequirements().Requests[corev1.ResourceCPU]; ok {
+						cpuRequested += int(reqCpu.MilliValue())
+						containers += 1
+					}
+				}
+			}
+		}
+	}
+	if cpuRequested > cpuAvail {
+		log.Warn("overbooked cpuset:%s: %dm CPUs requested by %d containers", pool.CPUs, cpuRequested, containers)
+	}
+}
+
+// pinCpuMem pins container to CPUs and memory nodes if flagged
+func (p *podpools) pinCpuMem(c cache.Container, cpus cpuset.CPUSet, mems sysfs.IDSet) {
+	if p.ppoptions.PinCPU {
+		log.Debug("  - pinning to cpuset: %s", cpus)
+		c.SetCpusetCpus(cpus.String())
+		if reqCpu, ok := c.GetResourceRequirements().Requests[corev1.ResourceCPU]; ok {
+			mCpu := int(reqCpu.MilliValue())
+			c.SetCPUShares(int64(cache.MilliCPUToShares(mCpu)))
+		}
+	}
+	if p.ppoptions.PinMemory {
+		log.Debug("  - pinning to memory %s", mems)
+		c.SetCpusetMems(mems.String())
+	}
+}
+
+func podpoolsError(format string, args ...interface{}) error {
+	return fmt.Errorf(PolicyName+": "+format, args...)
+}
+
+func removeString(strings []string, element string) []string {
+	for index, s := range strings {
+		if s == element {
+			strings[index] = strings[len(strings)-1]
+			return strings[:len(strings)-1]
+		}
+	}
+	return strings
+}
+
+// Register us as a policy implementation.
+func init() {
+	policy.Register(PolicyName, PolicyDescription, CreatePodpoolsPolicy)
+}

--- a/sample-configs/podpools-policy.cfg
+++ b/sample-configs/podpools-policy.cfg
@@ -1,0 +1,86 @@
+# This example demonstrates pod-based CPU and memory pinning.
+# All containers of a pod run in the same CPU/memory pool.
+# The capacity of a pool is defined as a number of pods.
+#
+# You can launch a pod to a pod pool by annotating it:
+#
+# metadata:
+#   annotations:
+#     pooltype.podpools.cri-resource-manager.intel.com: singlecpu
+
+policy:
+  # pod-based CPU and memory pinning is implemented in the podpools policy.
+  Active: podpools
+
+  # AvailableResources specifies CPUs that a policy is allowed to manage.
+  # By default AvailableResources contains all CPUs.
+  AvailableResources:
+    # Here we use 14 CPUs, excluding CPUs #0 and #1 (hyperthreads of core 0)
+    CPU: cpuset:2-15
+
+  # ReservedResources specifies CPU(s) that run only kube-system pods.
+  ReservedResources:
+    # Here we dedicate CPU #15 for these pods.
+    # This leaves 13 out of 14 available CPUs unallocated.
+    CPU: cpuset:15
+
+  # podpools-specific configuration specifies the following.
+  # 1. Available pod pool types.
+  #    There can be many pool instances of the same type.
+  # 2. How many host CPUs are allocated for each pool type in total.
+  #    This can be a number or a percentage of non-reserved CPUs.
+  # 3. How many CPUs each pool instance gets from the CPUs of its type.
+  #    This can be a number or a percentage of pool type CPUs.
+  # 4. Capacity of each pool instance.
+  #    This is the maximum number of pods in the same pool instance.
+  podpools:
+    # By default podpools pins both CPU and memory of all containers.
+    # Pinning either of them can be disabled with:
+    # pinCPU: false
+    # pinMemory: false
+    poolTypes:
+      # Define the "singlecpu" pod pool type:
+      - name: singlecpu
+        typeResources:
+          # Take 3 out of 13 AvailableResources CPUs to be used by
+          # all "singlecpu" pod pool instances in total.
+          # This leaves 10 CPUs unallocated.
+          cpu: 3
+        resources:
+          # Every "singlecpu" pod pool instance has 1 CPU to run all
+          # pods assigned to this pool.
+          # As the type can use 3 CPUs in total, there will be 3
+          # "singlecpu" pool instances.
+          cpu: 1
+        capacity:
+          # Every "singlecpu" pod pool instance holds at most 2 pods.
+          pod: 2
+
+      # Define the "dualcpu" pod pool type:
+      - name: dualcpu
+        # fillOrder specifies the order in which the capacity of pod
+        # pool instances of this pool type is filled with pods. The
+        # default is Balanced: new pod is assigned to a pool instance
+        # with most free capacity. The opposite is Packed: new pod is
+        # assigned to a pool instance with least free capacity.
+        fillOrder: Packed
+        typeResources:
+          # Take 50 % of AvailableResources CPUs (50 % * 14 = 7)
+          # to be used by all "dualcpu" pool instances in total.
+          cpu: 50%
+        resources:
+          # Every "dualcpu" pool instance has 2 CPUs.
+          # That is, 7 / 2 = 3 pool instances of this type will be created,
+          # and therefore only 6 CPUs actually consumed to this pool type.
+          # This leaves 4 CPUs unallocated.
+          cpu: 2
+        capacity:
+          # Every "dualcpu" pool instance holds at most 3 pods.
+          pod: 3
+
+      # Available CPUs that are neither reserved nor allocated to any
+      # of the pool instances will be "shared" CPUs. Pods that are not
+      # kube-system and are not assigned to any of the pools will run
+      # on the shared CPUs.
+logger:
+  Debug: podpools

--- a/test/e2e/policies.test-suite/podpools/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/podpools/cri-resmgr.cfg
@@ -1,0 +1,36 @@
+policy:
+  Active: podpools
+  # Use 14 CPUs in total.
+  AvailableResources:
+    CPU: cpuset:2-15
+  # One CPU is dedicated for reserved tasks, 13 CPUs left.
+  ReservedResources:
+    CPU: cpuset:15
+  podpools:
+    poolTypes:
+      # Take 3 CPUs to "singlecpu" podpools, 10 CPUs left.
+      - name: singlecpu
+        # Not defining pool fill order equals to the default:
+        # fillOrder: Balanced.
+        typeResources:
+          cpu: 3
+        resources:
+          cpu: 1
+        capacity:
+          pod: 2
+      # Take at most ~6.5 CPUs (= 50% * 13) to "dualcpu" pools.
+      # Allocating 2 CPUs per pool allows instantiating 3 pools,
+      # that is, 6 CPUs is really taken.
+      # 4 CPUs left.
+      # Leftover CPUs will be shared among pods and containers not in
+      # pools.
+      - name: dualcpu
+        fillOrder: Packed
+        typeResources:
+          cpu: 50%
+        resources:
+          cpu: 2
+        capacity:
+          pod: 3
+logger:
+  Debug: cri-resmgr,resource-manager,cache,policy

--- a/test/e2e/policies.test-suite/podpools/n4c16/test01-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test01-basic-placement/code.var.sh
@@ -1,0 +1,48 @@
+# Test placing containers with and without annotations to correct pools
+# reserved and shared CPUs.
+
+( kubectl delete pods pod3 -n kube-system --now ) || true
+
+# Test only BestEffort containers
+CPUREQ="" MEMREQ="" CPULIM="" MEMLIM=""
+
+# pod0: singlecpu
+out ""
+out "### Multicontainer pod, all containers run on single CPU"
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: singlecpu" CONTCOUNT=3 create podpools-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod0c1"] == cpus["pod0c2"]' \
+       'len(cpus["pod0c0"]) == 1' \
+       'mems["pod0c0"] == {"node0"}'
+
+# pod1: dualcpu
+out ""
+out "### Multicontainer pod, all containers run on two PCUs."
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CONTCOUNT=3 create podpools-busybox
+report allowed
+verify 'cpus["pod1c0"] == cpus["pod1c1"] == cpus["pod1c2"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"])' \
+       'len(cpus["pod1c0"]) == 2' \
+       'mems["pod1c1"] == {"node1"}'
+
+# pod2: shared
+out ""
+out "### Multicontainer pod, no annotations. Runs on shared CPUs."
+CONTCOUNT=3 create podpools-busybox
+report allowed
+verify 'cpus["pod2c0"] == cpus["pod2c1"] == cpus["pod2c2"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"])' \
+       'len(cpus["pod2c0"]) == 4' \
+       'mems["pod2c2"] == {"node3", "node1"}'
+
+# pod3: reserved
+out ""
+out "### Multicontainer pod in kube-system namespace. Runs on reserved CPUs."
+namespace=kube-system CONTCOUNT=3 create podpools-busybox
+report allowed
+verify 'cpus["pod3c0"] == cpus["pod3c1"] == cpus["pod3c2"] == {"cpu15"}' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"], cpus["pod3c0"])' \
+       'mems["pod3c0"] == {"node3"}'
+
+kubectl delete pods pod3 -n kube-system --now
+kubectl delete pods pod0 pod1 pod2 --now

--- a/test/e2e/policies.test-suite/podpools/n4c16/test02-fill-order/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test02-fill-order/code.var.sh
@@ -1,0 +1,69 @@
+# Test filling pools with pods in correct order
+
+# Test only BestEffort containers
+CPUREQ="" MEMREQ="" CPULIM="" MEMLIM=""
+
+# pod0..2: balanced filling, every singlecpu pool should have one pod
+out "### Filling singlecpu pool in Balanced fill order"
+n=3 POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: singlecpu" CONTCOUNT=2 create podpools-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'cpus["pod1c0"] == cpus["pod1c1"]' \
+       'cpus["pod2c0"] == cpus["pod2c1"]' \
+       'len(cpus["pod0c0"]) == 1' \
+       'len(cpus["pod1c0"]) == 1' \
+       'len(cpus["pod2c0"]) == 1' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"])'
+
+# pod3..5: balanced filling up to max, every singlecpu pool should have two pods
+n=3 POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: singlecpu" CONTCOUNT=2 create podpools-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'cpus["pod1c0"] == cpus["pod1c1"]' \
+       'cpus["pod2c0"] == cpus["pod2c1"]' \
+       'len(cpus["pod0c0"]) == 1' \
+       'len(cpus["pod1c0"]) == 1' \
+       'len(cpus["pod2c0"]) == 1' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"])' \
+       'cpus["pod3c0"] == cpus["pod3c1"]' \
+       'cpus["pod4c0"] == cpus["pod4c1"]' \
+       'cpus["pod5c0"] == cpus["pod5c1"]' \
+       'len(cpus["pod3c0"]) == 1' \
+       'len(cpus["pod4c0"]) == 1' \
+       'len(cpus["pod5c0"]) == 1' \
+       'disjoint_sets(cpus["pod3c0"], cpus["pod4c0"], cpus["pod5c0"])' \
+       'cpus["pod5c0"] == cpus["pod2c0"]' # the last pool should have been filled by pods 2 and 5
+
+# make a little room to the first pool and clear the last pool
+kubectl delete pods pod0 pod2 pod5 --now
+
+# pod6: Balanced fill order should place this pod to the last pool (it has maximal free space)
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: singlecpu" CONTCOUNT=1 create podpools-busybox
+report allowed
+verify 'disjoint_sets(cpus["pod6c0"],
+                      set.union(cpus["pod1c0"], cpus["pod3c0"], cpus["pod4c0"]))'
+
+kubectl delete pods --all --now
+reset counters
+
+out "### Filling dualcpu pool in Packed fill order"
+# pod0..2: should go to the first pool
+n=3 POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CONTCOUNT=1 create podpools-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod1c0"] == cpus["pod2c0"]'
+
+# pod3..5: should go to the second pool
+n=3 POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CONTCOUNT=1 create podpools-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod1c0"] == cpus["pod2c0"]' \
+       'cpus["pod3c0"] == cpus["pod4c0"] == cpus["pod5c0"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod3c0"])'
+
+# Deleting two pods from the first pool, one from the last.
+kubectl delete pods pod0 pod1 pod5
+
+# pod6: Packed fill order should place this to the last pool (it has minimal free space)
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CONTCOUNT=1 create podpools-busybox
+report allowed
+verify 'cpus["pod3c0"] == cpus["pod4c0"] == cpus["pod6c0"]' \
+       'disjoint_sets(cpus["pod2c0"], cpus["pod6c0"])'

--- a/test/e2e/policies.test-suite/podpools/n4c16/test03-qos/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test03-qos/code.var.sh
@@ -1,0 +1,63 @@
+# Test all QoS class pods in a pool, reserved and shared CPUs.
+# Verify that CFS CPU shares is set correctly in all cases.
+
+verify-cpushare() {
+    podXcY=$1
+    expected=$2
+    vm-command "cputasks=\$(find /sys/fs/cgroup/cpu/ -name tasks -type f -print0 | xargs -0 grep -l \$(pgrep -f ${podXcY})); cpudir=\${cputasks%/*}; cat \$cpudir/cpu.shares"
+    if [ "$COMMAND_OUTPUT" = "$expected" ]; then
+        echo "verified cpu.share of $podXcY == $expected"
+    else
+        echo "assertion failed when verifying cpu.share of $podXcY: got '$COMMAND_OUTPUT' expected '$expected'"
+        exit 1
+    fi
+}
+
+CPUREQ="" MEMREQ="" CPULIM="" MEMLIM="" POD_ANNOTATION=""
+
+out "### Assigning BestEffort, Burstable and Guaranteed pods to the same (dualcpu) pool"
+# pod0c0: besteffort
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" create podpools-busybox
+# pod1c0: burstable
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=500m create podpools-busybox
+# pod2c0: guaranteed
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1 CPULIM=1 MEMREQ=100M MEMLIM=100M create podpools-busybox
+report allowed
+
+verify-cpushare pod0c0 2
+verify-cpushare pod1c0 512
+verify-cpushare pod2c0 1024
+
+kubectl delete pods --all --now
+reset counters
+
+out "### Assigning BestEffort, Burstable and Guaranteed pods shared CPUs"
+# pod0c0: besteffort
+create podpools-busybox
+# pod1c0: burstable
+CPUREQ=500m create podpools-busybox
+# pod2c0: guaranteed
+CPUREQ=1 CPULIM=1 MEMREQ=100M MEMLIM=100M create podpools-busybox
+report allowed
+
+verify-cpushare pod0c0 2
+verify-cpushare pod1c0 512
+verify-cpushare pod2c0 1024
+
+kubectl delete pods --all --now
+reset counters
+
+out "### Assigning BestEffort, Burstable and Guaranteed pods reserved CPUs"
+# pod0c0: besteffort
+namespace=kube-system create podpools-busybox
+# pod1c0: burstable
+namespace=kube-system CPUREQ=500m create podpools-busybox
+# pod2c0: guaranteed
+namespace=kube-system CPUREQ=1 CPULIM=1 MEMREQ=100M MEMLIM=100M create podpools-busybox
+report allowed
+
+verify-cpushare pod0c0 2
+verify-cpushare pod1c0 512
+verify-cpushare pod2c0 1024
+
+kubectl delete pods pod0 pod1 pod2 -n kube-system

--- a/test/e2e/policies.test-suite/podpools/n4c16/test04-overbook-cpus/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test04-overbook-cpus/code.var.sh
@@ -1,0 +1,30 @@
+# Test overbooking CPUs in pod pools
+
+CRI_RESMGR_OUTPUT="cat cri-resmgr.output.txt"
+
+# pod0: overbook with single burstable pod and container
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=2900m MEMREQ="" CPULIM="" MEMLIM="" create podpools-busybox
+report allowed
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^W.*overbooked.*6-7.*(2899|2900)m'" || error "missing overbook warning"
+kubectl delete pods --all --now
+
+# pod1: overbook with single burstable pod with two containers
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1050m MEMREQ="" CPULIM="" MEMLIM="" CONTCOUNT=2 create podpools-busybox
+report allowed
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^W.*overbooked.*6-7.*2100m'" || error "missing overbook warning"
+kubectl delete pods --all --now
+
+# pod2, pod3: overbook with two guaranteed pods, one container in each pod
+n=2 POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1001m MEMREQ=100M CPULIM=1001m MEMLIM=100M create podpools-busybox
+report allowed
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^W.*overbooked.*6-7.*2002m'" || error "missing overbook warning"
+kubectl delete pods --all --now
+
+# pod4, pod5: no overbooking with exact CPUs guaranteed + besteffort pod
+terminate cri-resmgr # restart to clear log
+launch cri-resmgr
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=2000m MEMREQ=100M CPULIM=2000m MEMLIM=100M create podpools-busybox
+POD_ANNOTATION="pooltype.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ="" MEMREQ="" CPULIM="" MEMLIM="" create podpools-busybox
+report allowed
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^W.*overbooked'" && error "overbook warning with maximum allowed load"
+kubectl delete pods --all --now

--- a/test/e2e/policies.test-suite/podpools/n4c16/topology.var.json
+++ b/test/e2e/policies.test-suite/podpools/n4c16/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "packages": 2}
+]

--- a/test/e2e/policies.test-suite/podpools/podpools-busybox.yaml.in
+++ b/test/e2e/policies.test-suite/podpools/podpools-busybox.yaml.in
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  $(if [ -n "$POD_ANNOTATION" ]; then echo "
+  annotations:
+    $POD_ANNOTATION
+  "; fi)
+  labels:
+    app: ${NAME}
+spec:
+  containers:
+  $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
+  - name: ${NAME}c$(( contnum - 1 ))
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -c
+      - echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
+    $(if [ -n "${CPUREQ}" ]; then echo "
+    resources:
+      requests:
+        cpu: ${CPUREQ}
+        $(if [ -n "${MEMREQ}" ]; then echo "
+        memory: '${MEMREQ}'
+        "; fi)
+      $(if [ -n "${CPULIM}" ]; then echo "
+      limits:
+        cpu: ${CPULIM}
+        $(if [ -n "$MEMLIM" ]; then echo "
+        memory: '${MEMLIM}'
+        "; fi)
+    "; fi)
+    "; fi)
+  "; done )
+  terminationGracePeriodSeconds: 1


### PR DESCRIPTION
This PR is a draft.
Initial official version of the podpools policy, based on this draft, is being reviewed in PR #598.
Pool configurations in the official version and this draft differ. In order to avoid breaking the trials based on this draft branch, I did not commit API breaks here.