### PR TITLE
cache: add a directory to findContainerDir search path

### DIFF
--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -267,6 +267,7 @@ func findContainerDir(podCgroupDir, podID, ID string) string {
 	cpusetDir := cgroups.Cpuset.Path()
 
 	dirs = []string{
+		path.Join(cpusetDir, podCgroupDir, ID),
 		// containerd, systemd
 		path.Join(cpusetDir, podCgroupDir, "cri-containerd-"+ID+".scope"),
 		// containerd, cgroupfs


### PR DESCRIPTION
This change enables finding proper container cgroup directory with `container.GetCgroupDir()` on e2e/demo ubuntu/debian VMs.

The problem was found when trying to use future `blockio` from `goresctrl` like this:
```
blockio.SetContainerClass(c.GetCgroupDir(), class)
```
