### PR TITLE
docs: mention that golang 1.17 is needed for building

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ Although not recommended, you can install CRI Resource Manager from sources:
   - get the sources: `git clone https://github.com/intel/cri-resource-manager`
   - build and install: `cd cri-resource-manager; make build && sudo make install`
 
-You will need at least `git`, `golang 1.14` or newer, `GNU make`, `bash`,
+You will need at least `git`, `golang 1.17` or newer, `GNU make`, `bash`,
 `find`, `sed`, `head`, `date`, and `install` to be able to build and install
 from sources.
 


### PR DESCRIPTION
Currently, "make build" fails with golang 1.16.x but succeeds with 1.17, so we should update the doc.
This PR proposes trivial 1.14 -> 1.17 change.
But also "Don't merge yet", RFC: what about we stop mentioning exact version which tends to be correct for short time
and needs manual update often. And it is usually correct while it states the latest version, isn't it?
So what about avoiding static binding and use something more fuzzy (but less incorrect) like "decent version",
leaving the possible determining of working version to the user (which will happen anyway in case of trouble)?