### PR TITLE
e2e: Do not try to use govm if user has specified the VM address

### DIFF
--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -203,12 +203,14 @@ host-create-vm() {
 }
 
 host-wait-vm-ssh-server() {
-    VM_IP=$(${GOVM} ls | awk "/$VM_NAME/{print \$4}")
-    while [ "x$VM_IP" == "x" ]; do
-        host-command "${GOVM} start \"$VM_NAME\""
-        sleep 5
+    if [ -z "$VM_IP" ]; then
         VM_IP=$(${GOVM} ls | awk "/$VM_NAME/{print \$4}")
-    done
+        while [ "x$VM_IP" == "x" ]; do
+            host-command "${GOVM} start \"$VM_NAME\""
+            sleep 5
+            VM_IP=$(${GOVM} ls | awk "/$VM_NAME/{print \$4}")
+        done
+    fi
     echo "# VM SSH server  : ssh $VM_SSH_USER@$VM_IP"
 
     if [ -d "$HOME/vms/data/$VM_NAME" ]; then


### PR DESCRIPTION
If user has specified VM_IP when starting run.sh, then there is
no need to try to resolve the IP address of the VM. This allows
the script to be used to configure non govm based hosts.