### PR TITLE
[release-0.6] backport CI fixes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,15 +22,6 @@ jobs:
     - name: Gofmt
       run: make format
 
-    - name: Protoc
-      run: go get -u github.com/golang/protobuf/protoc-gen-go
-
-    - name: Protoc-gRPC
-      run: go get -u google.golang.org/grpc
-
-    - name: InstallVFSGenDev
-      run: go get -u github.com/shurcooL/vfsgen/cmd/vfsgendev
-
     - name: Build
       run: make
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ if getenv('VERSIONS_MENU'):
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark','sphinx_markdown_tables']
+extensions = ['myst_parser', 'sphinx_markdown_tables']
 source_suffix = {'.rst': 'restructuredtext','.md': 'markdown'}
 
 

--- a/docs/releases/conf.py
+++ b/docs/releases/conf.py
@@ -34,7 +34,7 @@ if os.getenv('VERSIONS_MENU'):
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-        'recommonmark',
+        'myst_parser',
         'sphinx_markdown_tables'
         ]
 source_suffix = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.2.1
+sphinx==3.5.4
 sphinx_rtd_theme
 myst-parser==0.15.1
 sphinx-markdown-tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==3.2.1
 sphinx_rtd_theme
 recommonmark==0.7.1
 sphinx-markdown-tables
-Pygments==2.6.1
+Pygments==2.7.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==3.2.1
 sphinx_rtd_theme
-recommonmark==0.7.1
+myst-parser==0.15.1
 sphinx-markdown-tables
 Pygments==2.7.4

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,7 +36,7 @@ tiering support.
 
 **NOTE**: Currently, the available policies are a work in progress.
 
-### Setting up kubelet to use CRI Resource Manager as the runtime
+## Setting up kubelet to use CRI Resource Manager as the runtime
 
 To let CRI Resource Manager act as a proxy between kubelet and the CRI
 runtime, you need to configure kubelet to connect to CRI Resource Manager


### PR DESCRIPTION
Backports from master to get CI to pass muster

1. docs: use myst markdown parser for docs/releases too
   Supplements 09cc1ee31db37f2f634f8a58d3f7b46704764b0f.
   (cherry picked from commit 009a83eb65cf3e9cf39bc4766fb114e782e60bd2)
2. docs: update to sphinx 3.5.4.
   (cherry picked from commit bf27672cff7de3b7b3f6745d4ac522ba3c5fc1c2)
3. docs: fix recommonmark breaking doc build on github.
   An unfixed upstream recommonmark bug causes warnings during
   'make site-build'/sphinx doc generation. These warnings are
   treated as errors in github actions, so they can break test
   builds of recent PRs. Fix this by switching to MyST-Parser.

   See https://github.com/readthedocs/recommonmark/issues/177
   for a miminal explanation of the bug.
   See https://github.com/readthedocs/recommonmark/issues/221
   for background information on recommon

   (cherry picked from commit 09cc1ee31db37f2f634f8a58d3f7b46704764b0f)


4. build(deps): bump pygments from 2.6.1 to 2.7.4 in /docs
   Bumps [pygments](https://github.com/pygments/pygments) from 2.6.1 to 2.7.4.

     - [Release notes](https://github.com/pygments/pygments/releases)
     - [Changelog](https://github.com/pygments/pygments/blob/master/CHANGES)
     - [Commits](https://github.com/pygments/pygments/compare/2.6.1...2.7.4)

   Signed-off-by: dependabot[bot] <support@github.com>

   (cherry picked from commit f0cc3ac6df86f6bcf04a59c98eb96665e2cc2e1d)


5. github: drop unnecessary CI steps
   They're unneeded and just causing unpredictable behavior by doing
   random-ish package updates.

   (cherry picked from commit c7d7965f07a7e0428e91811f05dbd81a98e3b116)
