### PR TITLE
e2e: allow templating in test suite variable files

### DIFF
--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -46,7 +46,11 @@ $(< "$var_filepath")"
             else
                 echo "exporting $var_name - overriding from $var_filepath"
             fi
-            export "$var_name"="$(< "$var_filepath")"
+            if [[ "$var_file_name" == *.var.in.* ]]; then
+                export "$var_name"="$(eval "echo -e \"$(<"${var_filepath}")\"")"
+            else
+                export "$var_name"="$(< "$var_filepath")"
+            fi
         fi
     done
 }


### PR DESCRIPTION
Test suite directories contain files varname.var* from which
environment variables are created for run.sh. This extension enables
using framework's common templating in variables when the file is
named "varname.var.in.*". Templating allows, for instance, expanding
environment values and giving default values when user has not
explicitly given them. As an example of both cases:
containerd_src.var.in.sh (sets containerd_src variable) contains
${containerd_src:-$GOPATH/src/github.com/containerd/containerd}