### PR TITLE
topology-aware: memory accounting and memset expansion fixes.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
@@ -162,7 +162,6 @@ func (ccg *cachedGrant) ToGrant(policy *policy) (Grant, error) {
 		cpuset.MustParse(ccg.Exclusive),
 		ccg.Part,
 		ccg.MemType,
-		ccg.MemType,
 		ccg.MemoryLimit,
 		ccg.ColdStart,
 	)

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
@@ -297,6 +297,7 @@ func (n *node) Dump(prefix string, level ...int) {
 	n.self.node.dump(prefix, lvl)
 	log.Debug("%s  - %s", idt, n.noderes.DumpCapacity())
 	log.Debug("%s  - %s", idt, n.freeres.DumpAllocatable())
+	n.freeres.DumpMemoryState(idt + "  ")
 	if n.mem.Size() > 0 {
 		log.Debug("%s  - normal memory: %v", idt, n.mem)
 	}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -618,8 +618,7 @@ func (p *policy) applyGrant(grant Grant) {
 	}
 
 	mems := ""
-	node := grant.GetMemoryNode()
-	if !node.IsRootNode() && opt.PinMemory {
+	if opt.PinMemory {
 		mems = grant.Memset().String()
 	}
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -391,7 +391,11 @@ func (p *policy) allocatePool(container cache.Container, poolHint string) (Grant
 			request, supply.DumpAllocatable(), err)
 	}
 
-	log.Debug("allocated req '%s' to memory node '%s' (memset %s,%s)", container.GetCacheID(), grant.GetMemoryNode().Name(), grant.GetMemoryNode().GetMemset(memoryDRAM), grant.GetMemoryNode().GetMemset(memoryPMEM))
+	log.Debug("allocated req '%s' to memory node '%s' (memset %s,%s,%s)",
+		container.PrettyName(), grant.GetMemoryNode().Name(),
+		grant.GetMemoryNode().GetMemset(memoryDRAM),
+		grant.GetMemoryNode().GetMemset(memoryPMEM),
+		grant.GetMemoryNode().GetMemset(memoryHBM))
 
 	// In case the workload is assigned to a memory node with multiple
 	// child nodes, there is no guarantee that the workload will
@@ -563,7 +567,8 @@ func (p *policy) allocatePool(container cache.Container, poolHint string) (Grant
 					return nil, err
 				}
 				if changed {
-					log.Debug("* moved container %s upward to node %s to guarantee memory", oldGrant.GetContainer().GetCacheID(), oldGrant.GetMemoryNode().Name())
+					log.Debug("* moved container %s upward to node %s to guarantee memory",
+						oldGrant.GetContainer().PrettyName(), oldGrant.GetMemoryNode().Name())
 					break
 				}
 			}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
@@ -49,10 +49,10 @@ type Supply interface {
 	Cumulate(Supply)
 	// AssignMemory adds extra memory to this supply (for extra NUMA nodes assigned to a pool).
 	AssignMemory(mem memoryMap)
-	// AccountAllocate accounts for (removes) allocated exclusive capacity from the supply.
-	AccountAllocate(Grant)
-	// AccountRelease accounts for (reinserts) released exclusive capacity into the supply.
-	AccountRelease(Grant)
+	// AccountAllocateCPU accounts for (removes) allocated exclusive capacity from the supply.
+	AccountAllocateCPU(Grant)
+	// AccountReleaseCPU accounts for (reinserts) released exclusive capacity into the supply.
+	AccountReleaseCPU(Grant)
 	// GetScore calculates how well this supply fits/fulfills the given request.
 	GetScore(Request) Score
 	// AllocatableSharedCPU calculates the allocatable amount of shared CPU of this supply.
@@ -112,6 +112,10 @@ type Request interface {
 
 // Grant represents CPU and memory capacity allocated to a container from a node.
 type Grant interface {
+	// SetCPUPortion sets the fraction CPU portion for the grant.
+	SetCPUPortion(fraction int)
+	// SetMemoryAllocation sets the memory allocation for the grant.
+	SetMemoryAllocation(memoryType, memoryMap, time.Duration)
 	// Clone creates a copy of this grant.
 	Clone() Grant
 	// RefetchNodes updates the stored cpu and memory nodes of this grant by name.
@@ -156,10 +160,10 @@ type Grant interface {
 	String() string
 	// Release releases the grant from all the Supplys it uses.
 	Release()
-	// AccountAllocate accounts for (removes) allocated exclusive capacity for this grant.
-	AccountAllocate()
-	// AccountRelease accounts for (reinserts) released exclusive capacity for this grant.
-	AccountRelease()
+	// AccountAllocateCPU accounts for (removes) allocated exclusive capacity for this grant.
+	AccountAllocateCPU()
+	// AccountReleaseCPU accounts for (reinserts) released exclusive capacity for this grant.
+	AccountReleaseCPU()
 	// UpdateExtraMemoryReservation() updates the reservations in the subtree
 	// of nodes under the node from which the memory was granted.
 	UpdateExtraMemoryReservation()
@@ -422,19 +426,18 @@ func (cs *supply) AssignMemory(mem memoryMap) {
 	}
 }
 
-// AccountAllocate accounts for (removes) allocated exclusive capacity from the supply.
-func (cs *supply) AccountAllocate(g Grant) {
+// AccountAllocateCPU accounts for (removes) allocated exclusive capacity from the supply.
+func (cs *supply) AccountAllocateCPU(g Grant) {
 	if cs.node.IsSameNode(g.GetCPUNode()) {
 		return
 	}
 	exclusive := g.ExclusiveCPUs()
 	cs.isolated = cs.isolated.Difference(exclusive)
 	cs.sharable = cs.sharable.Difference(exclusive)
-	// TODO: same for memory
 }
 
-// AccountRelease accounts for (reinserts) released exclusive capacity into the supply.
-func (cs *supply) AccountRelease(g Grant) {
+// AccountReleaseCPU accounts for (reinserts) released exclusive capacity into the supply.
+func (cs *supply) AccountReleaseCPU(g Grant) {
 	if cs.node.IsSameNode(g.GetCPUNode()) {
 		return
 	}
@@ -447,22 +450,21 @@ func (cs *supply) AccountRelease(g Grant) {
 	sharable := grantcpus.Intersection(ncs.SharableCPUs())
 	cs.isolated = cs.isolated.Union(isolated)
 	cs.sharable = cs.sharable.Union(sharable)
-	// For memory the extra allocations be released elsewhere.
 }
 
-func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
-	memType := cr.MemoryType()
+func (cs *supply) allocateMemory(r Request) (memoryMap, error) {
+	memType := r.MemoryType()
 	allocatedMem := createMemoryMap(0, 0, 0)
 
 	if memType == memoryUnspec {
 		memType = memoryAll
 	}
 
-	amount := cr.MemAmountToAllocate()
+	amount := r.MemAmountToAllocate()
 	remaining := amount
 
 	log.Debug("%s: need to allocate %s from %s",
-		cr.GetContainer().PrettyName(), prettyMem(amount), cs.GetNode().Name())
+		r.GetContainer().PrettyName(), prettyMem(amount), cs.GetNode().Name())
 
 	// First allocate from PMEM, then DRAM, finally HBM. No need to care about
 	// extra memory reservations since the nodes into which the request won't
@@ -472,7 +474,7 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 		available := cs.mem[memoryPMEM] - cs.grantedMem[memoryPMEM]
 
 		log.Debug("%s: trying %s from PMEM, available %s",
-			cr.GetContainer().PrettyName(),
+			r.GetContainer().PrettyName(),
 			prettyMem(remaining), prettyMem(available))
 
 		if remaining < available {
@@ -488,7 +490,7 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 		}
 	}
 
-	if remaining > 0 && cr.ColdStart() > 0 {
+	if remaining > 0 && r.ColdStart() > 0 {
 		cs.mem[memoryPMEM] += amount - remaining
 		cs.grantedMem[memoryPMEM] = amount - remaining
 		return nil, policyError("internal error: not enough memory at %s, short circuit due to cold start", cs.GetNode().Name())
@@ -498,7 +500,7 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 		available := cs.mem[memoryDRAM] - cs.grantedMem[memoryDRAM]
 
 		log.Debug("%s: trying %s from DRAM, available %s",
-			cr.GetContainer().PrettyName(),
+			r.GetContainer().PrettyName(),
 			prettyMem(remaining), prettyMem(available))
 
 		if remaining < available {
@@ -518,7 +520,7 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 		available := cs.mem[memoryHBM] - cs.grantedMem[memoryHBM]
 
 		log.Debug("%s: trying %s from HBMEM, available %s",
-			cr.GetContainer().PrettyName(),
+			r.GetContainer().PrettyName(),
 			prettyMem(remaining), prettyMem(available))
 
 		if remaining < available {
@@ -535,7 +537,17 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 	}
 
 	if remaining > 0 {
-		// FIXME: restore the already allocated memory to the supply
+		log.Debug("%s: allocation from %s fell short %s",
+			r.GetContainer().PrettyName(), cs.GetNode().Name(),
+			prettyMem(remaining))
+
+		for memType, a := range allocatedMem {
+			if a > 0 {
+				cs.grantedMem[memType] -= a
+				cs.mem[memType] += a
+			}
+		}
+
 		return nil, policyError("internal error: not enough memory at %s", cs.node.Name())
 	}
 
@@ -548,6 +560,24 @@ func (cs *supply) allocateMemory(cr *request) (memoryMap, error) {
 
 // Allocate allocates a grant from the supply.
 func (cs *supply) Allocate(r Request) (Grant, error) {
+	grant, err := cs.AllocateCPU(r)
+	if err != nil {
+		return nil, err
+	}
+
+	memory, err := cs.allocateMemory(r)
+	if err != nil {
+		cs.ReleaseCPU(grant)
+		return nil, err
+	}
+
+	grant.SetMemoryAllocation(r.MemoryType(), memory, r.ColdStart())
+
+	return grant, nil
+}
+
+// AllocateCPU allocates CPU for a grant from the supply.
+func (cs *supply) AllocateCPU(r Request) (Grant, error) {
 	var exclusive cpuset.CPUSet
 	var err error
 
@@ -561,6 +591,7 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 		fraction += full * 1000
 		full = 0
 	}
+
 	// allocate isolated exclusive CPUs or slice them off the sharable set
 	switch {
 	case full > 0 && cs.isolated.Size() >= full && cr.isolate:
@@ -585,10 +616,14 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 			cs.node.Name(), full, cs.sharable, cs.AllocatableSharedCPU())
 	}
 
+	grant := newGrant(cs.node, cr.GetContainer(), cr.cpuType, exclusive, 0, 0, nil, 0)
+	grant.AccountAllocateCPU()
+
 	if fraction > 0 {
 		if cr.cpuType == cpuNormal {
 			// allocate requested portion of shared CPUs
 			if cs.AllocatableSharedCPU() < fraction {
+				cs.ReleaseCPU(grant)
 				return nil, policyError("internal error: "+
 					"%s: not enough %dm sharable CPU for %dm, %dm available",
 					cs.node.Name(), fraction, cs.sharable, cs.AllocatableSharedCPU())
@@ -597,29 +632,15 @@ func (cs *supply) Allocate(r Request) (Grant, error) {
 		} else if cr.cpuType == cpuReserved {
 			// allocate requested portion of reserved CPUs
 			if cs.AllocatableReservedCPU() < fraction {
+				cs.ReleaseCPU(grant)
 				return nil, policyError("internal error: "+
 					"%s: not enough reserved CPU: %dm requested, %dm available",
 					cs.node.Name(), fraction, cs.AllocatableReservedCPU())
 			}
 			cs.grantedReserved += fraction
 		}
+		grant.SetCPUPortion(fraction)
 	}
-
-	allocatedMem, err := cs.allocateMemory(cr)
-	if err != nil {
-		return nil, err
-	}
-
-	// allocate only limited memory set due to cold start
-	memType := memoryPMEM
-	coldStart := cr.ColdStart()
-	if coldStart <= 0 {
-		memType = cr.memType
-	}
-
-	grant := newGrant(cs.node, cr.GetContainer(), cr.cpuType, exclusive, fraction, memType, cr.memType, allocatedMem, coldStart)
-
-	grant.AccountAllocate()
 
 	return grant, nil
 }
@@ -658,7 +679,7 @@ func (cs *supply) ReleaseCPU(g Grant) {
 	cs.grantedReserved -= g.ReservedPortion()
 	cs.grantedShared -= g.SharedPortion()
 
-	g.AccountRelease()
+	g.AccountReleaseCPU()
 }
 
 // ReleaseMemory returns memory from the given grant to the supply.
@@ -740,9 +761,7 @@ func (cs *supply) Reserve(g Grant) error {
 		cs.grantedReserved += sharedPortion
 	}
 
-	g.AccountAllocate()
-
-	// TODO: do the same for memory
+	g.AccountAllocateCPU()
 
 	return nil
 }
@@ -1227,27 +1246,45 @@ func (score *score) String() string {
 }
 
 // newGrant creates a CPU grant from the given node for the container.
-func newGrant(n Node, c cache.Container, cpuType cpuClass, exclusive cpuset.CPUSet, cpuPortion int, initialMt, mt memoryType, allocatedMem memoryMap, coldStart time.Duration) Grant {
-	mems := n.GetMemset(initialMt)
+func newGrant(n Node, c cache.Container, cpuType cpuClass, exclusive cpuset.CPUSet, cpuPortion int, mt memoryType, allocated memoryMap, coldstart time.Duration) Grant {
+	grant := &grant{
+		node:       n,
+		memoryNode: n,
+		container:  c,
+		cpuType:    cpuType,
+		exclusive:  exclusive,
+		cpuPortion: cpuPortion,
+	}
+	if allocated != nil {
+		grant.SetMemoryAllocation(mt, allocated, coldstart)
+	}
+	return grant
+}
+
+// SetCPUPortion sets the fractional CPU portion for the grant.
+func (cg *grant) SetCPUPortion(fraction int) {
+	cg.cpuPortion = fraction
+}
+
+// SetMemoryAllocation sets the memory allocation for the grant.
+func (cg *grant) SetMemoryAllocation(mt memoryType, allocated memoryMap, coldstart time.Duration) {
+	initial := memoryPMEM
+	if coldstart <= 0 {
+		initial = mt
+	}
+	mems := cg.node.GetMemset(initial)
 	if mems.Size() == 0 {
-		mems = n.GetMemset(memoryDRAM)
+		mems = cg.node.GetMemset(memoryDRAM)
 		if mems.Size() == 0 {
-			mems = n.GetMemset(memoryAll)
+			mems = cg.node.GetMemset(memoryAll)
 		}
 	}
+	mems = mems.Clone()
 
-	return &grant{
-		node:         n,
-		memoryNode:   n,
-		container:    c,
-		cpuType:      cpuType,
-		exclusive:    exclusive,
-		cpuPortion:   cpuPortion,
-		memType:      mt,
-		memset:       mems.Clone(),
-		allocatedMem: allocatedMem,
-		coldStart:    coldStart,
-	}
+	cg.memType = mt
+	cg.memset = mems
+	cg.allocatedMem = allocated
+	cg.coldStart = coldstart
 }
 
 // Clone creates a copy of this grant.
@@ -1390,13 +1427,13 @@ func (cg *grant) String() string {
 		cg.container.PrettyName(), cg.node.Name(), cpuType, isolated, exclusive, reserved, shared, mem)
 }
 
-func (cg *grant) AccountAllocate() {
+func (cg *grant) AccountAllocateCPU() {
 	cg.node.DepthFirst(func(n Node) error {
-		n.FreeSupply().AccountAllocate(cg)
+		n.FreeSupply().AccountAllocateCPU(cg)
 		return nil
 	})
 	for node := cg.node.Parent(); !node.IsNil(); node = node.Parent() {
-		node.FreeSupply().AccountAllocate(cg)
+		node.FreeSupply().AccountAllocateCPU(cg)
 	}
 }
 
@@ -1406,13 +1443,13 @@ func (cg *grant) Release() {
 	cg.StopTimer()
 }
 
-func (cg *grant) AccountRelease() {
+func (cg *grant) AccountReleaseCPU() {
 	cg.node.DepthFirst(func(n Node) error {
-		n.FreeSupply().AccountRelease(cg)
+		n.FreeSupply().AccountReleaseCPU(cg)
 		return nil
 	})
 	for node := cg.node.Parent(); !node.IsNil(); node = node.Parent() {
-		node.FreeSupply().AccountRelease(cg)
+		node.FreeSupply().AccountReleaseCPU(cg)
 	}
 }
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
@@ -82,6 +82,8 @@ type Supply interface {
 	DumpCapacity() string
 	// DumpAllocatable returns a printable representation of the supply's alloctable resources.
 	DumpAllocatable() string
+	// DumpMemoryState dumps the state of the available and allocated memory.
+	DumpMemoryState(string)
 }
 
 // Request represents CPU and memory resources requested by a container.
@@ -318,18 +320,24 @@ func (m memoryMap) AddHBM(hbm uint64) {
 func (m memoryMap) String() string {
 	mem, sep := "", ""
 
-	dram, pmem, hbm := m[memoryDRAM], m[memoryPMEM], m[memoryHBM]
+	dram, pmem, hbm, types := m[memoryDRAM], m[memoryPMEM], m[memoryHBM], 0
 	if dram > 0 || pmem > 0 || hbm > 0 {
 		if dram > 0 {
-			mem += "dram:" + strconv.FormatUint(dram, 10)
+			mem += "DRAM " + prettyMem(dram)
 			sep = ", "
+			types++
 		}
 		if pmem > 0 {
-			mem += sep + "pmem:" + strconv.FormatUint(pmem, 10)
+			mem += sep + "PMEM " + prettyMem(pmem)
 			sep = ", "
+			types++
 		}
 		if hbm > 0 {
-			mem += sep + "hbm:" + strconv.FormatUint(hbm, 10)
+			mem += sep + "HBM " + prettyMem(hbm)
+			types++
+		}
+		if types > 1 {
+			mem += sep + "total " + prettyMem(pmem+dram+hbm)
 		}
 	}
 
@@ -828,6 +836,74 @@ func (cs *supply) DumpAllocatable() string {
 	allocatable += ">"
 
 	return allocatable
+}
+
+// prettyMem formats the given amount as k, M, G, or T units.
+func prettyMem(value uint64) string {
+	units := []string{"k", "M", "G", "T"}
+	coeffs := []uint64{1 << 10, 1 << 20, 1 << 30, 1 << 40}
+
+	c, u := uint64(1), ""
+	for i := 0; i < len(units); i++ {
+		if coeffs[i] > value {
+			break
+		}
+		c, u = coeffs[i], units[i]
+	}
+	v := float64(value) / float64(c)
+
+	return strconv.FormatFloat(v, 'f', 2, 64) + u
+}
+
+// DumpMemoryState dumps the state of the available and allocated memory.
+func (cs *supply) DumpMemoryState(prefix string) {
+	memTypes := []memoryType{memoryDRAM, memoryPMEM, memoryHBM}
+	totalFree := uint64(0)
+	totalGranted := uint64(0)
+	for _, kind := range memTypes {
+		free := cs.mem[kind]
+		granted := cs.grantedMem[kind]
+		if free != 0 || granted != 0 {
+			log.Debug(prefix+"- %s: free: %s, granted %s",
+				kind, prettyMem(free), prettyMem(granted))
+		}
+		totalFree += free
+		totalGranted += granted
+	}
+	log.Debug(prefix+"- total free: %s, total granted %s",
+		prettyMem(totalFree), prettyMem(totalGranted))
+
+	printHdr := true
+	if len(cs.extraMemReservations) > 0 {
+		for g, memMap := range cs.extraMemReservations {
+			split := ""
+			sep := ""
+			total := uint64(0)
+			if mem := memMap[memoryDRAM]; mem > 0 {
+				split = "DRAM " + prettyMem(mem)
+				sep = ", "
+				total += mem
+			}
+			if mem := memMap[memoryPMEM]; mem > 0 {
+				split += sep + "PMEM " + prettyMem(mem)
+				sep = ", "
+				total += mem
+			}
+			if mem := memMap[memoryHBM]; mem > 0 {
+				split += sep + "HBMEM " + prettyMem(mem)
+				sep = ", "
+				total += mem
+			}
+			if total > 0 {
+				if printHdr {
+					log.Debug(prefix + "- extra reservations:")
+					printHdr = false
+				}
+				log.Debug(prefix+"  - %s: %s (%s)",
+					g.GetContainer().PrettyName(), prettyMem(total), split)
+			}
+		}
+	}
 }
 
 // newRequest creates a new request for the given container.
@@ -1331,7 +1407,10 @@ func (cg *grant) ExpandMemset() (bool, error) {
 			limit := supply.MemoryLimit()[memType]
 
 			if extra+granted > limit {
-				log.Debug("%s: extra():%d + granted(): %d > limit: %d -> moving from %s to %s", memType, extra, granted, limit, node.Name(), parent.Name())
+				log.Debug("%s: %s: extra:%d + granted: %d > limit:%d -> moving from %s to %s",
+					cg.GetContainer().PrettyName(), memType,
+					extra, granted, limit,
+					node.Name(), parent.Name())
 				fits = false
 				break
 			}


### PR DESCRIPTION
**Note 1:** This PR is stacked on [#615](https://github.com/intel/cri-resource-manager/pull/615). You probably want to review that separately first.
- [x] [#615: topology-aware: better and more readable logs](https://github.com/intel/cri-resource-manager/pull/615)

**Note 2:** This PR is also merged into stacked [PR #609](https://github.com/intel/cri-resource-manager/pull/609).

This PR
- fixes the memset expansion logic in `ExpandMemset()`
- fixes accounting to not leak resources on failed CPU allocation
- fixes accounting to not leak memory on (partially) failed memory allocation
- fixes a bug that double-charges pool tree nodes for already allocated memory
- adds debug logs to the memory accounting code