### PR TITLE
distro: force non-interactive 'apt-get install'.

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -208,7 +208,7 @@ debian-install-pkg() {
             break
         fi
     done
-    vm-command "yes \"\" | apt-get install $opts -y $*" ||
+    vm-command "yes \"\" | DEBIAN_FRONTEND=noninteractive apt-get install $opts -y $*" ||
         command-error "failed to install $*"
 }
 


### PR DESCRIPTION
Explicitly force apt-get (install) into non-interactive mode.
This should fix bootstrapping a cluster on debian sid.