### PR TITLE
e2e: Enable cri-o in centos-8

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -328,6 +328,15 @@ centos-8-install-crio-pre() {
     fi
 }
 
+centos-8-install-crio() {
+    if [ -n "$crio_src" ]; then
+	default-install-crio
+    else
+	distro-install-pkg cri-o
+	vm-command "systemctl enable crio"
+    fi
+}
+
 centos-8-install-containerd-pre() {
     distro-install-repo https://download.docker.com/linux/centos/docker-ce.repo
 }


### PR DESCRIPTION
If user has not specified cri-o sources, then system specified
cri-o package is used but it is not enabled by default in centos-8.
This means that in second boot of the VM, the kube environment does
not start properly because cri-o is not started automatically.
Fix this by enabling cri-o in systemd so that it is started at boot.