### PR TITLE
e2e: fix installing containernetworking with go 1.16

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -712,7 +712,7 @@ vm-install-cri() {
 
 vm-install-containernetworking() {
     vm-install-golang
-    vm-command "go get -d github.com/containernetworking/plugins"
+    vm-command "GO111MODULE=off go get -d github.com/containernetworking/plugins"
     CNI_PLUGINS_SOURCE_DIR="$(awk '/package.*plugins/{print $NF}' <<< "$COMMAND_OUTPUT")"
     [ -n "$CNI_PLUGINS_SOURCE_DIR" ] || {
         command-error "downloading containernetworking plugins failed"


### PR DESCRIPTION
golang update on e2e tests broke fetching containernetworking plugins
with go get.