### PR TITLE
rdt: support L2 cache allocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0
-	github.com/intel/goresctrl v0.0.0-20201221180043-c1bbf3a22bce
+	github.com/intel/goresctrl v0.0.0-20210216084728-8e0ae5411bf4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/intel/goresctrl v0.0.0-20201221180043-c1bbf3a22bce h1:T9NS/TAXUa6BCc/0lKtYLKaoyqMcky3avaK5Rn4kaa4=
-github.com/intel/goresctrl v0.0.0-20201221180043-c1bbf3a22bce/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
+github.com/intel/goresctrl v0.0.0-20210216084728-8e0ae5411bf4 h1:TU7hKzEkL/i2fuWeeyZC9wubq5QWrWLxx9Xl5uv237w=
+github.com/intel/goresctrl v0.0.0-20210216084728-8e0ae5411bf4/go.mod h1:fNHIcnsTDZtMoWI+PlAjniZM8xG/gRO5n6vyq363Qyk=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -78,23 +78,29 @@ data:
   rdt: |+
     # Common options
     options:
+      # Mode must be one of Full, Discovery or Disabled. Defaults to Full.
+      mode: Full
+      monitoringDisabled: false
+      l2:
+        optional: true
       l3:
         optional: true
       mb:
         optional: true
     # This example config specifies one partition with three classes (resctrl groups in the system)
-    # with L3 CAT configured
     partitions:
       default:
-        l3Allocation:
-          all: 100%
-        mbAllocation:
-          all: [100%]
+        l2Allocation: "100%"
+        l3Allocation: "100%"
+        mbAllocation: ["100%"]
         classes:
           Guaranteed:
-            l3schema:
-              all: "100%"
-## Specific settings for L3 CDP (Code and Data Prioritization)
+            l2schema: "100%"
+            l3schema: "100%"
+## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
+## remove the "100%" shorthand above if enabling this
+## 'all' specificies the default value for all cache-ids
+#              all:
 #                unified: "100%"
 #                code: "100%"
 #                data: "80%"
@@ -105,6 +111,7 @@ data:
 #              all: [100%]
 #              1-3: [80%, 10000MBps]
           Burstable:
+            l2schema: "66%"
             l3schema:
               all:
                 unified: "66%"
@@ -112,25 +119,18 @@ data:
                 code: "100%"
                 data: "50%"
 ## MBA (Memory Bandwidth Allocation) for 'Burstable'
-#            mbschema:
-#              all: [66%, 5000MBps]
+## 'all' may be omitted if no cache-id specific settings are required
+#            mbschema: [66%, 5000MBps]
           BestEffort:
-            l3schema:
-              all:
-                unified: "33%"
+            l2schema: "60%"
+            l3schema: "33%"
 ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-#            mbschema:
-#              all: [33%, 3000MBps]
+#            mbschema: [33%, 3000MBps]
 ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
 ## resctrl group of the system
 #          SYSTEM_DEFAULT:
-#            l3schema:
-#              all: "50%"
-  dump: |+
-    Config: full:.*,debug
-    File: /tmp/cri-full-debug.dump
-  logger: |+
-    Debug: resource-manager,cache,policy
+#            l2schema: "60%"
+#            l3schema: "50%"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -190,23 +190,29 @@ data:
   rdt: |+
     # Common options
     options:
+      # Mode must be one of Full, Discovery or Disabled. Defaults to Full.
+      mode: Full
+      monitoringDisabled: false
+      l2:
+        optional: true
       l3:
         optional: true
       mb:
         optional: true
     # This example config specifies one partition with three classes (resctrl groups in the system)
-    # with L3 CAT configured
     partitions:
       default:
-        l3Allocation:
-          all: 100%
-        mbAllocation:
-          all: [100%]
+        l2Allocation: "100%"
+        l3Allocation: "100%"
+        mbAllocation: ["100%"]
         classes:
           Guaranteed:
-            l3schema:
-              all: "100%"
-## Specific settings for L3 CDP (Code and Data Prioritization)
+            l2schema: "100%"
+            l3schema: "100%"
+## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
+## remove the "100%" shorthand above if enabling this
+## 'all' specificies the default value for all cache-ids
+#              all:
 #                unified: "100%"
 #                code: "100%"
 #                data: "80%"
@@ -217,6 +223,7 @@ data:
 #              all: [100%]
 #              1-3: [80%, 10000MBps]
           Burstable:
+            l2schema: "66%"
             l3schema:
               all:
                 unified: "66%"
@@ -224,20 +231,18 @@ data:
                 code: "100%"
                 data: "50%"
 ## MBA (Memory Bandwidth Allocation) for 'Burstable'
-#            mbschema:
-#              all: [66%, 5000MBps]
+## 'all' may be omitted if no cache-id specific settings are required
+#            mbschema: [66%, 5000MBps]
           BestEffort:
-            l3schema:
-              all:
-                unified: "33%"
+            l2schema: "60%"
+            l3schema: "33%"
 ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-#            mbschema:
-#              all: [33%, 3000MBps]
+#            mbschema: [33%, 3000MBps]
 ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
 ## resctrl group of the system
 #          SYSTEM_DEFAULT:
-#            l3schema:
-#              all: "50%"
+#            l2schema: "60%"
+#            l3schema: "50%"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -300,18 +305,21 @@ data:
       # Mode must be one of Full, Discovery or Disabled. Defaults to Full.
       mode: Full
       monitoringDisabled: false
+      l2:
+        optional: true
       l3:
         optional: true
       mb:
         optional: true
     # This example config specifies one partition with three classes (resctrl groups in the system)
-    # with L3 CAT configured
     partitions:
       default:
+        l2Allocation: "100%"
         l3Allocation: "100%"
         mbAllocation: ["100%"]
         classes:
           Guaranteed:
+            l2schema: "100%"
             l3schema: "100%"
 ## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
 ## remove the "100%" shorthand above if enabling this
@@ -327,6 +335,7 @@ data:
 #              all: [100%]
 #              1-3: [80%, 10000MBps]
           Burstable:
+            l2schema: "66%"
             l3schema:
               all:
                 unified: "66%"
@@ -337,12 +346,14 @@ data:
 ## 'all' may be omitted if no cache-id specific settings are required
 #            mbschema: [66%, 5000MBps]
           BestEffort:
+            l2schema: "60%"
             l3schema: "33%"
 ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
 #            mbschema: [33%, 3000MBps]
 ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
 ## resctrl group of the system
 #          SYSTEM_DEFAULT:
+#            l2schema: "60%"
 #            l3schema: "50%"
   dump: |+
     Config: full:.*,short:.*Stop.*,off:.*List.*


### PR DESCRIPTION
Update goresctrl to the latest revision which supports L2 CAT. There are no other (API) changes than new options in the configuration.