### PR TITLE
topology-aware: force reserved/kube-system containers to the root.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -347,7 +347,7 @@ func (p *policy) allocatePool(container cache.Container, poolHint string) (Grant
 	// the same pool. This assumption can be relaxed later, requires separate
 	// (but connected) scoring of memory and CPU.
 
-	if request.CPUType() == cpuNormal && container.GetNamespace() == kubernetes.NamespaceSystem {
+	if request.CPUType() == cpuReserved || container.GetNamespace() == kubernetes.NamespaceSystem {
 		pool = p.root
 	} else {
 		affinity := p.calculatePoolAffinities(request.GetContainer())


### PR DESCRIPTION
**Note:** This PR is also merged into stacked [PR #609](https://github.com/intel/cri-resource-manager/pull/609).

This PR fixes the allocation/assignment of resources to reserved containers in the kube-system namespace.