### PR TITLE
e2e: fix cloud-init error on distro=debian-sid

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -750,7 +750,7 @@ echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/k8s.conf
 # However, rp_filter > 0 breaks cilium networking. Make sure it's disabled.
 echo "net.ipv4.conf.*.rp_filter = 0" >> /etc/sysctl.d/k8s.conf
 
-/sbin/sysctl -p /etc/sysctl.d/k8s.conf
+/sbin/sysctl -p /etc/sysctl.d/k8s.conf || :
 EOF
 }
 


### PR DESCRIPTION
sysctl may fail when rp_filter is not available in the kernel.