### PR TITLE
e2e: add support for distro=ubuntu-21.04

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -117,8 +117,8 @@ ubuntu-20_04-image-url() {
     echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
 }
 
-ubuntu-20_10-image-url() {
-    echo "https://cloud-images.ubuntu.com/releases/groovy/release/ubuntu-20.10-server-cloudimg-amd64.img"
+ubuntu-21_04-image-url() {
+    echo "https://cloud-images.ubuntu.com/releases/hirsute/release/ubuntu-21.04-server-cloudimg-amd64.img"
 }
 
 debian-10-image-url() {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -93,7 +93,7 @@ usage() {
     echo "    distro:  Linux distribution to be / already installed on vm."
     echo "             Supported values: centos-7, centos-8, debian-10, debian-sid"
     echo "                 fedora, opensuse, opensuse-tumbleweed, sles,"
-    echo "                 ubuntu-18.10, ubuntu-20.04"
+    echo "                 ubuntu-18.04, ubuntu-20.04, ubuntu-21.04"
     echo "             If sles: set VM_SLES_REGCODE=<CODE> to use official packages."
     echo "    cgroups: cgroups version in the VM, v1 or v2. The default is v1."
     echo "             cgroups=v2 is supported only on distro=fedora"


### PR DESCRIPTION
Ubuntu 21.04 installs with GLIBC_2.33. This helps testing cri-resmgr
on Ubuntu when it has been built on a host that has newer libc than
the default Ubuntu 20.04 LTS (GLIBC_2.30) or 20.10 (GLIBC_2.32).