### PR TITLE
e2e: improve isolcpus test robustness

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
@@ -6,7 +6,9 @@ vm-command "grep isolcpus=8,9 /proc/cmdline" || {
     }
     launch cri-resmgr
     vm-command "systemctl restart kubelet"
+    sleep 1
     vm-wait-process --timeout 120 kube-apiserver
+    vm-run-until --timeout 120 "kubectl get node"
 }
 
 CONTCOUNT=1


### PR DESCRIPTION
Sometimes vm needs more time to get kubelet up and running after
restart.