### PR TITLE
[release-0.6] docs: Fix doc and example config typos/indentation

### DIFF
--- a/docs/developers-guide/architecture.md
+++ b/docs/developers-guide/architecture.md
@@ -135,20 +135,20 @@ B. If the request needs to be intercepted for policying, do the following:
  3. If the request has no resource allocation consequences, do proxying
     (step 6).
  4. Otherwise, invoke the policy layer for resource allocation:
-   - Pass it on to the configured active policy, which will
-   - Allocate resources for the container.
-   - Update the assignments for the container in the cache.
-   - Update any other containers affected by the allocation in the cache.
+    - Pass it on to the configured active policy, which will
+    - Allocate resources for the container.
+    - Update the assignments for the container in the cache.
+    - Update any other containers affected by the allocation in the cache.
  5. Invoke the controller layer for post-policy processing, which will:
-   - Collect controllers with pending changes in their domain of control
-   - for each invoke the post-policy processing function corresponding to
-     the request.
-   - Clear pending markers for the controllers.
+    - Collect controllers with pending changes in their domain of control
+    - for each invoke the post-policy processing function corresponding to
+      the request.
+    - Clear pending markers for the controllers.
  6. Proxy the request:
-   - Relay the request to the server.
-   - Send update requests for any additional affected containers.
-   - Update the cache if/as necessary based on the response.
-   - Relay the response back to the client.
+    - Relay the request to the server.
+    - Send update requests for any additional affected containers.
+    - Update the cache if/as necessary based on the response.
+    - Relay the response back to the client.
  7. Release the processing pipeline serialization lock.
 
 The high-level control flow of the event processing pipeline is one of the
@@ -269,7 +269,7 @@ A resource controller implementation responsible for the practical details of
 associating a container with Intel RDT classes. This class effectively
 determines how much last level cache and memory bandwidth will be available
 for the container. This controller uses the resctrl pseudo filesystem of the
-Linux\* kernel for control.
+Linux kernel for control.
 
 #### [Block I/O](/pkg/cri/resource-manager/control/blockio/)
 

--- a/docs/policy/cpu-allocator.md
+++ b/docs/policy/cpu-allocator.md
@@ -19,7 +19,7 @@ supports CPU priority detection based on the `intel_pstate` scaling
 driver in the Linux CPUFreq subsystem, and, Intel Speed Select Technology
 (SST).
 
-CPUs are divided into three priority classes, i.e. *hight*, *normal* and *low*.
+CPUs are divided into three priority classes, i.e. *high*, *normal* and *low*.
 Policies utilizing the CPU allocator may choose to prefer certain priority
 class for certain types of workloads. For example, prefer (and preserve) high
 priority CPUs for high priority workloads.

--- a/docs/policy/rdt.md
+++ b/docs/policy/rdt.md
@@ -4,7 +4,7 @@
 
 Intel® RDT provides capabilities for cache and memory allocation and
 monitoring. In Linux system the functionality is exposed to the user space via
-the [resctrl](https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt)
+the [resctrl](https://docs.kernel.org/x86/resctrl.html)
 filesystem. Cache and memory allocation in RDT is handled by using resource
 control groups. Resource allocation is specified on the group level and each
 task (process/thread) is assigned to one group. In the context of CRI Resource
@@ -20,14 +20,14 @@ Monitoring (MBM).
 
 RDT configuration in CRI-RM is class-based. Each container gets assigned to an
 RDT class. In turn, all processes of the container will be assigned to the RDT
-CLOS  (under `/sys/fs/resctrl`) corresponding the RDT class. CRI-RM will configure
+Classes of Service (CLOS) (under `/sys/fs/resctrl`) corresponding the RDT class. CRI-RM will configure
 the CLOSes according to its configuration at startup or whenever the
 configuration changes.
 
 By default there is a direct mapping between Pod QoS classes and RDT classes:
 the containers of the Pod get an RDT class with the same name as its QoS class
 (Guaranteed, Burstable or Besteffort). However, that can be overridden with the
-rdtclass.cri-resource-manager.intel.com Pod annotation. You can also specify
+`rdtclass.cri-resource-manager.intel.com` Pod annotation. You can also specify
 RDT classes other than Guaranteed, Burstable or Besteffort. In this case, the
 Pod can only be assigned to these classes with the Pod annotation, though.
 The default behavior can also be overridden by a policy but currently none of
@@ -52,7 +52,7 @@ The RDT controller supports three operating modes, controlled by
   are removed.
 - Full: Full operating mode. The controller manages the configuration of the
   resctrl filesystem according to the rdt class definitions in the CRI-RM
-  configiration. This is the default operating mode.
+  configuration. This is the default operating mode.
 
 ### RDT Classes
 
@@ -83,7 +83,7 @@ exceeded.
 
 ### Example
 
-Below is a config snippet that would allocate (ca.) 60% of the L3 cache lines
+Below is a config snippet that would allocate 60% of the L3 cache lines
 exclusively to the Guarenteed class. The remaining 40% L3 is for Burstable and
 Besteffort, Besteffort getting only 50% of this. Guaranteed class gets full
 memory bandwidth whereas the other classes are throttled to 50%.
@@ -159,7 +159,7 @@ and data paths.
         l3Allocation:
           # 'all' denotes the default and must be specified
           all: "40%"
-          # Specific cache allotation for cache-ids 2 and 3
+          # Specific cache allocation for cache-ids 2 and 3
           2-3: "20%"
         mbAllocation: ["100%"]
         classes:
@@ -169,9 +169,9 @@ and data paths.
                 unified: "100%"
                 code: "100%"
                 data: "80%"
-              mbSchema:
-                all: ["80%"]
-                2-3: ["50%"]
+            mbSchema:
+              all: ["80%"]
+              2-3: ["50%"]
 ...
 ...
 ```
@@ -179,10 +179,10 @@ and data paths.
 In addition, if the hardware details are known, raw bitmasks or bit numbers
 ("0x1f" or 0-4) can be used instead of percentages in order to be able to
 configure cache allocations exactly as required. The bits in this case are
-corresponding to those in /sys/fs/resctrl/ bitmasks. You can also mix relative
+corresponding to those in `/sys/fs/resctrl/` bitmasks. You can also mix relative
 (percentage) and absolute (bitmask) allocations. For cases where the resctrl
 filesystem is mounted with `-o mba_MBps` Memory bandwidth must be specifed in
-MBps.
+MegaBytes per second (MBps).
 
 ```yaml
 ...

--- a/docs/policy/topology-aware.md
+++ b/docs/policy/topology-aware.md
@@ -274,7 +274,7 @@ exclusive allocation.
 `CRI Resource Manager` automatically generates HW `Topology Hints` for devices
 assigned to a container, prior to handing the container off to the active policy
 for resource allocation. The `topology-aware` policy is hint-aware and normally
-takes topology hints into account when picking the best a pool to allocate
+takes topology hints into account when picking the best pool to allocate
 resources. Hints indicate optimal `HW locality` for device access and they can
 alter significantly which pool gets picked for a container.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -48,7 +48,7 @@ systemctl status cri-resource-manager
 
 ## Kubelet setup
 
-Next, you need to configure kubelet to user cri-resource-manager as it's
+Next, you need to configure kubelet to use cri-resource-manager as it's
 container runtime endpoint.
 
 ### Existing cluster

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -13,11 +13,13 @@ policy:
 ```
 
 **AvailableResources** specifies the available hardware resources.
+
 **ReservedResources** specifies the hardware resources reserved for system and
 kube tasks.
+
 Currently, only CPU resources are supported. CPUs may be specified as a cpuset
 or as a numerical value, similar to Kubernetes resource quantities. Not all
-policies use these configuration settins. See the policy-specific documentation
+policies use these configuration settings. See the policy-specific documentation
 for details.
 
 ```yaml

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -183,7 +183,7 @@ the configuration, and in your adjustment specifications.
 kubectl get adjustments.criresmgr.intel.com -n kube-system
 ```
 
-You can examine the contents of a single adjustments with these commands:
+You can examine the contents of a single adjustment with these commands:
 
 ```
 kubectl describe adjustments external-adjustment -n kube-system
@@ -196,7 +196,7 @@ Or you can examine the contents of all adjustments using this command:
 kubectl get adjustments.criresmgr.intel.com -n kube-system -oyaml
 ```
 
-Finally, you can delete and adjustment with commands like these:
+Finally, you can delete an adjustment with commands like these:
 
 ```
 kubectl delete -f sample-configs/external-adjustment.yaml

--- a/sample-configs/cri-resmgr-configmap.example.yaml
+++ b/sample-configs/cri-resmgr-configmap.example.yaml
@@ -106,10 +106,10 @@ data:
             #    data: "80%"
             ## Specify CacheId (typically corresponds to a CPU socket) specific setting
             #  1: "80%"
-          ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
-          #  mbschema:
-          #    all: [100%]
-          #    1-3: [80%, 10000MBps]
+            ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
+            #mbschema:
+            #  all: [100%]
+            #  1-3: [80%, 10000MBps]
           Burstable:
             l2schema: "66%"
             l3schema:
@@ -118,19 +118,19 @@ data:
                 # Separate schema for L3 code and data paths specified
                 code: "100%"
                 data: "50%"
-          ## MBA (Memory Bandwidth Allocation) for 'Burstable'
-          ## 'all' may be omitted if no cache-id specific settings are required
-          #  mbschema: [66%, 5000MBps]
+            ## MBA (Memory Bandwidth Allocation) for 'Burstable'
+            ## 'all' may be omitted if no cache-id specific settings are required
+            #mbschema: [66%, 5000MBps]
           BestEffort:
             l2schema: "60%"
             l3schema: "33%"
-          ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-          #  mbschema: [33%, 3000MBps]
-        ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
-        ## resctrl group of the system
-        #  SYSTEM_DEFAULT:
-        #    l2schema: "60%"
-        #    l3schema: "50%"
+            ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
+            #mbschema: [33%, 3000MBps]
+          ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
+          ## resctrl group of the system
+          #SYSTEM_DEFAULT:
+          #  l2schema: "60%"
+          #  l3schema: "50%"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -218,10 +218,10 @@ data:
             #    data: "80%"
             ## Specify CacheId (typically corresponds to a CPU socket) specific setting
             #  1: "80%"
-          ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
-          #  mbschema:
-          #    all: [100%]
-          #    1-3: [80%, 10000MBps]
+            ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
+            #mbschema:
+            #  all: [100%]
+            #  1-3: [80%, 10000MBps]
           Burstable:
             l2schema: "66%"
             l3schema:
@@ -230,19 +230,19 @@ data:
                 # Separate schema for L3 code and data paths specified
                 code: "100%"
                 data: "50%"
-          ## MBA (Memory Bandwidth Allocation) for 'Burstable'
-          ## 'all' may be omitted if no cache-id specific settings are required
-          #  mbschema: [66%, 5000MBps]
+            ## MBA (Memory Bandwidth Allocation) for 'Burstable'
+            ## 'all' may be omitted if no cache-id specific settings are required
+            #mbschema: [66%, 5000MBps]
           BestEffort:
             l2schema: "60%"
             l3schema: "33%"
-          ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-          #  mbschema: [33%, 3000MBps]
-        ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
-        ## resctrl group of the system
-        #  SYSTEM_DEFAULT:
-        #    l2schema: "60%"
-        #    l3schema: "50%"
+            ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
+            #mbschema: [33%, 3000MBps]
+          ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
+          ## resctrl group of the system
+          #SYSTEM_DEFAULT:
+          #  l2schema: "60%"
+          #  l3schema: "50%"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -330,10 +330,10 @@ data:
             #    data: "80%"
             ## Specify CacheId (typically corresponds to a CPU socket) specific setting
             #  1: "80%"
-          ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
-          #  mbschema:
-          #    all: [100%]
-          #    1-3: [80%, 10000MBps]
+            ## MBA (Memory Bandwidth Allocation) for 'Guaranteed'
+            #mbschema:
+            #  all: [100%]
+            #  1-3: [80%, 10000MBps]
           Burstable:
             l2schema: "66%"
             l3schema:
@@ -342,19 +342,19 @@ data:
                 # Separate schema for L3 code and data paths specified
                 code: "100%"
                 data: "50%"
-          ## MBA (Memory Bandwidth Allocation) for 'Burstable'
-          ## 'all' may be omitted if no cache-id specific settings are required
-          #  mbschema: [66%, 5000MBps]
+            ## MBA (Memory Bandwidth Allocation) for 'Burstable'
+            ## 'all' may be omitted if no cache-id specific settings are required
+            #mbschema: [66%, 5000MBps]
           BestEffort:
             l2schema: "60%"
             l3schema: "33%"
-          ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
-          #  mbschema: [33%, 3000MBps]
-        ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
-        ## resctrl group of the system
-        #  SYSTEM_DEFAULT:
-        #    l2schema: "60%"
-        #    l3schema: "50%"
+            ## MBA (Memory Bandwidth Allocation) for 'BestEffort'
+            #mbschema: [33%, 3000MBps]
+          ## Special class 'SYSTEM_DEFAULT'. Reserved name for configuring the "root"
+          ## resctrl group of the system
+          #SYSTEM_DEFAULT:
+          #  l2schema: "60%"
+          #  l3schema: "50%"
   dump: |+
     Config: full:.*,short:.*Stop.*,off:.*List.*
     File: /tmp/cri-selective-debug.dump


### PR DESCRIPTION
* fix indentation
  (cherry picked from commit 4f0be74a53e3ce460709aed25b02f9e3eb7887c1)
* fix typos, indentation etc.
  (cherry picked from commit 706aa60f02a935ad92f4a6cd3aa28c92d81e0427)