### PR TITLE
Monitor the pool CPU usage for podpools-policy.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -103,6 +104,21 @@ func (n *none) ExportResourceData(c cache.Container) map[string]string {
 // Introspect provides data for external introspection.
 func (n *none) Introspect(*introspect.State) {
 	return
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *none) PollMetrics() policy.Metrics {
+	return nil
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *none) DescribeMetrics() []*prometheus.Desc {
+	return nil
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *none) CollectMetrics(policy.Metrics) ([]prometheus.Metric, error) {
+	return nil, nil
 }
 
 // Register us as a policy implementation.

--- a/pkg/cri/resource-manager/policy/builtin/podpools/metrics.go
+++ b/pkg/cri/resource-manager/policy/builtin/podpools/metrics.go
@@ -1,0 +1,240 @@
+// Copyright 2020-2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podpools
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	"github.com/intel/cri-resource-manager/pkg/procstats"
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+// Metrics defines the podpools-specific metrics from policy level.
+type Metrics struct {
+	PoolMetrics map[string]*PoolMetrics
+}
+
+// PoolMetrics defines the podpools-specific metrics from pool level.
+type PoolMetrics struct {
+	DefName        string
+	PrettyName     string
+	CPUs           cpuset.CPUSet
+	CPUIds         []int
+	MilliCPUs      string
+	Memory         string
+	ContainerNames string
+	PodNames       string
+}
+
+// Prometheus Metric descriptor indices and descriptor table
+const (
+	cpuUsageDesc = iota
+	poolCPUUsageDesc
+)
+
+var descriptors = []*prometheus.Desc{
+	cpuUsageDesc: prometheus.NewDesc(
+		"cpu_usage",
+		"CPU usage per logical processor",
+		[]string{
+			"cpu",
+		}, nil,
+	),
+	poolCPUUsageDesc: prometheus.NewDesc(
+		"pool_cpu_usage",
+		"CPU usage for a given pool",
+		[]string{
+			"policy",
+			"pretty_name",
+			"def_name",
+			"CPUs",
+			"memory",
+			"pool_size",
+			"pod_name",
+			"container_name",
+		}, nil,
+	),
+}
+
+var cpuTimeStat *procstats.CPUTimeStat
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *podpools) DescribeMetrics() []*prometheus.Desc {
+	return descriptors
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *podpools) PollMetrics() policy.Metrics {
+	if p.pools == nil || len(p.pools) <= 0 {
+		log.Error("Failed to pull metrics.")
+		return nil
+	}
+	policyMetrics := &Metrics{}
+	policyMetrics.PoolMetrics = make(map[string]*PoolMetrics, len(p.pools))
+
+	for _, pool := range p.pools {
+		policyMetrics.PoolMetrics[pool.PrettyName()] = &PoolMetrics{}
+		policyMetrics.PoolMetrics[pool.PrettyName()].DefName = pool.Def.Name
+		policyMetrics.PoolMetrics[pool.PrettyName()].PrettyName = pool.PrettyName()
+		policyMetrics.PoolMetrics[pool.PrettyName()].CPUs = pool.CPUs
+		policyMetrics.PoolMetrics[pool.PrettyName()].CPUIds = pool.CPUs.ToSlice()
+		policyMetrics.PoolMetrics[pool.PrettyName()].MilliCPUs = strconv.Itoa(pool.CPUs.Size() * 1000)
+		policyMetrics.PoolMetrics[pool.PrettyName()].Memory = pool.Mems.String()
+		policyMetrics.PoolMetrics[pool.PrettyName()].ContainerNames = ""
+		policyMetrics.PoolMetrics[pool.PrettyName()].PodNames = ""
+		if len(pool.PodIDs) > 0 {
+			podIds := make([]string, 0, len(pool.PodIDs))
+			for podId := range pool.PodIDs {
+				podIds = append(podIds, podId)
+			}
+			sort.Sort(sort.StringSlice(podIds))
+			for _, podId := range podIds {
+				for _, containerId := range pool.PodIDs[podId] {
+					if container, ok := p.cch.LookupContainer(containerId); ok {
+						containerName := container.PrettyName()
+						if policyMetrics.PoolMetrics[pool.PrettyName()].ContainerNames == "" {
+							policyMetrics.PoolMetrics[pool.PrettyName()].ContainerNames = containerName
+						} else {
+							policyMetrics.PoolMetrics[pool.PrettyName()].ContainerNames = fmt.Sprintf("%s,%s", policyMetrics.PoolMetrics[pool.PrettyName()].ContainerNames, containerName)
+						}
+					}
+				}
+				if pod, ok := p.cch.LookupPod(podId); ok {
+					podName := pod.GetName()
+					if policyMetrics.PoolMetrics[pool.PrettyName()].PodNames == "" {
+						policyMetrics.PoolMetrics[pool.PrettyName()].PodNames = podName
+					} else {
+						policyMetrics.PoolMetrics[pool.PrettyName()].PodNames = fmt.Sprintf("%s,%s", policyMetrics.PoolMetrics[pool.PrettyName()].PodNames, podName)
+					}
+				}
+			}
+		}
+	}
+	return policyMetrics
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *podpools) CollectMetrics(m policy.Metrics) ([]prometheus.Metric, error) {
+	metrics, ok := m.(*Metrics)
+	if !ok {
+		return nil, fmt.Errorf("Wrong podpools metrics.")
+	}
+	if cpuTimeStat == nil {
+		if initSys, err := sysfs.DiscoverSystem(); err != nil {
+			return nil, err
+		} else {
+			cpuCount := len(initSys.CPUIDs())
+			cpuTimeStat = &procstats.CPUTimeStat{
+				PrevIdleTime:       make([]uint64, cpuCount),
+				PrevTotalTime:      make([]uint64, cpuCount),
+				CurIdleTime:        make([]uint64, cpuCount),
+				CurTotalTime:       make([]uint64, cpuCount),
+				DeltaIdleTime:      make([]uint64, cpuCount),
+				DeltaTotalTime:     make([]uint64, cpuCount),
+				CPUUsage:           make([]float64, cpuCount),
+				IsGetCPUUsageBegin: false,
+			}
+		}
+	}
+	err := cpuTimeStat.GetCPUTimeStat()
+	if err != nil {
+		return nil, err
+	}
+	cpuMetrics, err := updateCPUUsageMetrics()
+	if err != nil {
+		return nil, err
+	}
+	poolCPUMetrics, err := updatePoolCPUUsageMetrics(metrics)
+	if err != nil {
+		return nil, err
+	}
+	return append(cpuMetrics, poolCPUMetrics...), nil
+}
+
+// updateCPUUsageMetrics collects the CPU usage per logical processor.
+func updateCPUUsageMetrics() ([]prometheus.Metric, error) {
+	cpuTimeStat.RLock()
+	defer cpuTimeStat.RUnlock()
+	sys, err := sysfs.DiscoverSystem()
+	if err != nil {
+		return nil, err
+	}
+	onlined := sys.CPUSet().Difference(sys.Offlined())
+	onlinedUsage := make([]prometheus.Metric, onlined.Size())
+	for i, j := range onlined.ToSlice() {
+		onlinedUsage[i] = prometheus.MustNewConstMetric(
+			descriptors[cpuUsageDesc],
+			prometheus.GaugeValue,
+			cpuTimeStat.CPUUsage[j],
+			strconv.Itoa(j),
+		)
+	}
+	return onlinedUsage, nil
+}
+
+// updatePoolCPUUsageMetrics collects the CPU usage of pools defined by podpools-policy.
+func updatePoolCPUUsageMetrics(ppm *Metrics) ([]prometheus.Metric, error) {
+	if ppm == nil {
+		return nil, fmt.Errorf("Podpools metrics used to count pool CPU usage is missing.")
+	}
+	// Sort the pool metrics.
+	poolNames := make([]string, 0, len(ppm.PoolMetrics))
+	for poolName := range ppm.PoolMetrics {
+		poolNames = append(poolNames, poolName)
+	}
+	sort.Sort(sort.StringSlice(poolNames))
+
+	// Calculate the CPU usage of a pool and send to prometheus.
+	poolCPUUsageMetrics := make([]prometheus.Metric, len(poolNames))
+	poolCPUUsageList := make(map[string]float64, len(poolNames))
+	cpuTimeStat.RLock()
+	defer cpuTimeStat.RUnlock()
+	for index, poolName := range poolNames {
+		poolDeltaIdleTime := uint64(0)
+		poolDeltaTotalTime := uint64(0)
+		for _, cpuId := range ppm.PoolMetrics[poolName].CPUIds {
+			poolDeltaIdleTime += cpuTimeStat.DeltaIdleTime[cpuId]
+			poolDeltaTotalTime += cpuTimeStat.DeltaTotalTime[cpuId]
+		}
+		poolCPUUsageList[poolName] = 0.0
+		if poolDeltaTotalTime != 0 {
+			sys, err := sysfs.DiscoverSystem()
+			if err != nil {
+				return nil, err
+			}
+			poolCPUOnlined := ppm.PoolMetrics[poolName].CPUs.Difference(sys.Offlined())
+			poolCPUUsageList[poolName] = (1.0 - float64(poolDeltaIdleTime)/float64(poolDeltaTotalTime)) * 100.0 * float64(len(poolCPUOnlined.ToSlice()))
+		}
+		poolCPUUsageMetrics[index] = prometheus.MustNewConstMetric(
+			descriptors[poolCPUUsageDesc],
+			prometheus.GaugeValue,
+			poolCPUUsageList[poolName],
+			PolicyName,
+			poolName,
+			ppm.PoolMetrics[poolName].DefName,
+			ppm.PoolMetrics[poolName].CPUs.String(),
+			ppm.PoolMetrics[poolName].Memory,
+			ppm.PoolMetrics[poolName].MilliCPUs,
+			ppm.PoolMetrics[poolName].PodNames,
+			ppm.PoolMetrics[poolName].ContainerNames,
+		)
+	}
+	return poolCPUUsageMetrics, nil
+}

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
@@ -212,6 +213,21 @@ func (p *staticplus) ExportResourceData(c cache.Container) map[string]string {
 // Introspect provides data for external introspection.
 func (p *staticplus) Introspect(*introspect.State) {
 	return
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *staticplus) DescribeMetrics() []*prometheus.Desc {
+	return nil
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *staticplus) PollMetrics() policy.Metrics {
+	return nil
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *staticplus) CollectMetrics(policy.Metrics) ([]prometheus.Metric, error) {
+	return nil, nil
 }
 
 // policyError creates a formatted policy-specific error.

--- a/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/stp-policy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -249,6 +250,21 @@ func (stp *stp) ExportResourceData(c cache.Container) map[string]string {
 // Introspect provides data for external introspection.
 func (stp *stp) Introspect(*introspect.State) {
 	return
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *stp) DescribeMetrics() []*prometheus.Desc {
+	return nil
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *stp) PollMetrics() policy.Metrics {
+	return nil
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *stp) CollectMetrics(policy.Metrics) ([]prometheus.Metric, error) {
+	return nil, nil
 }
 
 func (stp *stp) configNotify(event pkgcfg.Event, source pkgcfg.Source) error {

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/config"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
@@ -200,6 +201,21 @@ func (s *static) ExportResourceData(c cache.Container) map[string]string {
 // Introspect provides data for external introspection.
 func (s *static) Introspect(*introspect.State) {
 	return
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *static) DescribeMetrics() []*prometheus.Desc {
+	return nil
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *static) PollMetrics() policy.Metrics {
+	return nil
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *static) CollectMetrics(policy.Metrics) ([]prometheus.Metric, error) {
+	return nil, nil
 }
 
 func (s *static) configNotify(event config.Event, source config.Source) error {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
@@ -284,6 +285,21 @@ func (p *policy) Introspect(state *introspect.State) {
 		assignments[a.ContainerID] = a
 	}
 	state.Assignments = assignments
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *policy) DescribeMetrics() []*prometheus.Desc {
+	return nil
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *policy) PollMetrics() policyapi.Metrics {
+	return nil
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *policy) CollectMetrics(policyapi.Metrics) ([]prometheus.Metric, error) {
+	return nil, nil
 }
 
 // ExportResourceData provides resource data to export for the container.

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -31,6 +31,8 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/rdt"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
+	"github.com/prometheus/client_golang/prometheus"
+
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
 )
@@ -127,6 +129,12 @@ type Backend interface {
 	ExportResourceData(cache.Container) map[string]string
 	// Introspect provides data for external introspection.
 	Introspect(*introspect.State)
+	// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+	DescribeMetrics() []*prometheus.Desc
+	// PollMetrics provides policy metrics for monitoring.
+	PollMetrics() Metrics
+	// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+	CollectMetrics(Metrics) ([]prometheus.Metric, error)
 }
 
 // Policy is the exposed interface for container resource allocations decision making.
@@ -135,7 +143,7 @@ type Policy interface {
 	Start([]cache.Container, []cache.Container) error
 	// Sync synchronizes the state of the active policy.
 	Sync([]cache.Container, []cache.Container) error
-	// AlocateResources allocates resources to a container.
+	// AllocateResources allocates resources to a container.
 	AllocateResources(cache.Container) error
 	// ReleaseResources releases resources of a container.
 	ReleaseResources(cache.Container) error
@@ -153,7 +161,15 @@ type Policy interface {
 	Introspect() *introspect.State
 	// Bypassed checks if local policy processing is effectively disabled/bypassed.
 	Bypassed() bool
+	// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+	DescribeMetrics() []*prometheus.Desc
+	// PollMetrics provides policy metrics for monitoring.
+	PollMetrics() Metrics
+	// CollectMetrics generates prometheus metrics from cached/polled policy-specific metrics data.
+	CollectMetrics(Metrics) ([]prometheus.Metric, error)
 }
+
+type Metrics interface{}
 
 // Policy instance/state.
 type policy struct {
@@ -398,6 +414,30 @@ func (p *policy) Introspect() *introspect.State {
 	}
 
 	return state
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *policy) PollMetrics() Metrics {
+	if !p.Bypassed() {
+		return p.active.PollMetrics()
+	}
+	return nil
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
+func (p *policy) DescribeMetrics() []*prometheus.Desc {
+	if !p.Bypassed() {
+		return p.active.DescribeMetrics()
+	}
+	return nil
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled policys-specific metrics data.
+func (p *policy) CollectMetrics(m Metrics) ([]prometheus.Metric, error) {
+	if !p.Bypassed() {
+		return p.active.CollectMetrics(m)
+	}
+	return nil, nil
 }
 
 // Register registers a policy backend.

--- a/pkg/policycollector/collector.go
+++ b/pkg/policycollector/collector.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policycollector
+
+import (
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	"github.com/intel/cri-resource-manager/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PolicyCollector struct {
+	policy policy.Policy
+}
+
+func (c *PolicyCollector) SetPolicy(policy policy.Policy) {
+	c.policy = policy
+}
+
+// HasPolicySpecificMetrics judges whether the policy defines the policy-specific metrics
+func (c *PolicyCollector) HasPolicySpecificMetrics() bool {
+	if c.policy.DescribeMetrics() == nil {
+		return false
+	}
+	return true
+}
+
+// Describe implements prometheus.Collector interface
+func (c *PolicyCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, d := range c.policy.DescribeMetrics() {
+		ch <- d
+	}
+}
+
+// Collect implements prometheus.Collector interface
+func (c *PolicyCollector) Collect(ch chan<- prometheus.Metric) {
+	prometheusMetrics, err := c.policy.CollectMetrics(c.policy.PollMetrics())
+	if err != nil {
+		return
+	}
+	for _, m := range prometheusMetrics {
+		ch <- m
+	}
+}
+
+// RegisterPolicyMetricsCollector registers policy-specific collector
+func (c *PolicyCollector) RegisterPolicyMetricsCollector() error {
+	return metrics.RegisterCollector("policyMetrics", func() (prometheus.Collector, error) {
+		return c, nil
+	})
+}

--- a/pkg/procstats/procstats.go
+++ b/pkg/procstats/procstats.go
@@ -1,0 +1,127 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procstats
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
+)
+
+// CPUTimeStat is used to calculate the CPU usage.
+type CPUTimeStat struct {
+	sync.RWMutex
+	PrevIdleTime       []uint64
+	PrevTotalTime      []uint64
+	CurIdleTime        []uint64
+	CurTotalTime       []uint64
+	DeltaIdleTime      []uint64
+	DeltaTotalTime     []uint64
+	CPUUsage           []float64
+	IsGetCPUUsageBegin bool
+}
+
+var (
+	// procRoot is the mount point for the proc filesystem
+	procRoot = "/proc"
+	procStat = procRoot + "/stat"
+)
+
+// GetCPUTimeStat calculates CPU usage by using the CPU time statistics from /proc/stat
+func (t *CPUTimeStat) GetCPUTimeStat() error {
+	lines, err := readLines(procStat)
+	if err != nil {
+		return err
+	}
+	// /proc/stat looks like this:
+	// cpuid: user, nice, system, idle, iowait, irq, softirq
+	// cpu  130216 19944 162525 1491240 3784 24749 17773 0 0 0
+	// cpu0 40321 11452 49784 403099 2615 6076 6748 0 0 0
+	// cpu1 26585 2425 36639 151166 404 2533 3541 0 0 0
+	// ...
+	t.Lock()
+	defer t.Unlock()
+	sys, err := sysfs.DiscoverSystem()
+	if err != nil {
+		return err
+	}
+	cpuCount := len(sys.CPUIDs())
+	for index, line := range lines {
+		if index > cpuCount {
+			break
+		}
+		split := strings.Split(line, " ")
+		if matched, _ := regexp.MatchString("cpu+\\d", split[0]); matched {
+			i, err := strconv.Atoi(split[0][3:])
+			if err != nil {
+				log.Error("Fail to get CPU index.")
+				return err
+			}
+			t.CurIdleTime[i], err = strconv.ParseUint(split[4], 10, 64)
+			if err != nil {
+				log.Error("Fail to get idle time.")
+				return err
+			}
+			totalTime := uint64(0)
+			for _, s := range split[1:] {
+				u, err := strconv.ParseUint(s, 10, 64)
+				if err == nil {
+					totalTime += u
+				}
+			}
+			t.CurTotalTime[i] = totalTime
+			t.CPUUsage[i] = 0.0
+			if t.IsGetCPUUsageBegin {
+				t.DeltaIdleTime[i] = t.CurIdleTime[i] - t.PrevIdleTime[i]
+				t.DeltaTotalTime[i] = t.CurTotalTime[i] - t.PrevTotalTime[i]
+				if t.DeltaTotalTime[i] != 0 {
+					t.CPUUsage[i] = (1.0 - float64(t.DeltaIdleTime[i])/float64(t.DeltaTotalTime[i])) * 100.0
+				}
+			}
+			t.PrevIdleTime[i] = t.CurIdleTime[i]
+			t.PrevTotalTime[i] = t.CurTotalTime[i]
+		}
+	}
+	for _, i := range sys.Offlined().ToSlice() {
+		t.DeltaIdleTime[i] = 0.0
+		t.DeltaTotalTime[i] = 0.0
+		t.PrevIdleTime[i] = t.CurIdleTime[i]
+		t.PrevTotalTime[i] = t.CurTotalTime[i]
+		t.CPUUsage[i] = 0.0
+	}
+	t.IsGetCPUUsageBegin = true
+	return nil
+}
+
+func readLines(filePath string) ([]string, error) {
+	f, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	data := string(f)
+	rawLines := strings.Split(data, "\n")
+	lines := make([]string, 0)
+	for _, rawLine := range rawLines {
+		if len(strings.TrimSpace(rawLine)) > 0 {
+			lines = append(lines, rawLine)
+		}
+	}
+	return lines, nil
+}


### PR DESCRIPTION
1. Add APIs DescribeMetrics, PollMetrics, CollectMetrics in Policy
and Backend interface. It aims to define policy-specific metrics
and expose them for monitoring.
2. After setupPolicy successfully, ResourceManager will register
the policy-specific collector to metrics if the policy has defined.
3. Add the package procstats to calculate CPU utilization of each
thread by using the time statistics from /proc/stat.

Signed-off-by: Huang Rui <rui1.huang@intel.com>