### PR TITLE
.githooks: add hook to check go version conistency.

### DIFF
--- a/.githooks/pre-commit.d/20-go-version
+++ b/.githooks/pre-commit.d/20-go-version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+WORKFLOWS=".github/workflows/verify.yml"
+
+gomod=$(git diff --cached go.mod | grep '^+go ' | sed 's/^.* //g')
+[ -z "$gomod" ] && exit 0
+
+status=0
+for wf in $WORKFLOWS; do
+    workflow=$(grep 'go-version:' .github/workflows/verify.yml | sed 's/^.*: //')
+    if [ "gomod" != "$workflow" ]; then
+        echo >&2 "ERROR: inconsistent golang versions, $gomod in go.mod but $workflow in $wf..."
+        status=1
+    fi
+done
+
+if [ "$status" != 0 ]; then
+    echo >&2 "Please consider fixing these inconsistencies before committing..."
+fi
+
+exit $status


### PR DESCRIPTION
Add a hook to check the consistency of declared golang version requirement vs. the one used in github workflows. No need to always wait for the already slow and overloaded github workers to run our tests till failure then let us know we forgot to update the other.