### PR TITLE
broken/rfc: e2e: opensuse 15.3

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -559,6 +559,10 @@ opensuse-image-url() {
     echo "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images/openSUSE-Leap-15.2-OpenStack.x86_64-0.0.4-Build8.25.qcow2"
 }
 
+opensuse-15_3-image-url() {
+    echo "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-1.0.1-NoCloud-Build2.14.qcow2"
+}
+
 opensuse-tumbleweed-image-url() {
     echo "https://ftp.uni-erlangen.de/opensuse/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2"
 }
@@ -772,6 +776,16 @@ opensuse-install-kernel-dev() {
 opensuse-bootstrap-commands-pre() {
     cat <<EOF
 sed -e '/Signature checking/a gpgcheck = off' -i /etc/zypp/zypp.conf
+EOF
+}
+
+opensuse-15_3-bootstrap-commands-pre() {
+    # BROKEN: cloud-init enabling hack below does not work now
+    # because this script gets executed only if cloud-init works.
+    # Adding ConfigDrive like below is needed for cloud-init to work.
+    cat <<EOF
+sed -e '/Signature checking/a gpgcheck = off' -i /etc/zypp/zypp.conf
+sed -e 's/datasource_list: \[ NoCloud None \]/datasource_list: [ ConfigDrive NoCloud None ]/g' -i /etc/cloud/cloud.cfg
 EOF
 }
 


### PR DESCRIPTION
In order to work, this patch needs either of the following:
1. govm update that enables writing cloud-init iso image so that
   it has "NoCloud" cloud-init files. Currently govm adds only
   ConfigDrive cloud-init.
2. govm update that enables modifying qcow2 images before launching
   Qemu inside the govm docker container. Like:
     1. qemu-nbd --connect=/dev/nbd0 /PATH/TO/opensuse153.qcow2
     2. mount /dev/nbd0 /mnt/vm-vda
     3. run user image modifying script in /mnt/vm-vda
   (Would this be possible with reasonable security on host?)
   Having this in place, our new distro-modify-image() could
   add ConfigDrive to /etc/cloud/cloud.cfg datasource_list, and
   opensuse 15.3 NoCloud image would start working.
3. Find an opensuse 15.3 openstack build somewhere else.