### PR TITLE
resource-manager,dump: dump extra data for message disambiguation.

### DIFF
--- a/pkg/cri/relay/relay.go
+++ b/pkg/cri/relay/relay.go
@@ -37,6 +37,8 @@ type Options struct {
 	ImageSocket string
 	// RuntimeSocket is the socket path for the (real) CRI runtime services.
 	RuntimeSocket string
+	// QualifyReqFn produces context for disambiguating a CRI request/reply.
+	QualifyReqFn func(interface{}) string
 }
 
 // Relay is the interface we expose for controlling our CRI relay.
@@ -81,10 +83,11 @@ func NewRelay(options Options) (Relay, error) {
 	}
 
 	srvopts := server.Options{
-		Socket: r.options.RelaySocket,
-		User:   -1,
-		Group:  -1,
-		Mode:   0660,
+		Socket:       r.options.RelaySocket,
+		User:         -1,
+		Group:        -1,
+		Mode:         0660,
+		QualifyReqFn: r.options.QualifyReqFn,
 	}
 	if r.server, err = server.NewServer(srvopts); err != nil {
 		return nil, relayError("failed to create relay server: %v", err)

--- a/pkg/cri/relay/runtime-service.go
+++ b/pkg/cri/relay/runtime-service.go
@@ -23,8 +23,17 @@ import (
 
 func (r *relay) dump(method string, req interface{}) {
 	if r.DebugEnabled() {
-		dump.RequestMessage("relayed", method, req, true)
+		qualif := r.qualifier(req)
+		dump.RequestMessage("relayed", method, qualif, req, true)
 	}
+}
+
+// qualifier pulls a qualifier for disambiguation from a CRI request message.
+func (r *relay) qualifier(msg interface{}) string {
+	if fn := r.options.QualifyReqFn; fn != nil {
+		return fn(msg)
+	}
+	return ""
 }
 
 func (r *relay) Version(ctx context.Context,

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -57,7 +57,7 @@ type ResourceManager interface {
 // resmgr is the implementation of ResourceManager.
 type resmgr struct {
 	logger.Logger
-	sync.Mutex
+	sync.RWMutex
 	relay        relay.Relay        // our CRI relay
 	cache        cache.Cache        // cached state
 	policy       policy.Policy      // resource manager policy
@@ -446,6 +446,7 @@ func (m *resmgr) setupRelay() error {
 		RelaySocket:   opt.RelaySocket,
 		ImageSocket:   opt.ImageSocket,
 		RuntimeSocket: opt.RuntimeSocket,
+		QualifyReqFn:  m.disambiguate,
 	}
 	if m.relay, err = relay.NewRelay(options); err != nil {
 		return resmgrError("failed to create CRI relay: %v", err)

--- a/pkg/dump/dump_test.go
+++ b/pkg/dump/dump_test.go
@@ -155,8 +155,8 @@ func (ft *filterTest) setup(train bool) *testlog {
 func (ft *filterTest) dumpMessages(logger *testlog) []string {
 	// dump all test messages and a fake reply for each
 	for _, msg := range ft.messages {
-		RequestMessage(marker, msgname(msg), msg, false)
-		ReplyMessage(marker, msgname(msg), Reply, time.Duration(0), false)
+		RequestMessage(marker, msgname(msg), "", msg, false)
+		ReplyMessage(marker, msgname(msg), "", Reply, time.Duration(0), false)
 	}
 	dump.sync()
 


### PR DESCRIPTION
**Note:** This PR is also merged into stacked [PR #609](https://github.com/intel/cri-resource-manager/pull/609).

This PR adds extra data to dumped `CRI` messages to help disambiguate corresponding pairs of request/response messages.