### PR TITLE
resource-manager: force full reallocation when switching policies.

### DIFF
--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -60,6 +60,20 @@ func (m *resmgr) startRequestProcessing() error {
 		return err
 	}
 
+	//
+	// Notes:
+	//   While normally it is enough to release stale containers and allocate
+	//   newly discovered ones, if we are switching policies we need to force
+	//   reallocating everything. Otherwise containers already present in the
+	//   cache would not get properly updated by the new policy.
+	//
+	if m.policySwitch {
+		containers := m.cache.GetContainers()
+		cache.SortContainers(containers)
+		add, del = containers, containers
+		m.policySwitch = false
+	}
+
 	if err := m.policy.Start(add, del); err != nil {
 		return resmgrError("failed to start policy %s: %v", policy.ActivePolicy(), err)
 	}

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -61,6 +61,7 @@ type resmgr struct {
 	relay        relay.Relay        // our CRI relay
 	cache        cache.Cache        // cached state
 	policy       policy.Policy      // resource manager policy
+	policySwitch bool               // active policy is being switched
 	configServer config.Server      // configuration management server
 	control      control.Control    // policy controllers/enforcement
 	agent        agent.Interface    // connection to cri-resmgr agent
@@ -426,6 +427,7 @@ func (m *resmgr) setupPolicy() error {
 			}
 		}
 		m.cache.SetActivePolicy(active)
+		m.policySwitch = true
 	}
 
 	options := &policy.Options{AgentCli: m.agent, SendEvent: m.SendEvent}


### PR DESCRIPTION
Normally it is enough to release stale containers and reallocate newly discovered
ones when we do our initial sync with the runtime during startup. However, when
switching the active policy is allowed and it does happen during startup, we need
to force reallocating everything. Otherwise containers already known and present
in the cache would not get properly updated by the newly activated policy.
