### PR TITLE
e2e: support annotations in common pod templates

### DIFF
--- a/test/e2e/besteffort.yaml.in
+++ b/test/e2e/besteffort.yaml.in
@@ -4,6 +4,15 @@ metadata:
   name: ${NAME}
   labels:
     app: ${NAME}
+    $(for lbl in ${!LABEL*}; do [[ "$lbl" == LABEL[0-9]* ]] && echo "
+    ${!lbl}
+    "; done)
+  $([ -n "${!ANN*}" ] && echo "
+  annotations:
+    $(for ann in ${!ANN*}; do [[ "$ann" == ANN[0-9]* ]] && echo "
+    ${!ann}
+    "; done)
+  ")
 spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "

--- a/test/e2e/burstable.yaml.in
+++ b/test/e2e/burstable.yaml.in
@@ -4,6 +4,15 @@ metadata:
   name: ${NAME}
   labels:
     app: ${NAME}
+    $(for lbl in ${!LABEL*}; do [[ "$lbl" == LABEL[0-9]* ]] && echo "
+    ${!lbl}
+    "; done)
+  $([ -n "${!ANN*}" ] && echo "
+  annotations:
+    $(for ann in ${!ANN*}; do [[ "$ann" == ANN[0-9]* ]] && echo "
+    ${!ann}
+    "; done)
+  ")
 spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "

--- a/test/e2e/guaranteed.yaml.in
+++ b/test/e2e/guaranteed.yaml.in
@@ -4,6 +4,15 @@ metadata:
   name: ${NAME}
   labels:
     app: ${NAME}
+    $(for lbl in ${!LABEL*}; do [[ "$lbl" == LABEL[0-9]* ]] && echo "
+    ${!lbl}
+    "; done)
+  $([ -n "${!ANN*}" ] && echo "
+  annotations:
+    $(for ann in ${!ANN*}; do [[ "$ann" == ANN[0-9]* ]] && echo "
+    ${!ann}
+    "; done)
+  ")
 spec:
   containers:
   $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "


### PR DESCRIPTION
Annotations can be added to besteffort, burstable and guaranteed pods
through ANN[0-9] environment variables. Example:
CPU=500m MEM=64M ANN0='my.key: "myvalue"' create guaranteed