### PR TITLE
e2e: allow installing cri-o from distro repos.

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -303,6 +303,15 @@ centos-7-install-containerd-pre() {
     distro-install-repo https://download.docker.com/linux/centos/docker-ce.repo
 }
 
+centos-8-install-crio-pre() {
+    if [ -z "$crio_src" ]; then
+        local os=CentOS_8
+        local version=${crio_version:-1.20}
+        vm-command "curl -L -o /etc/yum.repos.d/libcontainers-stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$os/devel:kubic:libcontainers:stable.repo"
+        vm-command "curl -L -o /etc/yum.repos.d/crio.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$version/$os/devel:kubic:libcontainers:stable:cri-o:$version.repo"
+    fi
+}
+
 centos-8-install-containerd-pre() {
     distro-install-repo https://download.docker.com/linux/centos/docker-ce.repo
 }
@@ -371,6 +380,18 @@ fedora-install-golang() {
 fedora-install-crio-pre() {
     distro-install-pkg runc conmon
     vm-command "ln -sf /usr/lib64/libdevmapper.so.1.02 /usr/lib64/libdevmapper.so.1.02.1" || true
+
+    if [ -z "$crio_src" ]; then
+        vm-command "dnf -y module enable cri-o:${crio_version:-1.20}"
+    fi
+}
+
+fedora-install-crio() {
+    if [ -n "$crio_src" ]; then
+        default-install-crio
+    else
+        distro-install-pkg cri-o
+    fi
 }
 
 fedora-install-containerd-pre() {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -48,7 +48,8 @@ usage() {
     echo "    crio_src:"
     echo "             \"/host/path/to/go/project\": replace vm /usr/bin binaries"
     echo "             from /host/path/to/go/project/bin directory."
-    echo "             Must be set if crio is a part of \$k8scri."
+    echo "             Must be set if crio is a part of \$k8scri and the vm distro"
+    echo "             does not have (or implement installing) cri-o packages."
     echo "    crirm_src:"
     echo "             \"/host/path/to/go/project\": replace vm /usr/local/bin binaries"
     echo "             from /host/path/to/go/project/bin directory."
@@ -106,6 +107,8 @@ usage() {
     echo "             \"containerd\"            containerd, no cri-resmgr."
     echo "             \"crio\"                  cri-o, no cri-resmgr."
     echo "             The default is \"cri-resmgr|containerd\"."
+    echo "    crio_version: Version of cri-o to try to pull in, if cri-o is"
+    echo "                  not being installed from sources."
     echo ""
     echo "  Test input VARs:"
     echo "    cri_resmgr_cfg: configuration file forced to cri-resmgr."
@@ -1020,6 +1023,7 @@ containerd_src=${containerd_src:=}
 crio_src=${crio_src:=}
 crirm_src=${crirm_src:=$HOST_PROJECT_DIR}
 runc_src=${runc_src:=}
+crio_version=${crio_version:=}
 BIN_DIR=${crirm_src}/bin
 TOPOLOGY_DIR=${TOPOLOGY_DIR:=e2e}
 vm=${vm:=$(basename ${TOPOLOGY_DIR})-${distro}-${cri}}


### PR DESCRIPTION
Don't insist installing cri-o from sources. Add support for
installing cri-o from distro repos for Fedora and CentOS-8.