### PR TITLE
fixes: better socket probing.

### DIFF
--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -253,7 +253,7 @@ func (m *resmgr) resetCachedPolicy() int {
 	m.Info("resetting active policy stored in cache...")
 	defer logger.Flush()
 
-	if utils.ServerActiveAt(opt.RelaySocket) {
+	if ls, err := utils.IsListeningSocket(opt.RelaySocket); ls || err != nil {
 		m.Error("refusing to reset, looks like an instance of %q is active at socket %q...",
 			filepath.Base(os.Args[0]), opt.RelaySocket)
 		return 1
@@ -271,7 +271,7 @@ func (m *resmgr) resetCachedConfig() int {
 	m.Info("resetting cached configuration...")
 	defer logger.Flush()
 
-	if utils.ServerActiveAt(opt.RelaySocket) {
+	if ls, err := utils.IsListeningSocket(opt.RelaySocket); ls || err != nil {
 		m.Error("refusing to reset, looks like an instance of %q is active at socket %q...",
 			filepath.Base(os.Args[0]), opt.RelaySocket)
 		return 1

--- a/pkg/cri/server/server.go
+++ b/pkg/cri/server/server.go
@@ -196,11 +196,11 @@ func (s *server) createGrpcServer() error {
 
 	l, err := net.Listen("unix", s.options.Socket)
 	if err != nil {
-		if utils.ServerActiveAt(s.options.Socket) {
-			return serverError("failed to create server: socket %s already in use",
+		if ls, lsErr := utils.IsListeningSocket(s.options.Socket); ls || lsErr != nil {
+			return serverError("failed to create server: socket %q already exists",
 				s.options.Socket)
 		}
-		s.Warn("removing abandoned socket '%s' in use...", s.options.Socket)
+		s.Warn("removing abandoned socket %q...", s.options.Socket)
 		os.Remove(s.options.Socket)
 		l, err = net.Listen("unix", s.options.Socket)
 		if err != nil {

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -61,8 +61,8 @@ func newFakeCriServer(t *testing.T, socket string, fakeHandlers map[string]inter
 
 	lis, err := net.Listen("unix", socket)
 	if err != nil {
-		if utils.ServerActiveAt(socket) {
-			t.Fatalf("failed to create fake server: socket %s already in use", socket)
+		if ls, err := utils.IsListeningSocket(socket); ls || err != nil {
+			t.Fatalf("failed to create fake server: socket %s already exists", socket)
 		}
 		os.Remove(socket)
 		lis, err = net.Listen("unix", socket)


### PR DESCRIPTION
Invert active socket test logic by testing if connecting to the socket fails with ECONNREFUSED instead of going through the full gRPC stack and checking if a connection can be established.

This PR should fix the apparent misbehavior for the corner case described [in this comment](https://github.com/intel/cri-resource-manager/pull/756#pullrequestreview-844621132).