### PR TITLE
scripts/build/get-buildid: return unknown version

### DIFF
--- a/scripts/build/get-buildid
+++ b/scripts/build/get-buildid
@@ -259,7 +259,7 @@ done
 if ! dotgit_version; then
     if ! stored_version; then
         if ! parent_version; then
-            fail "failed to determine version from any source"
+            unknown_version
         fi
     fi
 fi


### PR DESCRIPTION
Otherwise you might get version numbers like
"failed to determine version from any source" in the Makefile which
breaks things.