### PR TITLE
e2e: enable reinstalling pretty much everything on VMs

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -145,7 +145,6 @@ vm-check-running-binary() {
     return 0
 }
 
-
 vm-check-source-files-changed() {
     local bin_change
     local src_change
@@ -634,7 +633,7 @@ vm-install-pkg() {
 
 vm-setup-oneshot() {
     local util
-    distro-refresh-pkg-db
+    ( distro-refresh-pkg-db ) || true
     distro-install-utils
     # Verify that all required utilities exit on the VM.
     for util in pidof killall; do
@@ -660,7 +659,7 @@ vm-install-runc() {
         fi
         vm-put-file "$host_runc" "$vm_runc"
     else
-        distro-install-pkg runc
+        distro-install-runc
     fi
 }
 
@@ -780,8 +779,12 @@ vm-create-cluster() {
     vm-command "cp /etc/kubernetes/admin.conf ~root/.kube/config"
 }
 
+vm-destroy-cluster() {
+    vm-command "yes | kubeadm reset; rm -f \$HOME/.kube/config ~root/.kube/config /etc/kubernetes"
+}
+
 vm-install-cni-cilium() {
-    vm-command "kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.8/install/kubernetes/quick-install.yaml"
+    vm-command "kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.9/install/kubernetes/quick-install.yaml"
     if ! vm-command "kubectl rollout status --timeout=360s -n kube-system daemonsets/cilium"; then
         command-error "installing cilium CNI to Kubernetes timed out"
     fi

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -632,6 +632,18 @@ vm-install-pkg() {
     distro-install-pkg "$@"
 }
 
+vm-setup-oneshot() {
+    local util
+    distro-refresh-pkg-db
+    distro-install-utils
+    # Verify that all required utilities exit on the VM.
+    for util in pidof killall; do
+        vm-command-q "command -v $util >/dev/null" || {
+            error "required command '$util' missing on VM, fix/implement $distro-install-utils()"
+        }
+    done
+}
+
 vm-install-golang() {
     distro-install-golang
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1161,6 +1161,11 @@ fi
 
 is-hooked "on_vm_online" && run-hook "on_vm_online"
 
+if [ "$reinstall_oneshot" == "1" ] || ! vm-command-q "[ -f .vm-setup-oneshot ]"; then
+    vm-setup-oneshot
+    vm-command-q "touch .vm-setup-oneshot"
+fi
+
 if [ -n "$vm_files" ]; then
     install-files "$vm_files"
 fi


### PR DESCRIPTION
- If a reinstall variable is set for any package, it will be forced to reinstall on the system.
- OpenSUSE / SLES install runc from Virtualization_containers.
- Reinstalling k8s means scrapping and recreating the cluster on VM -- in addition to reinstalling kubeadm, kubectl and kubelet.
- Refactor: get rid of screen-install-k8s.

Implemented on top of #688.

Implements suggested reinstall feature in issue #686 .