### PR TITLE
e2e: support running tests with CRI-O and cri-resmgr in NRI mode

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -103,9 +103,10 @@ usage() {
     echo "             Options are:"
     echo "             \"cri-resmgr|containerd\" cri-resmgr is a proxy to containerd."
     echo "             \"cri-resmgr|crio\"       cri-resmgr is a proxy to cri-o."
-    echo "             \"containerd&cri-resmgr\" containerd, cri-resmgr is an NRI plugin."
     echo "             \"containerd\"            containerd, no cri-resmgr."
+    echo "             \"containerd&cri-resmgr\" containerd, cri-resmgr is an NRI plugin."
     echo "             \"crio\"                  cri-o, no cri-resmgr."
+    echo "             \"crio&cri-resmgr\"       cri-o, cri-resmgr is an NRI plugin."
     echo "             The default is \"cri-resmgr|containerd\"."
     echo "    crio_version: Version of cri-o to try to pull in, if cri-o is"
     echo "                  not being installed from sources."
@@ -996,11 +997,6 @@ case "${k8scri}" in
         cri_sock="/var/run/crio/crio.sock"
         cri=crio
         ;;
-    "containerd&cri-resmgr")
-        k8scri_sock="/var/run/containerd/containerd.sock"
-        cri_sock="/var/run/containerd/containerd.sock"
-        cri=containerd
-        ;;
     "containerd")
         k8scri_sock="/var/run/containerd/containerd.sock"
         cri_sock="/var/run/containerd/containerd.sock"
@@ -1008,12 +1004,22 @@ case "${k8scri}" in
         omit_cri_resmgr=1
         omit_agent=1
         ;;
+    "containerd&cri-resmgr")
+        k8scri_sock="/var/run/containerd/containerd.sock"
+        cri_sock="/var/run/containerd/containerd.sock"
+        cri=containerd
+        ;;
     "crio")
         k8scri_sock="/var/run/crio/crio.sock"
         cri_sock="/var/run/crio/crio.sock"
         cri=crio
         omit_cri_resmgr=1
         omit_agent=1
+        ;;
+    "crio&cri-resmgr")
+        k8scri_sock="/var/run/crio/crio.sock"
+        cri_sock="/var/run/crio/crio.sock"
+        cri=crio
         ;;
     *)
         error "unsupported k8scri: \"${k8scri}\""

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -198,14 +198,17 @@ for POLICY_DIR in "$TESTS_ROOT_DIR"/*; do
                     "cri-resmgr|crio")
                         criname=crirm-crio
                         ;;
-                    "containerd&cri-resmgr")
-                        criname=nrirm-containerd
-                        ;;
                     "containerd")
                         criname=containerd
                         ;;
+                    "containerd&cri-resmgr")
+                        criname=nrirm-containerd
+                        ;;
                     "crio")
                         criname=crio
+                        ;;
+                    "crio&cri-resmgr")
+                        criname=nrirm-crio
                         ;;
                     *)
                         error "unsupported k8scri: \"${k8scri}\""


### PR DESCRIPTION
Add support for k8scri='crio&cri-resmgr'. In this CRI pipe kubelet
will connect to CRI-O, and cri-resmgr runs as an NRI plugin.

Example:
crio_src=/path/to/CRI-O-with-NRI-support \
crirm_src=/path/to/cri-resource-manager-with-NRI-support \
k8scri='crio&cri-resmgr' \
./run_tests.sh policies.test-suite/topology-aware