### PR TITLE
e2e: update podpools tests to pass with new cpuallocator

### DIFF
--- a/test/e2e/policies.test-suite/podpools/n4c16/py_consts.var.py
+++ b/test/e2e/policies.test-suite/podpools/n4c16/py_consts.var.py
@@ -1,0 +1,51 @@
+# This file captures expected CPU allocator behavior when the podpools
+# policy is started with the test default cri-resmgr configuration on
+# n4c16 topology.
+
+# cri-resmgr output on constructed pools.
+expected_podpools_output = """
+podpools policy pools:
+- pool 0: reserved[0]{cpus:15, mems:3, pods:0/0, containers:0}
+- pool 1: default[0]{cpus:5,12-14, mems:1,3, pods:0/0, containers:0}
+- pool 2: singlecpu[0]{cpus:2, mems:0, pods:0/2, containers:0}
+- pool 3: singlecpu[1]{cpus:3, mems:0, pods:0/2, containers:0}
+- pool 4: singlecpu[2]{cpus:4, mems:1, pods:0/2, containers:0}
+- pool 5: dualcpu[0]{cpus:6-7, mems:1, pods:0/3, containers:0}
+- pool 6: dualcpu[1]{cpus:8-9, mems:2, pods:0/3, containers:0}
+- pool 7: dualcpu[2]{cpus:10-11, mems:2, pods:0/3, containers:0}
+"""
+
+# 1. Parse expected_podpools_output into
+#    expected.cpus.POOLNAME[INSTANCE] = {"cpuNN", ...}
+# 2. Calculate memory nodes based on expected.cpus into
+#    expected.mems.POOLNAME[INSTANCE] = {"nodeN", ...}
+#    (do not read these from output in order to verify its correctness)
+#
+# As the result:
+# expected.cpus.singlecpu == [{"cpu02"}, {"cpu03"}, {"cpu04"}]
+# expected.mems.singlecpu == [{"node0"}, {"node0"}, {"node1"}]
+
+import re
+
+class expected:
+    class cpus:
+        pass
+    class mems:
+        pass
+
+def _add_expected_pool(poolname, poolindex, cpuset):
+    cpus = []
+    for cpurange in cpuset.split(","):
+        lower_upper = [int(n) for n in cpurange.split("-")]
+        if len(lower_upper) == 1:
+            cpus.append(lower_upper[0])
+        else:
+            cpus.extend([i for i in range(lower_upper[0], lower_upper[1]+1)])
+    if not hasattr(expected.cpus, poolname):
+        setattr(expected.cpus, poolname, [])
+        setattr(expected.mems, poolname, [])
+    getattr(expected.cpus, poolname).append(set('cpu%s' % (str(cpu).zfill(2),) for cpu in cpus))
+    getattr(expected.mems, poolname).append(set("node%s" % (cpu//4,) for cpu in cpus))
+
+for poolname, poolindex, cpuset in re.findall(r': ([a-z]+)\[([0-9]+)\]\{cpus:([0-9,-]+), ', expected_podpools_output):
+    _add_expected_pool(poolname, poolindex, cpuset)

--- a/test/e2e/policies.test-suite/podpools/n4c16/test04-overbook-cpus/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test04-overbook-cpus/code.var.sh
@@ -7,19 +7,19 @@ CRI_RESMGR_OUTPUT="cat cri-resmgr.output.txt"
 # pod0: overbook with single burstable pod and container
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=2900m CPULIM="" MEMREQ="" MEMLIM="" create podpools-busybox
 report allowed
-vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*6-7.*(2899|2900)m'" || error "missing overbook warning"
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*(2899|2900)m'" || error "missing overbook warning"
 kubectl delete pods --all --now
 
 # pod1: overbook with single burstable pod with two containers
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1050m CPULIM="" MEMREQ="" MEMLIM="" CONTCOUNT=2 create podpools-busybox
 report allowed
-vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*6-7.*2100m'" || error "missing overbook warning"
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*2100m'" || error "missing overbook warning"
 kubectl delete pods --all --now
 
 # pod2, pod3: overbook with two guaranteed pods, one container in each pod
 n=2 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1001m MEMREQ=100M CPULIM=1001m MEMLIM=100M create podpools-busybox
 report allowed
-vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*6-7.*2002m'" || error "missing overbook warning"
+vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*2002m'" || error "missing overbook warning"
 kubectl delete pods --all --now
 
 # pod4, pod5: no overbooking with exact CPUs guaranteed + besteffort pod

--- a/test/e2e/policies.test-suite/podpools/n4c16/test05-agent-updates-config/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test05-agent-updates-config/code.var.sh
@@ -14,29 +14,29 @@ launch cri-resmgr-agent
 # reserved, shared, singlecpu, dualcpu
 # pod0: reserved
 CPUREQ="" namespace=kube-system create podpools-busybox
-# pod1: shared
+# pod1: default
 CPUREQ="" create podpools-busybox
 # pod2: singlecpu
 CPUREQ="1" POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: singlecpu" create podpools-busybox
 # pod3, pod4, pod5, pod6: dualcpu (dualcpu 3 pods/pool, packed)
 n=4 CPUREQ="1" POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" create podpools-busybox
 report allowed
-verify "cpus['pod0c0'] == {'cpu15'}" \
-       "cpus['pod1c0'] == {'cpu13', 'cpu05', 'cpu12', 'cpu14'}" \
-       "cpus['pod2c0'] == {'cpu02'}" \
-       "cpus['pod3c0'] == {'cpu06', 'cpu07'}" \
-       "cpus['pod4c0'] == {'cpu06', 'cpu07'}" \
-       "cpus['pod5c0'] == {'cpu06', 'cpu07'}" \
-       "cpus['pod6c0'] == {'cpu08', 'cpu09'}"
+verify "cpus['pod0c0'] == expected.cpus.reserved[0]" \
+       "cpus['pod1c0'] == expected.cpus.default[0]" \
+       "cpus['pod2c0'] == expected.cpus.singlecpu[0]" \
+       "cpus['pod3c0'] == expected.cpus.dualcpu[0]" \
+       "cpus['pod4c0'] == expected.cpus.dualcpu[0]" \
+       "cpus['pod5c0'] == expected.cpus.dualcpu[0]" \
+       "cpus['pod6c0'] == expected.cpus.dualcpu[1]"
 
 echo "Switch to new configuration without singlecpu pools"
 vm-put-file $(NAME=dualcpu CPU=2 MAXPODS=2 INSTANCES="100 %" instantiate podpools-configmap.yaml) podpools-dualcpu-configmap.yaml
 kubectl apply -f podpools-dualcpu-configmap.yaml
 sleep 5
 report allowed
-verify "cpus['pod0c0'] == {'cpu15'}" `# reserved remains the same` \
-       "cpus['pod1c0'] == {'cpu14'}" `# the default pool has only one CPU` \
-       "cpus['pod2c0'] == {'cpu14'}" `# no singlecpu pool -> assign to default` \
+verify "cpus['pod0c0'] == expected.cpus.reserved[0]" `# reserved remains the same` \
+       "len(cpus['pod1c0']) == 1" `# the default pool has only one CPU` \
+       "cpus['pod2c0'] == cpus['pod1c0']" `# no singlecpu pool -> assign to default` \
        `# there are many dualcpu pools (1 out of 2 pods/pool, balanced)` \
        "len(cpus['pod3c0']) == 2" \
        "len(cpus['pod4c0']) == 2" \
@@ -50,7 +50,7 @@ kubectl apply -f podpools-borked-configmap.yaml
 sleep 5
 report allowed
 verify "cpus['pod0c0'] == {'cpu15'}" \
-       "cpus['pod1c0'] == cpus['pod2c0'] == {'cpu14'}" \
+       "cpus['pod1c0'] == cpus['pod2c0']" \
        "disjoint_sets(cpus['pod3c0'], cpus['pod4c0'], cpus['pod5c0'], cpus['pod6c0'])" \
 
 echo "After broken reconfiguration trial, switch to valid configuration without dualcpu pools"
@@ -61,25 +61,23 @@ kubectl apply -f podpools-dualcpu-configmap.yaml
 sleep 5
 report allowed
 
-verify "cpus['pod0c0'] == {'cpu15'}" `# reserved remains the same` \
-       "cpus['pod1c0'] == {'cpu15'}" `# the default pool equals to reserved` \
-       "cpus['pod2c0'] == {'cpu02'}" `# pod2 in singlecpu[0]` \
+verify "cpus['pod0c0'] == expected.cpus.reserved[0]" `# reserved remains the same` \
+       "cpus['pod1c0'] == expected.cpus.reserved[0]" `# the default pool equals to reserved` \
+       "len(cpus['pod2c0']) == 1" `# pod2 in singlecpu[0]` \
+       "disjoint_sets(cpus['pod2c0'], expected.cpus.reserved[0])" \
        `# all dualcpu pods endup into the default pool` \
-       "cpus['pod3c0'] == {'cpu15'}" \
-       "cpus['pod4c0'] == {'cpu15'}" \
-       "cpus['pod5c0'] == {'cpu15'}" \
-       "cpus['pod6c0'] == {'cpu15'}"
+       "cpus['pod3c0'] == cpus['pod4c0'] == cpus['pod5c0'] == cpus['pod6c0']" \
+       "cpus['pod3c0'] == expected.cpus.reserved[0]"
 
 echo "Not enough dualcpu pools for all running dualcpu pods, the rest fall back to the default pool"
 vm-put-file $(NAME=dualcpu CPU=2 MAXPODS=1 INSTANCES="2" instantiate podpools-configmap.yaml) podpools-dualcpu-configmap.yaml
 kubectl apply -f podpools-dualcpu-configmap.yaml
 sleep 5
 report allowed
-DEFAULTCPUS="{'cpu06', 'cpu07', 'cpu08', 'cpu09', 'cpu10', 'cpu11', 'cpu12', 'cpu13', 'cpu14'}"
 pp cpus
-verify "cpus['pod0c0'] == {'cpu15'}" `# reserved remains the same` \
-       "cpus['pod1c0'] == $DEFAULTCPUS" `# the default pool` \
-       "cpus['pod2c0'] == $DEFAULTCPUS" `# no singlecpu pool -> assign to default` \
+verify "cpus['pod0c0'] == expected.cpus.reserved[0]" `# reserved remains the same` \
+       "len(cpus['pod1c0']) == 9" `# the default pool` \
+       "cpus['pod2c0'] == cpus['pod1c0']" `# no singlecpu pool -> assign to default` \
        `# two dualcpu pods go to dualcpu pools, two to the default pool` \
        "len([c for c in ['pod3c0', 'pod4c0', 'pod5c0', 'pod6c0'] if len(cpus[c])==2]) == 2" \
        "len([c for c in ['pod3c0', 'pod4c0', 'pod5c0', 'pod6c0'] if len(cpus[c])==9]) == 2"


### PR DESCRIPTION
Update podpools tests and make them easy to update when CPU allocator behavior changes next time.

This PR runs on top of PR #602.