### PR TITLE
pkg/sysfs: clarifying comment on getCPUMapping()

### DIFF
--- a/pkg/sysfs/sst_if.go
+++ b/pkg/sysfs/sst_if.go
@@ -55,7 +55,9 @@ func isstIoctl(ioctl uintptr, req uintptr) error {
 }
 
 // getCPUMapping gets mapping of Linux logical CPU numbers to (package-specific)
-// PUNIT CPU number for one cpu
+// PUNIT CPU number for one cpu. This is needed because the PUNIT CPU/core
+// numbering differs from the Linux kernel numbering (exposed via sysfs) which
+// is based on APIC.
 func getCPUMapping(cpu ID) (ID, error) {
 	req := isstIfCPUMaps{
 		Cmd_count: 1,


### PR DESCRIPTION
Describes why we need that instead of using sysfs topology information.