### PR TITLE
e2e: Fixes for non govm usage

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -472,8 +472,9 @@ EOF
         command-error "failed to enable kubelet"
 }
 
-fedora-bootstrap-commands-pre() {
+fedora-bootstrap-commands-post() {
     cat <<EOF
+reboot_needed=0
 mkdir -p /etc/sudoers.d
 echo 'Defaults !requiretty' > /etc/sudoers.d/10-norequiretty
 
@@ -487,11 +488,29 @@ EOF
 if grep -q NAME=Fedora /etc/os-release; then
     if ! grep -q systemd.unified_cgroup_hierarchy=0 /proc/cmdline; then
         sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
-        shutdown -r now
+        reboot_needed=1
     fi
 fi
 EOF
     fi
+
+    # Using swapoff is not enough as we also need to disable the swap from systemd
+    # and then reboot the VM
+    cat <<EOF
+if swapon --show | grep -q partition; then
+    sed -E -i '/^\\/.*[[:space:]]swap[[:space:]].*\$/d' /etc/fstab
+    systemctl --type swap
+    for swp in \`systemctl --type swap | awk '/\\.swap/ { print \$1 }'\`; do systemctl stop "\$swp"; systemctl mask "\$swp"; done
+    swapoff --all
+    reboot_needed=1
+fi
+EOF
+
+    cat <<EOF
+if [ "\$reboot_needed" == "1" ]; then
+   shutdown -r now
+fi
+EOF
 }
 
 ###########################################################################
@@ -806,7 +825,7 @@ rpm-refresh-pkg-db() {
 
 default-bootstrap-commands() {
     cat <<EOF
-touch /etc/modules-load.d/k8s.conf
+rm -f /etc/modules-load.d/k8s.conf; touch /etc/modules-load.d/k8s.conf
 modprobe bridge && echo bridge >> /etc/modules-load.d/k8s.conf || :
 modprobe nf-tables-bridge && echo nf-tables-bridge >> /etc/modules-load.d/k8s.conf || :
 modprobe br_netfilter && echo br_netfilter >> /etc/modules-load.d/k8s.conf || :

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -33,7 +33,7 @@ vms:
 vm-bootstrap() {
     distro-bootstrap-commands | vm-pipe-to-file "./e2e-bootstrap.sh"
     vm-command "sh ./e2e-bootstrap.sh"
-    host-wait-vm-ssh-server
+    host-wait-vm-ssh-server --timeout 600
 }
 
 vm-image-url() {

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -516,11 +516,16 @@ vm-reboot() { # script API
     host-wait-vm-ssh-server
 }
 
+vm-setup-proxies() {
+    distro-setup-proxies
+}
+
 vm-networking() {
     vm-command-q "touch /etc/hosts; grep -q \$(hostname) /etc/hosts" || {
         vm-command "echo \"$VM_IP \$(hostname)\" >>/etc/hosts"
     }
-    distro-setup-proxies
+
+    vm-setup-proxies
 }
 
 vm-install-cri-resmgr() {

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -30,6 +30,12 @@ vms:
         grep -E -v '^ *$'
 }
 
+vm-bootstrap() {
+    distro-bootstrap-commands | vm-pipe-to-file "./e2e-bootstrap.sh"
+    vm-command "sh ./e2e-bootstrap.sh"
+    host-wait-vm-ssh-server
+}
+
 vm-image-url() {
     distro-image-url
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -71,6 +71,8 @@ usage() {
     echo "             The default is 0."
     echo "             Set containerd_src/crio_src/runc_src to install a local build."
     echo "    reinstall_k8s: if 1, destroy existing k8s cluster and create a new one."
+    echo "    reinstall_bootstrap: if 1, run the bootstrap and proxy setup commands."
+    echo "                         Only available if VM_IP is set when calling the script."
     echo "    reinstall_all: if 1, set all above reinstall_* options to 1."
     echo "    omit_cri_resmgr: if 1, omit checking/installing/starting cri-resmgr."
     echo "    omit_agent: if 1, omit checking/installing/starting cri-resmgr-agent."
@@ -1077,6 +1079,9 @@ if [ "$reinstall_k8s" == "1" ]; then
     reinstall_kubectl=1
     reinstall_kubelet=1
 fi
+if [ "$reinstall_bootstrap" == "1" ]; then
+    setup_proxies=1
+fi
 omit_agent=${omit_agent:-0}
 omit_cri_resmgr=${omit_cri_resmgr:-0}
 py_consts="${py_consts:-''}"
@@ -1206,6 +1211,10 @@ if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ]; then
 else
     if [ "$setup_proxies" == "1" ]; then
 	vm-setup-proxies
+    fi
+
+    if [ "$reinstall_bootstrap" == "1" ]; then
+	vm-bootstrap
     fi
 fi
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -115,6 +115,10 @@ usage() {
     echo "             The default is \"cri-resmgr|containerd\"."
     echo "    crio_version: Version of cri-o to try to pull in, if cri-o is"
     echo "                  not being installed from sources."
+    echo "    setup_proxies: Setup proxies even if not using govm based VM."
+    echo "                   This is only needed if you have set VM_IP and want"
+    echo "                   the proxy information set in the target host. By default"
+    echo "                   the proxies are not set if VM_IP is set."
     echo ""
     echo "  Test input VARs:"
     echo "    cri_resmgr_cfg: configuration file forced to cri-resmgr."
@@ -1199,6 +1203,10 @@ host-get-vm-config "$vm" || host-set-vm-config "$vm" "$distro" "$cri"
 
 if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ]; then
     screen-create-vm
+else
+    if [ "$setup_proxies" == "1" ]; then
+	vm-setup-proxies
+    fi
 fi
 
 is-hooked "on_vm_online" && run-hook "on_vm_online"


### PR DESCRIPTION
These fix couple of issues when the k8s is installed to a non VM host.
* The proxies can be setup automatically if `setup_proxies=1` is set when invoking `run.sh`
* Setup pre-flight reqs like ip_forward setting in the host