### PR TITLE
e2e: add support for distro=sles

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -632,6 +632,18 @@ vm-install-pkg() {
     distro-install-pkg "$@"
 }
 
+vm-setup-oneshot() {
+    local util
+    distro-refresh-pkg-db
+    distro-install-utils
+    # Verify that all required utilities exit on the VM.
+    for util in pidof killall; do
+        vm-command-q "command -v $util >/dev/null" || {
+            error "required command '$util' missing on VM, fix/implement $distro-install-utils()"
+        }
+    done
+}
+
 vm-install-golang() {
     distro-install-golang
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1161,6 +1161,11 @@ fi
 
 is-hooked "on_vm_online" && run-hook "on_vm_online"
 
+if [ "$reinstall_oneshot" == "1" ] || ! vm-command-q "[ -f .vm-setup-oneshot ]"; then
+    vm-setup-oneshot
+    vm-command-q "touch .vm-setup-oneshot"
+fi
+
 if [ -n "$vm_files" ]; then
     install-files "$vm_files"
 fi


### PR DESCRIPTION
Fixes AWS SLES VM support as required in issue #686.

Also enables running SLES on local VMs if the user has downloaded SLES cloud image (requires registration).