### PR TITLE
blockio demo: fix detecting already installed cri-resmgr

### DIFF
--- a/demo/blockio/run.sh
+++ b/demo/blockio/run.sh
@@ -194,7 +194,7 @@ if ! vm-command-q "dpkg -l | grep -q kubelet"; then
     screen-install-k8s
 fi
 
-if ! vm-command-q "[ -f /usr/bin/cri-resmgr ]"; then
+if ! vm-command-q "[ -f /usr/bin/cri-resmgr ] || [ -f /usr/local/bin/cri-resmgr ]"; then
     screen-install-cri-resmgr
 fi
 


### PR DESCRIPTION
cri-resmgr that is installed from the source tree to a VM, is now
installed to /usr/local/bin. Fix detecting it from there, in addition
to /usr/bin.