### PR TITLE
e2e: support k8scni=<cilium|weavenet|flannel>

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -2,7 +2,6 @@
 GO_URLDIR=https://golang.org/dl
 GO_VERSION=1.16.8
 GOLANG_URL=$GO_URLDIR/go$GO_VERSION.linux-amd64.tar.gz
-CNI_SUBNET=10.217.0.0/16
 
 ###########################################################################
 
@@ -39,6 +38,7 @@ distro-restart-crio()       { distro-resolve "$@"; }
 distro-install-k8s()        { distro-resolve "$@"; }
 distro-install-kernel-dev() { distro-resolve "$@"; }
 distro-k8s-cni()            { distro-resolve "$@"; }
+distro-k8s-cni-subnet()     { distro-resolve "$@"; }
 distro-set-kernel-cmdline() { distro-resolve "$@"; }
 distro-bootstrap-commands() { distro-resolve "$@"; }
 
@@ -941,7 +941,15 @@ default-install-utils() {
 }
 
 default-k8s-cni() {
-    echo cilium
+    echo ${k8scni:-cilium}
+}
+
+default-k8s-cni-subnet() {
+    if [ "$(distro-k8s-cni)" == "flannel" ]; then
+        echo 10.244.0.0/16
+    else
+        echo 10.217.0.0/16
+    fi
 }
 
 default-install-runc() {
@@ -1084,3 +1092,5 @@ EOF
             command-error "failed to copy $dir.orig to $dir"
     fi
 }
+
+CNI_SUBNET=$(distro-k8s-cni-subnet)

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -795,6 +795,9 @@ vm-install-k8s() {
 }
 
 vm-create-singlenode-cluster() {
+    if ! [ "$(type -t vm-install-cni-$(distro-k8s-cni))" == "function" ]; then
+        error "invalid CNI: $(distro-k8s-cni)"
+    fi
     vm-create-cluster
     vm-command "kubectl taint nodes --all node-role.kubernetes.io/master-"
     vm-install-cni-"$(distro-k8s-cni)"
@@ -829,6 +832,13 @@ vm-install-cni-weavenet() {
     vm-command "kubectl apply -f \"https://cloud.weave.works/k8s/net?k8s-version=\$(kubectl version | base64 | tr -d '\n')\""
     if ! vm-command "kubectl rollout status --timeout=360s -n kube-system daemonsets/weave-net"; then
         command-error "installing weavenet CNI to Kubernetes failed/timed out"
+    fi
+}
+
+vm-install-cni-flannel() {
+    vm-command "kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
+    if ! vm-command "kubectl rollout status --timeout=360s -n kube-system daemonsets/kube-flannel-ds"; then
+        command-error "installing flannel CNI to Kubernetes failed/timed out"
     fi
 }
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -115,6 +115,8 @@ usage() {
     echo "             \"crio\"                  cri-o, no cri-resmgr."
     echo "             \"crio&cri-resmgr\"       cri-o, cri-resmgr is an NRI plugin."
     echo "             The default is \"cri-resmgr|containerd\"."
+    echo "    k8scni:  The container network interface plugin to install. Options are:"
+    echo "             \"cilium\" (the default), \"flannel\", \"weavenet\"."
     echo "    crio_version: Version of cri-o to try to pull in, if cri-o is"
     echo "                  not being installed from sources."
     echo "    setup_proxies: Setup proxies even if not using govm based VM."
@@ -1059,6 +1061,7 @@ cri_resmgr_extra_args=${cri_resmgr_extra_args:-""}
 cri_resmgr_agent_extra_args=${cri_resmgr_agent_extra_args:-""}
 cleanup=${cleanup:-0}
 reinstall_all=${reinstall_all:-0}
+reinstall_bootstrap=${reinstall_bootstrap:-0}
 reinstall_containerd=${reinstall_containerd:-0}
 reinstall_cri_resmgr=${reinstall_cri_resmgr:-0}
 reinstall_cri_resmgr_agent=${reinstall_cri_resmgr_agent:-0}


### PR DESCRIPTION
Similarly to the `k8scri` parameter, allow user to define which CNI to install on new cluster by setting `k8scni`.

This patch also adds support to the flannel CNI.

Setting `reinstall_bootstrap` is added to keep our shellcheck (git hook) happy.