### PR TITLE
e2e: add goresctrl debugging support to "run.sh debug"

### DIFF
--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -5,6 +5,9 @@ HOST_LIB_DIR="$(dirname "${BASH_SOURCE[0]}")"
 HOST_PROJECT_DIR="$(dirname "$(dirname "$(realpath "$HOST_LIB_DIR")")")"
 HOST_VM_IMAGE_DIR=~/vms/images
 HOST_VM_DATA_DIR_TEMPLATE="~/vms/data/\${VM_NAME}"
+if [ -z "$HOST_GORESCTRL_DIR" ]; then
+    HOST_GORESCTRL_DIR="$(realpath "$HOST_PROJECT_DIR/../goresctrl")"
+fi
 GOVM=${GOVM-govm}
 
 host-command() {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -147,8 +147,12 @@ screen-install-cri-resmgr-debugging() {
         command-error "installing delve failed"
     }
     host-command "cd \"$HOST_PROJECT_DIR/..\" && rsync -av --exclude .git $(basename "$HOST_PROJECT_DIR") $VM_SSH_USER@$VM_IP:"
+    host-command "cd \"$HOST_GORESCTRL_DIR/..\" && rsync -av --exclude .git $(basename "$HOST_GORESCTRL_DIR") $VM_SSH_USER@$VM_IP:"
     vm-command "mkdir -p \"\$HOME/.config/dlv\""
-    vm-command "( echo 'substitute-path:'; echo ' - {from: $HOST_PROJECT_DIR, to: /home/$VM_SSH_USER/$(basename "$HOST_PROJECT_DIR")}' ) > \"\$HOME/.config/dlv/config.yml\""
+    vm-command "( echo 'substitute-path:'
+                  echo ' - {from: $HOST_PROJECT_DIR, to: /home/$VM_SSH_USER/$(basename "$HOST_PROJECT_DIR")}'
+                  echo ' - {from: $HOST_GORESCTRL_DIR, to: /home/$VM_SSH_USER/$(basename "$HOST_GORESCTRL_DIR")}'
+                ) > \"\$HOME/.config/dlv/config.yml\""
 }
 
 screen-launch-cri-resmgr() {


### PR DESCRIPTION
This patch extends "vm=VMNAME test/e2e/run.sh debug" to
- Copy goresctrl sources to VMNAME.
- Add goresctrl source directory substitution on VM so that dlv will
  find the sources.