### PR TITLE
e2e: lib: Use proper locale for bc to work

### DIFF
--- a/demo/lib/command.bash
+++ b/demo/lib/command.bash
@@ -10,6 +10,8 @@
 # command-start and command-end set environment variables:
 # COMMAND, COMMAND_STATUS, COMMAND_OUTPUT
 
+export LC_NUMERIC=C
+
 # These exports force ssh-* to fail instead of prompting for a passphrase.
 export DISPLAY=bogus-none
 export SSH_ASKPASS=/bin/false


### PR DESCRIPTION
The current time returned by bash variable EPOCHREALTIME can contain
either "." or "," separator between seconds and microseconds (depending
on used locale), and because that value is feed directly to bc, then it
is possible that bc command will not understand the value and can return
"(standard_in) 1: syntax error"
if the current locale uses "," separator.
    
In order to fix this issue, set LC_NUMERIC=C so that bash uses always "."
when feeding the data to bc command.
