### PR TITLE
cri-resmgr: increase allowed service journal log bursts.

### DIFF
--- a/cmd/cri-resmgr/cri-resource-manager.service.in
+++ b/cmd/cri-resmgr/cri-resource-manager.service.in
@@ -2,6 +2,8 @@
 Description=A CRI proxy with (hardware) resource aware container placement policies.
 Documentation=https://github.com/intel/cri-resource-manager
 Before=kubelet.service
+LogRateLimitIntervalSec=5
+LogRateLimitBurst=100000
 
 [Service]
 Type=simple


### PR DESCRIPTION
Increate journald log bursts to avoid losing messages
when running with extensive debugging enabled.