### PR TITLE
scripts: add CRI-O support to kube-cgroups

### DIFF
--- a/scripts/testing/kube-cgroups
+++ b/scripts/testing/kube-cgroups
@@ -100,6 +100,9 @@ kubectl get pods -A | grep -E "$pod_regexp" | while read -r namespace podname re
         grep -q -E "$cntr_regexp" <<< "$containername" || continue
 
         while read -r cgroupdir; do
+            if [[ "$cgroupdir" == *crio-conmon* ]]; then
+                continue
+            fi
             for filename in "$cgroupdir"/*; do
                 if [[ ! -f "$filename" ]]; then
                     continue
@@ -132,6 +135,6 @@ kubectl get pods -A | grep -E "$pod_regexp" | while read -r namespace podname re
                     sed "s/^/      /g" < "$filename"
                 fi
             done
-        done <<< "$(find "$cg_controller_dir" -name "$containerID")"
+        done <<< "$(find "$cg_controller_dir" -name "*${containerID}*")"
     done
 done


### PR DESCRIPTION
kube-cgroups prints pods/containers with their cgroups configuration.
Before this change it found the configurations only for containers
managed by containerd. This change makes it work similarly with CRI-O
containers, too.

This change is needed for running
test/e2e$ k8scri=crio ./run_tests.sh blockio.test-suite