### PR TITLE
sample-configs: make cri-resmgr-configmap.example.yaml usable

### DIFF
--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -97,19 +97,19 @@ data:
           Guaranteed:
             l2schema: "100%"
             l3schema: "100%"
-## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
-## remove the "100%" shorthand above if enabling this
-## 'all' specificies the default value for all cache-ids
-#              all:
-#                unified: "100%"
-#                code: "100%"
-#                data: "80%"
-## Specify CacheId (typically corresponds to a CPU socket) specific setting
-#              1: "80%"
-## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
-#            mbschema:
-#              all: [100%]
-#              1-3: [80%, 10000MBps]
+            ## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
+            ## remove the "100%" shorthand above if enabling this
+            ## 'all' specificies the default value for all cache-ids
+            #  all:
+            #    unified: "100%"
+            #    code: "100%"
+            #    data: "80%"
+            ## Specify CacheId (typically corresponds to a CPU socket) specific setting
+            #  1: "80%"
+          ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
+          #  mbschema:
+          #    all: [100%]
+          #    1-3: [80%, 10000MBps]
           Burstable:
             l2schema: "66%"
             l3schema:
@@ -118,19 +118,19 @@ data:
                 # Separate schema for L3 code and data paths specified
                 code: "100%"
                 data: "50%"
-## MBA (Memory Bandwidth Allocation) for 'Burstable'
-## 'all' may be omitted if no cache-id specific settings are required
-#            mbschema: [66%, 5000MBps]
+          ## MBA (Memory Bandwidth Allocation) for 'Burstable'
+          ## 'all' may be omitted if no cache-id specific settings are required
+          #  mbschema: [66%, 5000MBps]
           BestEffort:
             l2schema: "60%"
             l3schema: "33%"
-## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-#            mbschema: [33%, 3000MBps]
-## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
-## resctrl group of the system
-#          SYSTEM_DEFAULT:
-#            l2schema: "60%"
-#            l3schema: "50%"
+          ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
+          #  mbschema: [33%, 3000MBps]
+        ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
+        ## resctrl group of the system
+        #  SYSTEM_DEFAULT:
+        #    l2schema: "60%"
+        #    l3schema: "50%"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -209,19 +209,19 @@ data:
           Guaranteed:
             l2schema: "100%"
             l3schema: "100%"
-## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
-## remove the "100%" shorthand above if enabling this
-## 'all' specificies the default value for all cache-ids
-#              all:
-#                unified: "100%"
-#                code: "100%"
-#                data: "80%"
-## Specify CacheId (typically corresponds to a CPU socket) specific setting
-#              1: "80%"
-## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
-#            mbschema:
-#              all: [100%]
-#              1-3: [80%, 10000MBps]
+            ## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
+            ## remove the "100%" shorthand above if enabling this
+            ## 'all' specificies the default value for all cache-ids
+            #  all:
+            #    unified: "100%"
+            #    code: "100%"
+            #    data: "80%"
+            ## Specify CacheId (typically corresponds to a CPU socket) specific setting
+            #  1: "80%"
+          ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
+          #  mbschema:
+          #    all: [100%]
+          #    1-3: [80%, 10000MBps]
           Burstable:
             l2schema: "66%"
             l3schema:
@@ -230,19 +230,19 @@ data:
                 # Separate schema for L3 code and data paths specified
                 code: "100%"
                 data: "50%"
-## MBA (Memory Bandwidth Allocation) for 'Burstable'
-## 'all' may be omitted if no cache-id specific settings are required
-#            mbschema: [66%, 5000MBps]
+          ## MBA (Memory Bandwidth Allocation) for 'Burstable'
+          ## 'all' may be omitted if no cache-id specific settings are required
+          #  mbschema: [66%, 5000MBps]
           BestEffort:
             l2schema: "60%"
             l3schema: "33%"
-## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-#            mbschema: [33%, 3000MBps]
-## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
-## resctrl group of the system
-#          SYSTEM_DEFAULT:
-#            l2schema: "60%"
-#            l3schema: "50%"
+          ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
+          #  mbschema: [33%, 3000MBps]
+        ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
+        ## resctrl group of the system
+        #  SYSTEM_DEFAULT:
+        #    l2schema: "60%"
+        #    l3schema: "50%"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -321,19 +321,19 @@ data:
           Guaranteed:
             l2schema: "100%"
             l3schema: "100%"
-## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
-## remove the "100%" shorthand above if enabling this
-## 'all' specificies the default value for all cache-ids
-#              all:
-#                unified: "100%"
-#                code: "100%"
-#                data: "80%"
-## Specify CacheId (typically corresponds to a CPU socket) specific setting
-#              1: "80%"
-## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
-#            mbschema:
-#              all: [100%]
-#              1-3: [80%, 10000MBps]
+            ## Specific settings for L3 CDP (Code and Data Prioritization). Note: need to
+            ## remove the "100%" shorthand above if enabling this
+            ## 'all' specificies the default value for all cache-ids
+            #  all:
+            #    unified: "100%"
+            #    code: "100%"
+            #    data: "80%"
+            ## Specify CacheId (typically corresponds to a CPU socket) specific setting
+            #  1: "80%"
+          ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
+          #  mbschema:
+          #    all: [100%]
+          #    1-3: [80%, 10000MBps]
           Burstable:
             l2schema: "66%"
             l3schema:
@@ -342,19 +342,19 @@ data:
                 # Separate schema for L3 code and data paths specified
                 code: "100%"
                 data: "50%"
-## MBA (Memory Bandwidth Allocation) for 'Burstable'
-## 'all' may be omitted if no cache-id specific settings are required
-#            mbschema: [66%, 5000MBps]
+          ## MBA (Memory Bandwidth Allocation) for 'Burstable'
+          ## 'all' may be omitted if no cache-id specific settings are required
+          #  mbschema: [66%, 5000MBps]
           BestEffort:
             l2schema: "60%"
             l3schema: "33%"
-## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-#            mbschema: [33%, 3000MBps]
-## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
-## resctrl group of the system
-#          SYSTEM_DEFAULT:
-#            l2schema: "60%"
-#            l3schema: "50%"
+          ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
+          #  mbschema: [33%, 3000MBps]
+        ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
+        ## resctrl group of the system
+        #  SYSTEM_DEFAULT:
+        #    l2schema: "60%"
+        #    l3schema: "50%"
   dump: |+
     Config: full:.*,short:.*Stop.*,off:.*List.*
     File: /tmp/cri-selective-debug.dump


### PR DESCRIPTION
Comments starting from the beginning of line inside the configmap data
broke the yaml format.