### PR TITLE
blockio demo: always drop caches before measuring blockio speed

### DIFF
--- a/demo/blockio/run.sh
+++ b/demo/blockio/run.sh
@@ -105,6 +105,7 @@ screen-launch-cri-resmgr-agent() {
 screen-measure-io-speed() {
     process=$1
     measuretime=2
+    vm-command "echo 3 > /proc/sys/vm/drop_caches"
     out "### Measuring $process read speed -- twice."
     cmd="pid=\$(ps -A | awk \"/$process/{print \\\$1}\"); [ -n \"\$pid\" ] && { echo \$(grep read_bytes /proc/\$pid/io; sleep $measuretime; grep read_bytes /proc/\$pid/io) | awk \"{print \\\"$process read speed: \\\"(\\\$4-\\\$2)/$measuretime/1024\\\" kBps\\\"}\"; }"
     speed=360 outcolor=10 vm-command "$cmd"


### PR DESCRIPTION
When VM disk contents are small enough, md5sum scan may cause all data
to be cached before measuring md5sum I/O speed. That leads md5sum
process to exit/restart between measurements which prevents getting
reliable numbers.