### PR TITLE
fixes: properly reject containers with invalid/unparsable affinity annotations.

### DIFF
--- a/pkg/cri/resource-manager/cache/affinity.go
+++ b/pkg/cri/resource-manager/cache/affinity.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"fmt"
+
 	"sigs.k8s.io/yaml"
 
 	"github.com/intel/cri-resource-manager/pkg/apis/resmgr"
@@ -120,7 +121,7 @@ func (a *Affinity) String() string {
 // Try to parse affinities in simplified notation from the given annotation value.
 func (pca *podContainerAffinity) parseSimple(pod *pod, value string, weight int32) bool {
 	parsed := simpleAffinity{}
-	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(value), &parsed); err != nil {
 		return false
 	}
 
@@ -185,7 +186,7 @@ func (pca *podContainerAffinity) parseSimple(pod *pod, value string, weight int3
 // Try to parse affinities in full notation from the given annotation value.
 func (pca *podContainerAffinity) parseFull(pod *pod, value string, weight int32) error {
 	parsed := podContainerAffinity{}
-	if err := yaml.Unmarshal([]byte(value), &parsed); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(value), &parsed); err != nil {
 		return cacheError("failed to parse affinity annotation '%s': %v", value, err)
 	}
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -161,7 +161,7 @@ type Pod interface {
 	// webhook was found.
 	GetPodResourceRequirements() PodResourceRequirements
 	// GetContainerAffinity returns the affinity expressions for the named container.
-	GetContainerAffinity(string) []*Affinity
+	GetContainerAffinity(string) ([]*Affinity, error)
 	// ScopeExpression returns an affinity expression for defining this pod as the scope.
 	ScopeExpression() *resmgr.Expression
 
@@ -348,7 +348,7 @@ type Container interface {
 	SetCpusetMems(string)
 
 	// GetAffinity returns the annotated affinity expressions for this container.
-	GetAffinity() []*Affinity
+	GetAffinity() ([]*Affinity, error)
 
 	// GetCgroupDir returns the relative path of the cgroup directory for the container.
 	GetCgroupDir() string

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -751,19 +751,22 @@ func getKubeletHint(cpus, mems string) (ret topology.Hints) {
 	return
 }
 
-func (c *container) GetAffinity() []*Affinity {
+func (c *container) GetAffinity() ([]*Affinity, error) {
 	pod, ok := c.GetPod()
 	if !ok {
 		c.cache.Error("internal error: can't find Pod for container %s", c.PrettyName())
 	}
-
-	affinity := append(pod.GetContainerAffinity(c.GetName()), c.implicitAffinities()...)
+	affinity, err := pod.GetContainerAffinity(c.GetName())
+	if err != nil {
+		return nil, err
+	}
+	affinity = append(affinity, c.implicitAffinities()...)
 	c.cache.Debug("affinity for container %s:", c.PrettyName())
 	for _, a := range affinity {
 		c.cache.Debug("  - %s", a.String())
 	}
 
-	return affinity
+	return affinity, nil
 }
 
 func (c *container) GetCgroupDir() string {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -466,8 +466,8 @@ func (m *mockContainer) UpdateCriCreateRequest(*cri.CreateContainerRequest) erro
 func (m *mockContainer) CriUpdateRequest() (*cri.UpdateContainerResourcesRequest, error) {
 	panic("unimplemented")
 }
-func (m *mockContainer) GetAffinity() []*cache.Affinity {
-	return nil
+func (m *mockContainer) GetAffinity() ([]*cache.Affinity, error) {
+	return nil, nil
 }
 func (m *mockContainer) SetRDTClass(string) {
 	panic("unimplemented")
@@ -631,7 +631,7 @@ func (m *mockPod) GetCgroupParentDir() string {
 func (m *mockPod) GetPodResourceRequirements() cache.PodResourceRequirements {
 	panic("unimplemented")
 }
-func (m *mockPod) GetContainerAffinity(string) []*cache.Affinity {
+func (m *mockPod) GetContainerAffinity(string) ([]*cache.Affinity, error) {
 	panic("unimplemented")
 }
 func (m *mockPod) ScopeExpression() *resmgr.Expression {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -354,7 +354,7 @@ func (p *policy) allocatePool(container cache.Container, poolHint string) (Grant
 		affinity, err := p.calculatePoolAffinities(request.GetContainer())
 
 		if err != nil {
-			log.Error("failed to calculate affinity for container %s: %v",
+			return nil, policyError("failed to calculate affinity for container %s: %v",
 				container.PrettyName(), err)
 		}
 


### PR DESCRIPTION
The current implementation fails to parse affinity annotations properly. In the worst case this can lead to the misinterpretation of annotations. This PR updates affinity handling to fix this.
- cache:
  - parse affinity annotations with a strict YAML parser
  - propagate parse errors back to the entity querying affinities (a policy)
  - add minimal test case to verify parsing/failing valid/invalid affinity annotations
- topology-aware policy:
  - properly fail allocations for containers with invalid affinity annotations