### PR TITLE
fixes: fixes for fedora 33

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -366,14 +366,15 @@ echo 'Defaults !requiretty' > /etc/sudoers.d/10-norequiretty
 setenforce 0
 sed -E -i 's/^SELINUX=.*$/SELINUX=permissive/' /etc/selinux/config
 
+echo PATH="\$PATH:/usr/local/bin:/usr/local/sbin" > /etc/profile.d/usr-local-path.sh
+
 if grep -q NAME=Fedora /etc/os-release; then
     if ! grep -q systemd.unified_cgroup_hierarchy=0 /proc/cmdline; then
-        sed -i -E 's/^kernelopts=(.*)/kernelopts=\1 systemd.unified_cgroup_hierarchy=0/' /boot/grub2/grubenv
+        sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
         shutdown -r now
     fi
 fi
 
-echo PATH="\$PATH:/usr/local/bin:/usr/local/sbin" > /etc/profile.d/usr-local-path.sh
 EOF
 }
 

--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -293,7 +293,7 @@ centos-install-golang() {
 }
 
 fedora-image-url() {
-    echo "https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2"
+    echo "https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2"
 }
 
 fedora-ssh-user() {


### PR DESCRIPTION
This PR switches the fedora cloud image to 33 and the corresponding bootstrap commands
to use grubby for switching systemd to a non-unified v1/v2 cgroupfs mount.

We expect fedora users to have switched by now now to the latest which is version 33.
Since that is glibc-incompatible with the previous ones, switching the cloud image
as well allows running on fedora 33 hosts e2e tests in fedora 33 VMs.