### PR TITLE
e2e: change e2e test framework title

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_TITLE="CRI Resource Manager: End-to-End Testing"
+DEMO_TITLE="Container Runtime End-to-End Testing"
 DEFAULT_DISTRO="ubuntu-20.04"
 
 PV='pv -qL'


### PR DESCRIPTION
This framework is not anymore only about CRI Resource Manager. This
is also about testing CRI Resource Manager features included in
container runtimes.