### PR TITLE
resource-manager: save cache at startup.

### DIFF
--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -153,7 +153,7 @@ func (m *resmgr) startRequestProcessing() error {
 		m.Error("startup: failed to run post-release hooks: %v", err)
 	}
 
-	return nil
+	return m.cache.Save()
 }
 
 // syncWithCRI synchronizes cache pods and containers with the CRI runtime.


### PR DESCRIPTION
Save the cache as the last action in a successful startup sequence.