### PR TITLE
e2e: fix error message after installing golang from tar

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -616,9 +616,9 @@ default-restart-containerd() {
 from-tarball-install-golang() {
     vm-command-q "go version | grep -q go$GOLANG_VERSION" || {
         vm-command "wget --progress=dot:giga $GOLANG_URL -O go.tgz" && \
-            vm-command "tar -C /usr/local -xvzf go.tgz && rm go.tgz" && \
-            vm-command "echo \"PATH=/usr/local/go/bin:\$PATH\" > /etc/profile.d/go.sh" && \
-            vm-command "* installed \$(go version)"
+            vm-command "tar -C /usr/local -xvzf go.tgz >/dev/null && rm go.tgz" && \
+            vm-command "echo 'PATH=/usr/local/go/bin:\$PATH' > /etc/profile.d/go.sh" && \
+            vm-command "echo \* installed \$(go version)"
     }
 }
 


### PR DESCRIPTION
Asterisk was expanded by the shell in the vm.