### PR TITLE
e2e: clean up vm after successful reserved-resources test run

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
@@ -5,6 +5,8 @@
 
 AVAILABLE_CPU="cpuset:4-7,8-13"
 
+cri_resmgr_cfg_orig=$cri_resmgr_cfg
+
 # This script will create pods to the kube-system namespace
 # that is not automatically cleaned up by the framework.
 # Make sure the namespace is clear when starting the test and clean it up
@@ -94,3 +96,7 @@ namespace=kube-system CPU=2 CONTCOUNT=1 create besteffort
 verify "cpus['pod0c0'] == {'cpu04', 'cpu05', 'cpu06'}"
 
 kubectl delete -n kube-system pods/pod0
+
+terminate cri-resmgr
+cri_resmgr_cfg=$cri_resmgr_cfg_orig
+launch cri-resmgr


### PR DESCRIPTION
The reserved resources test left the vm in a configuration that was
likely to cause failures on tests executed after it. This fix restores
the configuration when this test passes. Leave configuration as is on
failure to help debugging.