### PR TITLE
resmgr: write a PID file upon successful startup.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/common v0.30.0
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
+	github.com/stretchr/testify v1.7.0 // indirect
 	go.opencensus.io v0.22.4
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/sys v0.0.0-20210903071746-97244b99971b

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
+	"github.com/intel/cri-resource-manager/pkg/pidfile"
 )
 
 // Options captures our command line parameters.
@@ -29,6 +30,7 @@ type options struct {
 	RelayDir            string
 	AgentSocket         string
 	ConfigSocket        string
+	PidFile             string
 	ResctrlPath         string
 	FallbackConfig      string
 	ForceConfig         string
@@ -58,7 +60,8 @@ func init() {
 		"local socket of the cri-resmgr agent to connect")
 	flag.StringVar(&opt.ConfigSocket, "config-socket", sockets.ResourceManagerConfig,
 		"Unix domain socket path where the resource manager listens for cri-resmgr-agent")
-
+	flag.StringVar(&opt.PidFile, "pid-file", pidfile.GetPath(),
+		"PID file to write daemon PID to")
 	flag.StringVar(&opt.FallbackConfig, "fallback-config", "",
 		"Fallback configuration to use unless/until one is available from the cache or agent.")
 	flag.StringVar(&opt.ForceConfig, "force-config", "",

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -1,0 +1,165 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pidfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	pidFilePath = defaultPath()
+	pidFile     *os.File
+)
+
+// GetPath returns the current pidfile path.
+func GetPath() string {
+	return pidFilePath
+}
+
+// SetPath sets the pidfile path to the given one.
+func SetPath(path string) {
+	close()
+	pidFilePath = path
+}
+
+// Write opens the PID file and writes os.Getpid() to it. If the PID file already
+// exists Write() fails with an error. On successful completion, Write keeps the
+// PID file open.
+func Write() error {
+	if pidFile != nil {
+		return nil
+	}
+
+	err := os.MkdirAll(filepath.Dir(pidFilePath), 0755)
+	if err != nil {
+		return errors.Wrap(err, "failed to create PID file")
+	}
+
+	pidFile, err = os.OpenFile(pidFilePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to create PID file")
+	}
+
+	_, err = pidFile.Write([]byte(fmt.Sprintf("%d\n", os.Getpid())))
+	if err != nil {
+		close()
+		return errors.Wrap(err, "failed to write PID file")
+	}
+
+	return nil
+}
+
+// Read reads the content of the PID file. It returns the process ID found
+// in the file. If opening the file or reading an integer process ID fails
+// Read() returns -1 and an error.
+func Read() (int, error) {
+	var (
+		pid int
+		buf []byte
+		err error
+	)
+
+	if buf, err = os.ReadFile(pidFilePath); err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return -1, errors.Wrap(err, "failed to read PID file")
+	}
+
+	if pid, err = strconv.Atoi(strings.TrimRight(string(buf), "\n")); err != nil {
+		return -1, errors.Wrapf(err, "invalid PID (%q) in PID file", string(buf))
+	}
+
+	return pid, nil
+}
+
+// close closes the PID file and truncates it to zero length.
+func close() {
+	if pidFile != nil {
+		pidFile.Truncate(0)
+		pidFile.Close()
+		pidFile = nil
+	}
+}
+
+// Remove removes the PID file for the process unconditionally, regardless if
+// the current process had created the PID file or not.
+func Remove() error {
+	close()
+	err := os.Remove(pidFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+	}
+	return err
+}
+
+// OwnerPid returns the ID of the process owning the PID file. 0 is returned
+// if it is known that no process owns the file. -1 and an error is returned
+// if the owner or its existence could not be determined.
+func OwnerPid() (int, error) {
+	var (
+		pid int
+		p   *os.Process
+		err error
+	)
+
+	pid, err = Read()
+	if err != nil {
+		return -1, err
+	}
+	if pid == 0 {
+		return 0, nil
+	}
+
+	p, err = os.FindProcess(pid)
+	if err != nil {
+		return -1, errors.Wrapf(err, "FindProcess() failed for PID %d", pid)
+	}
+
+	err = p.Signal(syscall.Signal(0))
+	if err == os.ErrProcessDone {
+		return 0, nil
+	}
+	if err == nil {
+		return pid, nil
+	}
+
+	return -1, errors.Wrapf(err, "failed to check process %d", pid)
+}
+
+// defaultPath returns the default pidfile path.
+func defaultPath() string {
+	var path string
+
+	if len(os.Args) > 0 {
+		name := filepath.Base(os.Args[0])
+		if euid := os.Geteuid(); euid > 0 {
+			path = filepath.Join("/tmp", name+".pid")
+		} else {
+			path = filepath.Join("/", "var", "run", name+".pid")
+		}
+	}
+
+	return path
+}

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -1,0 +1,255 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pidfile
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPidFile = "pidfile-test.pid"
+)
+
+func prepare(t *testing.T) string {
+	dir, err := mkTestDir(t)
+	if err != nil {
+		t.Errorf("failed to create test directory: %v", err)
+		os.Exit(1)
+	}
+
+	SetPath(filepath.Join(dir, testPidFile))
+	return dir
+}
+
+func TestDefaults(t *testing.T) {
+	t.Run("TestDefaults", func(t *testing.T) {
+		var (
+			pid int
+			err error
+		)
+
+		Remove()
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+
+		close()
+		err = Write()
+		require.NotNil(t, err)
+
+		Remove()
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+	})
+}
+
+func TestGetSetPath(t *testing.T) {
+	t.Run("TestTestGetSetPath", func(t *testing.T) {
+		var (
+			dir  string
+			path string
+		)
+
+		dir = prepare(t)
+		path = GetPath()
+		require.Equal(t, path, filepath.Join(dir, testPidFile))
+	})
+}
+
+func TestReadNonExisting(t *testing.T) {
+	t.Run("TestReadNonExisting", func(t *testing.T) {
+		var (
+			pid int
+			err error
+		)
+
+		prepare(t)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, 0)
+	})
+}
+
+func TestRemoveNonExisting(t *testing.T) {
+	t.Run("TestRemoveNonExisting", func(t *testing.T) {
+		prepare(t)
+		err := Remove()
+		require.Nil(t, err)
+	})
+}
+
+func TestRemoveExisting(t *testing.T) {
+	t.Run("TestRemoveExisting", func(t *testing.T) {
+		var (
+			err error
+		)
+
+		prepare(t)
+		err = Write()
+		require.Nil(t, err)
+
+		err = Remove()
+		require.Nil(t, err)
+	})
+}
+
+func TestWrite(t *testing.T) {
+	t.Run("TestWrite", func(t *testing.T) {
+		var (
+			pid int
+			err error
+		)
+
+		prepare(t)
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+	})
+}
+
+func TestReadClosed(t *testing.T) {
+	t.Run("TestReadClosed", func(t *testing.T) {
+		var (
+			pid int
+			err error
+		)
+
+		prepare(t)
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+
+		close()
+		pid, err = Read()
+		require.NotNil(t, err)
+		require.Equal(t, pid, -1)
+	})
+}
+
+func TestFailToOverwrite(t *testing.T) {
+	t.Run("TestFailToOverwrite", func(t *testing.T) {
+		var (
+			pid int
+			err error
+		)
+
+		prepare(t)
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+
+		close()
+		err = Write()
+		require.NotNil(t, err)
+	})
+}
+
+func TestRemoveToOverwrite(t *testing.T) {
+	t.Run("TestRemoveToOverwrite", func(t *testing.T) {
+		var (
+			pid int
+			err error
+		)
+
+		prepare(t)
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+
+		err = Remove()
+		require.Nil(t, err)
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+	})
+}
+
+func TestOwnerPid(t *testing.T) {
+	t.Run("TestOwnerPid", func(t *testing.T) {
+		var (
+			pid int
+			chk int
+			err error
+		)
+
+		prepare(t)
+
+		err = Write()
+		require.Nil(t, err)
+
+		pid, err = Read()
+		require.Nil(t, err)
+		require.Equal(t, pid, os.Getpid())
+
+		chk, err = OwnerPid()
+		require.Nil(t, err)
+		require.Equal(t, pid, chk)
+	})
+}
+
+func mkTestDir(t *testing.T) (string, error) {
+	tmp, err := ioutil.TempDir("", ".pidfile-test*")
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create test directory")
+	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(tmp)
+	})
+
+	return tmp, nil
+}


### PR DESCRIPTION
Implement basic PID file handling. Write a PID file upon successful startup. If we fail to start up due to an existing active socket, try to read the process ID of the running instance from the PID file. If this succeeds write an diagnostic/error message with the read process ID.