### PR TITLE
server,resource-manager: flush logs after every request/event processed.

### DIFF
--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -78,6 +78,7 @@ func (m *resmgr) startEventProcessing() error {
 					evtlog.Error("rebalancing failed: %v", err)
 				}
 			}
+			logger.Flush()
 		}
 	}()
 

--- a/pkg/cri/server/server.go
+++ b/pkg/cri/server/server.go
@@ -342,6 +342,7 @@ func (s *server) intercept(ctx context.Context, req interface{},
 	}
 
 	s.collectStatistics(kind, name, start, send, recv, end)
+	logger.Flush()
 
 	return rpl, err
 }


### PR DESCRIPTION
Explicitly flush logs after every CRI request and resource-manager event processed.
