### PR TITLE
e2e: support CRI-O, containerd, and containerd + cri-resmgr as NRI

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -115,16 +115,16 @@ vm-check-env() {
     fi
 }
 
-vm-check-binary-cri-resmgr() {
-    # Check running cri-resmgr version, print warning if it is not
-    # the latest local build.
-    # shellcheck disable=SC2016
-    if [ -f "$BIN_DIR/cri-resmgr" ] && [ "$(vm-command-q 'md5sum < /proc/$(pidof cri-resmgr)/exe')" != "$(md5sum < "$BIN_DIR/cri-resmgr")" ]; then
+vm-check-running-binary() {
+    local bin_file="$1"
+    local bin_name
+    bin_name="$(basename "$bin_file")"
+    pid_of_bin="$(vm-command-q "pidof $bin_name")"
+    if [ -f "$bin_file" ] && [ -n "$pid_of_bin" ] && [ "$(vm-command-q "md5sum < /proc/$pid_of_bin/exe")" != "$(md5sum < "$bin_file")" ]; then
         echo "WARNING:"
-        echo "WARNING: Running cri-resmgr binary is different from"
-        echo "WARNING: $BIN_DIR/cri-resmgr"
-        echo "WARNING: Consider restarting with \"reinstall_cri_resmgr=1\" or"
-        echo "WARNING: run.sh> uninstall cri-resmgr; install cri-resmgr; launch cri-resmgr"
+        echo "WARNING: Running $bin_name binary is different from"
+        echo "WARNING: $bin_file"
+        echo "WARNING: Consider restarting with reinstall_${bin_name//-/_}=1."
         echo "WARNING:"
         sleep "${warning_delay:-0}"
         return 1
@@ -480,17 +480,6 @@ vm-install-cri-resmgr() {
         }
         vm-command "systemctl daemon-reload"
     elif [ -z "$binsrc" ] || [ "$binsrc" == "local" ]; then
-        local bin_change
-        local src_change
-        bin_change=$(stat --format "%Z" "$BIN_DIR/cri-resmgr")
-        src_change=$(find "$HOST_PROJECT_DIR" -name '*.go' -type f -print0 | xargs -0 stat --format "%Z" | sort -n | tail -n 1)
-        if [[ "$src_change" > "$bin_change" ]]; then
-            echo "WARNING:"
-            echo "WARNING: Source files changed - installing possibly outdated binaries from"
-            echo "WARNING: $BIN_DIR/"
-            echo "WARNING:"
-            sleep "${warning_delay:-0}"
-        fi
         vm-put-file "$BIN_DIR/cri-resmgr" "$prefix/bin/cri-resmgr"
         vm-put-file "$BIN_DIR/cri-resmgr-agent" "$prefix/bin/cri-resmgr-agent"
     else
@@ -610,6 +599,24 @@ vm-install-golang() {
 vm-install-cri() {
     distro-install-"$VM_CRI"
     distro-config-"$VM_CRI"
+    if [ "$VM_CRI" == "containerd" ]; then
+        if [ -n "$containerd_src" ]; then
+            vm-command "systemctl stop containerd"
+            for f in ctr containerd containerd-stress containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
+                vm-put-file "$containerd_src/bin/$f" "/usr/bin/$f"
+            done
+            vm-command "systemctl start containerd"
+        fi
+    elif [ "$VM_CRI" == "crio" ]; then
+        if [ -n "$crio_src" ]; then
+            vm-command "systemctl stop crio"
+            for f in crio crio-status pinns; do
+                vm-put-file "$crio_src/bin/$f" "/usr/bin/$f"
+            done
+            vm-command "systemctl enable crio"
+            vm-command "systemctl start crio"
+        fi
+    fi
 }
 
 vm-install-containernetworking() {
@@ -671,7 +678,7 @@ vm-create-singlenode-cluster() {
 }
 
 vm-create-cluster() {
-    vm-command "kubeadm init --pod-network-cidr=$CNI_SUBNET --cri-socket /var/run/cri-resmgr/cri-resmgr.sock"
+    vm-command "kubeadm init --pod-network-cidr=$CNI_SUBNET --cri-socket ${k8scri_sock}"
     if ! grep -q "initialized successfully" <<< "$COMMAND_OUTPUT"; then
         command-error "kubeadm init failed"
     fi

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -184,9 +184,30 @@ for POLICY_DIR in "$TESTS_ROOT_DIR"/*; do
             (
                 distro=${distro:=$DEFAULT_DISTRO}
                 export distro
-                cri=${cri:=containerd}
-                export cri
-                vm="$(basename "$TOPOLOGY_DIR")-${distro}-${cri}"
+                # Create name for the vm.
+                # Needs topology, distro and container runtime stack.
+                k8scri=${k8scri:-"cri-resmgr|containerd"}
+                case "${k8scri}" in
+                    "cri-resmgr|containerd")
+                        criname=crirm-containerd
+                        ;;
+                    "cri-resmgr|crio")
+                        criname=crirm-crio
+                        ;;
+                    "containerd&cri-resmgr")
+                        criname=nrirm-containerd
+                        ;;
+                    "containerd")
+                        criname=containerd
+                        ;;
+                    "crio")
+                        criname=crio
+                        ;;
+                    *)
+                        error "unsupported k8scri: \"${k8scri}\""
+                        ;;
+                esac
+                vm="$(basename "$TOPOLOGY_DIR")-${distro}-${criname}"
                 export vm
                 export-and-source-dir "$TOPOLOGY_DIR"
                 for TEST_DIR in "$TOPOLOGY_DIR"/*; do


### PR DESCRIPTION
- Install locally built crio, containerd, runc, and cri-resmgr from
  explictly given source directories (<project>_src variables).
- "run.sh debug" installs sources from <project>_src directories.
- Add k8scri to specify the CRI pipe that run.sh sets up on vm.
- Add on_k8s_online to hook when Kubernetes is running on vm.

**Note**: PRs up to 681 include features required by this change.