### PR TITLE
topology-aware: Do not advertise shared CPUs if there are none

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -315,7 +315,7 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 	isolated := grant.ExclusiveCPUs().Intersection(grant.GetCPUNode().GetSupply().IsolatedCPUs())
 	exclusive := grant.ExclusiveCPUs().Difference(isolated).String()
 
-	if shared != "" {
+	if grant.SharedPortion() > 0 && shared != "" {
 		data[policyapi.ExportSharedCPUs] = shared
 	}
 	if isolated.String() != "" {


### PR DESCRIPTION
Only write shared CPU information to resource.sh if there
are shared CPUs allocated to the container.