### PR TITLE
docs: fix docs Sphinx build breaking in github actions.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ if getenv('VERSIONS_MENU'):
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark','sphinx_markdown_tables']
+extensions = ['myst_parser', 'sphinx_markdown_tables']
 source_suffix = {'.rst': 'restructuredtext','.md': 'markdown'}
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.2.1
+sphinx==3.5.4
 sphinx_rtd_theme
 myst-parser==0.15.1
 sphinx-markdown-tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==3.2.1
 sphinx_rtd_theme
-recommonmark==0.7.1
+myst-parser==0.15.1
 sphinx-markdown-tables
 Pygments==2.7.4

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,7 +36,7 @@ tiering support.
 
 **NOTE**: Currently, the available policies are a work in progress.
 
-### Setting up kubelet to use CRI Resource Manager as the runtime
+## Setting up kubelet to use CRI Resource Manager as the runtime
 
 To let CRI Resource Manager act as a proxy between kubelet and the CRI
 runtime, you need to configure kubelet to connect to CRI Resource Manager


### PR DESCRIPTION
Fix recent docs build breakage by switching from the phased out `recommonmark` to `MyST-Parser` and by ugrading from `Sphinx 3.2.1` to `3.5.4` which is the latest in the 3.x series.
