### PR TITLE
docs: recognize/handle .md-links to element IDs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ def isHTTPLink(uri):
     return uri.startswith('http://') or uri.startswith('https://')
 
 def isMDFileLink(uri):
-    return uri.endswith('.md')
+    return uri.endswith('.md') or '.md#' in uri
 
 def isRSTFileLink(uri):
     return uri.endswith('.rst')


### PR DESCRIPTION
Properly recognize a `[]()`-link to an `.md`-file with a `#`-prefixed element ID.
This will cause the generation of a proper link to the corresponding final `HTML`
element in the generated output, instead of a link to the base `.md`-file itself.
