### PR TITLE
pkg/cri: switch internals to CRI v1, add ingress/egress v1/v1alpha2 CRI conversion.

### DIFF
--- a/pkg/cri/client/client.go
+++ b/pkg/cri/client/client.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/instrumentation"
 	logger "github.com/intel/cri-resource-manager/pkg/log"

--- a/pkg/cri/client/v1alpha2/client.go
+++ b/pkg/cri/client/v1alpha2/client.go
@@ -1,0 +1,894 @@
+// Copyright Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha2
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1alpha2 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+)
+
+type Client interface {
+	criv1.ImageServiceClient
+	criv1.RuntimeServiceClient
+}
+
+type client struct {
+	logger.Logger
+	isc criv1alpha2.ImageServiceClient
+	rsc criv1alpha2.RuntimeServiceClient
+	rcc *grpc.ClientConn
+	icc *grpc.ClientConn
+}
+
+// Connect v2alpha1 RuntimeService and ImageService clients.
+func Connect(runtime, image *grpc.ClientConn) (Client, error) {
+	c := &client{
+		Logger: logger.Get("cri/client"),
+		rcc:    runtime,
+		icc:    image,
+	}
+
+	if c.rcc != nil {
+		c.Info("probing CRI v1alpha2 RuntimeService client...")
+		c.rsc = criv1alpha2.NewRuntimeServiceClient(c.rcc)
+		_, err := c.rsc.Version(context.Background(), &criv1alpha2.VersionRequest{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if c.icc != nil {
+		c.Info("probing CRI v1alpha2 ImageService client...")
+		c.isc = criv1alpha2.NewImageServiceClient(c.icc)
+		_, err := c.isc.ListImages(context.Background(), &criv1alpha2.ListImagesRequest{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+func (c *client) checkRuntimeService() error {
+	if c.rcc == nil {
+		return fmt.Errorf("no CRI v1alpha2 RuntimeService client")
+	}
+	return nil
+}
+
+func (c *client) checkImageService() error {
+	if c.icc == nil {
+		return fmt.Errorf("no CRI v1alpha2 ImageService client")
+	}
+	return nil
+}
+
+func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...grpc.CallOption) (*criv1.VersionResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.VersionRequest{}
+		v1resp = &criv1.VersionResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.Version(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, opts ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.RunPodSandboxRequest{}
+		v1resp = &criv1.RunPodSandboxResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.RunPodSandbox(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, opts ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.StopPodSandboxRequest{}
+		v1resp = &criv1.StopPodSandboxResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.StopPodSandbox(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, opts ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.RemovePodSandboxRequest{}
+		v1resp = &criv1.RemovePodSandboxResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.RemovePodSandbox(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.PodSandboxStatusRequest{}
+		v1resp = &criv1.PodSandboxStatusResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.PodSandboxStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ListPodSandboxRequest{}
+		v1resp = &criv1.ListPodSandboxResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ListPodSandbox(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, opts ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.CreateContainerRequest{}
+		v1resp = &criv1.CreateContainerResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.CreateContainer(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, opts ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.StartContainerRequest{}
+		v1resp = &criv1.StartContainerResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.StartContainer(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, opts ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.StopContainerRequest{}
+		v1resp = &criv1.StopContainerResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.StopContainer(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, opts ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.RemoveContainerRequest{}
+		v1resp = &criv1.RemoveContainerResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.RemoveContainer(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, opts ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ListContainersRequest{}
+		v1resp = &criv1.ListContainersResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ListContainers(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, opts ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ContainerStatusRequest{}
+		v1resp = &criv1.ContainerStatusResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ContainerStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, opts ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.UpdateContainerResourcesRequest{}
+		v1resp = &criv1.UpdateContainerResourcesResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.UpdateContainerResources(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, opts ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ReopenContainerLogRequest{}
+		v1resp = &criv1.ReopenContainerLogResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ReopenContainerLog(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ExecSyncRequest{}
+		v1resp = &criv1.ExecSyncResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ExecSync(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.CallOption) (*criv1.ExecResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ExecRequest{}
+		v1resp = &criv1.ExecResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.Exec(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...grpc.CallOption) (*criv1.AttachResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.AttachRequest{}
+		v1resp = &criv1.AttachResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.Attach(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, opts ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.PortForwardRequest{}
+		v1resp = &criv1.PortForwardResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.PortForward(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ContainerStatsRequest{}
+		v1resp = &criv1.ContainerStatsResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ContainerStats(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ListContainerStatsRequest{}
+		v1resp = &criv1.ListContainerStatsResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ListContainerStats(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.PodSandboxStatsRequest{}
+		v1resp = &criv1.PodSandboxStatsResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.PodSandboxStats(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ListPodSandboxStatsRequest{}
+		v1resp = &criv1.ListPodSandboxStatsResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.ListPodSandboxStats(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, opts ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.UpdateRuntimeConfigRequest{}
+		v1resp = &criv1.UpdateRuntimeConfigResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.UpdateRuntimeConfig(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...grpc.CallOption) (*criv1.StatusResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.StatusRequest{}
+		v1resp = &criv1.StatusResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.rsc.Status(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+//
+// These are being introduced but they are not defined yet for the
+// CRI API version we are compiling against.
+/*
+func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
+	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
+}
+
+func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetContainerEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
+	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
+}
+
+func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, opts ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
+	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
+}
+
+func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
+	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
+}
+*/
+
+func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, opts ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
+	if err := c.checkImageService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ListImagesRequest{}
+		v1resp = &criv1.ListImagesResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.isc.ListImages(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, opts ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
+	if err := c.checkImageService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ImageStatusRequest{}
+		v1resp = &criv1.ImageStatusResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.isc.ImageStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts ...grpc.CallOption) (*criv1.PullImageResponse, error) {
+	if err := c.checkImageService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.PullImageRequest{}
+		v1resp = &criv1.PullImageResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.isc.PullImage(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, opts ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
+	if err := c.checkImageService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.RemoveImageRequest{}
+		v1resp = &criv1.RemoveImageResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.isc.RemoveImage(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+}
+
+func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, opts ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
+	if err := c.checkImageService(); err != nil {
+		return nil, err
+	}
+
+	var (
+		req    = &criv1alpha2.ImageFsInfoRequest{}
+		v1resp = &criv1.ImageFsInfoResponse{}
+	)
+
+	if err := v1ReqToAlpha(in, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.isc.ImageFsInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := alphaRespToV1(resp, v1resp); err != nil {
+		return nil, err
+	}
+
+	return v1resp, nil
+
+}
+
+func v1ReqToAlpha(
+	v1req interface{ Marshal() ([]byte, error) },
+	alpha interface{ Unmarshal(_ []byte) error },
+) error {
+	p, err := v1req.Marshal()
+	if err != nil {
+		return err
+	}
+
+	if err = alpha.Unmarshal(p); err != nil {
+		return err
+	}
+	return nil
+}
+
+func alphaRespToV1(
+	alpha interface{ Marshal() ([]byte, error) },
+	v1res interface{ Unmarshal(_ []byte) error },
+) error {
+	p, err := alpha.Marshal()
+	if err != nil {
+		return err
+	}
+
+	if err = v1res.Unmarshal(p); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Return a formatted client-specific error.
+func clientError(format string, args ...interface{}) error {
+	return fmt.Errorf("cri/client: "+format, args...)
+}

--- a/pkg/cri/relay/image-service.go
+++ b/pkg/cri/relay/image-service.go
@@ -16,7 +16,8 @@ package relay
 
 import (
 	"context"
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (r *relay) ListImages(ctx context.Context,

--- a/pkg/cri/relay/image-service.go
+++ b/pkg/cri/relay/image-service.go
@@ -17,30 +17,30 @@ package relay
 import (
 	"context"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (r *relay) ListImages(ctx context.Context,
-	req *api.ListImagesRequest) (*api.ListImagesResponse, error) {
+	req *criv1.ListImagesRequest) (*criv1.ListImagesResponse, error) {
 	return r.client.ListImages(ctx, req)
 }
 
 func (r *relay) ImageStatus(ctx context.Context,
-	req *api.ImageStatusRequest) (*api.ImageStatusResponse, error) {
+	req *criv1.ImageStatusRequest) (*criv1.ImageStatusResponse, error) {
 	return r.client.ImageStatus(ctx, req)
 }
 
 func (r *relay) PullImage(ctx context.Context,
-	req *api.PullImageRequest) (*api.PullImageResponse, error) {
+	req *criv1.PullImageRequest) (*criv1.PullImageResponse, error) {
 	return r.client.PullImage(ctx, req)
 }
 
 func (r *relay) RemoveImage(ctx context.Context,
-	req *api.RemoveImageRequest) (*api.RemoveImageResponse, error) {
+	req *criv1.RemoveImageRequest) (*criv1.RemoveImageResponse, error) {
 	return r.client.RemoveImage(ctx, req)
 }
 
 func (r *relay) ImageFsInfo(ctx context.Context,
-	req *api.ImageFsInfoRequest) (*api.ImageFsInfoResponse, error) {
+	req *criv1.ImageFsInfoRequest) (*criv1.ImageFsInfoResponse, error) {
 	return r.client.ImageFsInfo(ctx, req)
 }

--- a/pkg/cri/relay/runtime-service.go
+++ b/pkg/cri/relay/runtime-service.go
@@ -17,7 +17,7 @@ package relay
 import (
 	"context"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/dump"
 )
@@ -164,8 +164,7 @@ func (r *relay) PodSandboxStats(ctx context.Context,
 }
 
 func (r *relay) ListPodSandboxStats(ctx context.Context,
-	req *api.ListPodSandboxStatsRequest) (*api.ListPodSandboxStatsResponse,
-	error) {
+	req *api.ListPodSandboxStatsRequest) (*api.ListPodSandboxStatsResponse, error) {
 	r.dump("ListPodSandboxStats", req)
 	return r.client.ListPodSandboxStats(ctx, req)
 }

--- a/pkg/cri/relay/runtime-service.go
+++ b/pkg/cri/relay/runtime-service.go
@@ -17,7 +17,7 @@ package relay
 import (
 	"context"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/dump"
 )
@@ -38,145 +38,145 @@ func (r *relay) qualifier(msg interface{}) string {
 }
 
 func (r *relay) Version(ctx context.Context,
-	req *api.VersionRequest) (*api.VersionResponse, error) {
+	req *criv1.VersionRequest) (*criv1.VersionResponse, error) {
 	r.dump("Version", req)
 	return r.client.Version(ctx, req)
 }
 
 func (r *relay) RunPodSandbox(ctx context.Context,
-	req *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+	req *criv1.RunPodSandboxRequest) (*criv1.RunPodSandboxResponse, error) {
 	r.dump("RunPodSandbox", req)
 	return r.client.RunPodSandbox(ctx, req)
 }
 
 func (r *relay) StopPodSandbox(ctx context.Context,
-	req *api.StopPodSandboxRequest) (*api.StopPodSandboxResponse, error) {
+	req *criv1.StopPodSandboxRequest) (*criv1.StopPodSandboxResponse, error) {
 	r.dump("StopPodSandbox", req)
 	return r.client.StopPodSandbox(ctx, req)
 }
 
 func (r *relay) RemovePodSandbox(ctx context.Context,
-	req *api.RemovePodSandboxRequest) (*api.RemovePodSandboxResponse, error) {
+	req *criv1.RemovePodSandboxRequest) (*criv1.RemovePodSandboxResponse, error) {
 	r.dump("RemovePodSandbox", req)
 	return r.client.RemovePodSandbox(ctx, req)
 }
 
 func (r *relay) PodSandboxStatus(ctx context.Context,
-	req *api.PodSandboxStatusRequest) (*api.PodSandboxStatusResponse, error) {
+	req *criv1.PodSandboxStatusRequest) (*criv1.PodSandboxStatusResponse, error) {
 	r.dump("PodSandboxStatus", req)
 	return r.client.PodSandboxStatus(ctx, req)
 }
 
 func (r *relay) ListPodSandbox(ctx context.Context,
-	req *api.ListPodSandboxRequest) (*api.ListPodSandboxResponse, error) {
+	req *criv1.ListPodSandboxRequest) (*criv1.ListPodSandboxResponse, error) {
 	r.dump("ListPodSandbox", req)
 	return r.client.ListPodSandbox(ctx, req)
 }
 
 func (r *relay) CreateContainer(ctx context.Context,
-	req *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
+	req *criv1.CreateContainerRequest) (*criv1.CreateContainerResponse, error) {
 	r.dump("CreateContainer", req)
 	return r.client.CreateContainer(ctx, req)
 }
 
 func (r *relay) StartContainer(ctx context.Context,
-	req *api.StartContainerRequest) (*api.StartContainerResponse, error) {
+	req *criv1.StartContainerRequest) (*criv1.StartContainerResponse, error) {
 	r.dump("StartContainer", req)
 	return r.client.StartContainer(ctx, req)
 }
 
 func (r *relay) StopContainer(ctx context.Context,
-	req *api.StopContainerRequest) (*api.StopContainerResponse, error) {
+	req *criv1.StopContainerRequest) (*criv1.StopContainerResponse, error) {
 	r.dump("StopContainer", req)
 	return r.client.StopContainer(ctx, req)
 }
 
 func (r *relay) RemoveContainer(ctx context.Context,
-	req *api.RemoveContainerRequest) (*api.RemoveContainerResponse, error) {
+	req *criv1.RemoveContainerRequest) (*criv1.RemoveContainerResponse, error) {
 	r.dump("RemoveContainer", req)
 	return r.client.RemoveContainer(ctx, req)
 }
 
 func (r *relay) ListContainers(ctx context.Context,
-	req *api.ListContainersRequest) (*api.ListContainersResponse, error) {
+	req *criv1.ListContainersRequest) (*criv1.ListContainersResponse, error) {
 	r.dump("ListContainers", req)
 	return r.client.ListContainers(ctx, req)
 }
 
 func (r *relay) ContainerStatus(ctx context.Context,
-	req *api.ContainerStatusRequest) (*api.ContainerStatusResponse, error) {
+	req *criv1.ContainerStatusRequest) (*criv1.ContainerStatusResponse, error) {
 	r.dump("ContainerStatus", req)
 	return r.client.ContainerStatus(ctx, req)
 }
 
 func (r *relay) UpdateContainerResources(ctx context.Context,
-	req *api.UpdateContainerResourcesRequest) (*api.UpdateContainerResourcesResponse, error) {
+	req *criv1.UpdateContainerResourcesRequest) (*criv1.UpdateContainerResourcesResponse, error) {
 	r.dump("UpdateContainerResources", req)
 	return r.client.UpdateContainerResources(ctx, req)
 }
 
 func (r *relay) ReopenContainerLog(ctx context.Context,
-	req *api.ReopenContainerLogRequest) (*api.ReopenContainerLogResponse, error) {
+	req *criv1.ReopenContainerLogRequest) (*criv1.ReopenContainerLogResponse, error) {
 	r.dump("ReopenContainerLog", req)
 	return r.client.ReopenContainerLog(ctx, req)
 }
 
 func (r *relay) ExecSync(ctx context.Context,
-	req *api.ExecSyncRequest) (*api.ExecSyncResponse, error) {
+	req *criv1.ExecSyncRequest) (*criv1.ExecSyncResponse, error) {
 	r.dump("ExecSync", req)
 	return r.client.ExecSync(ctx, req)
 }
 
 func (r *relay) Exec(ctx context.Context,
-	req *api.ExecRequest) (*api.ExecResponse, error) {
+	req *criv1.ExecRequest) (*criv1.ExecResponse, error) {
 	r.dump("Exec", req)
 	return r.client.Exec(ctx, req)
 }
 
 func (r *relay) Attach(ctx context.Context,
-	req *api.AttachRequest) (*api.AttachResponse, error) {
+	req *criv1.AttachRequest) (*criv1.AttachResponse, error) {
 	r.dump("Attach", req)
 	return r.client.Attach(ctx, req)
 }
 
 func (r *relay) PortForward(ctx context.Context,
-	req *api.PortForwardRequest) (*api.PortForwardResponse, error) {
+	req *criv1.PortForwardRequest) (*criv1.PortForwardResponse, error) {
 	r.dump("PortForward", req)
 	return r.client.PortForward(ctx, req)
 }
 
 func (r *relay) ContainerStats(ctx context.Context,
-	req *api.ContainerStatsRequest) (*api.ContainerStatsResponse, error) {
+	req *criv1.ContainerStatsRequest) (*criv1.ContainerStatsResponse, error) {
 	r.dump("ContainerStats", req)
 	return r.client.ContainerStats(ctx, req)
 }
 
 func (r *relay) ListContainerStats(ctx context.Context,
-	req *api.ListContainerStatsRequest) (*api.ListContainerStatsResponse, error) {
+	req *criv1.ListContainerStatsRequest) (*criv1.ListContainerStatsResponse, error) {
 	r.dump("ListContainerStats", req)
 	return r.client.ListContainerStats(ctx, req)
 }
 
 func (r *relay) PodSandboxStats(ctx context.Context,
-	req *api.PodSandboxStatsRequest) (*api.PodSandboxStatsResponse, error) {
+	req *criv1.PodSandboxStatsRequest) (*criv1.PodSandboxStatsResponse, error) {
 	r.dump("PodSandboxStats", req)
 	return r.client.PodSandboxStats(ctx, req)
 }
 
 func (r *relay) ListPodSandboxStats(ctx context.Context,
-	req *api.ListPodSandboxStatsRequest) (*api.ListPodSandboxStatsResponse, error) {
+	req *criv1.ListPodSandboxStatsRequest) (*criv1.ListPodSandboxStatsResponse, error) {
 	r.dump("ListPodSandboxStats", req)
 	return r.client.ListPodSandboxStats(ctx, req)
 }
 
 func (r *relay) UpdateRuntimeConfig(ctx context.Context,
-	req *api.UpdateRuntimeConfigRequest) (*api.UpdateRuntimeConfigResponse, error) {
+	req *criv1.UpdateRuntimeConfigRequest) (*criv1.UpdateRuntimeConfigResponse, error) {
 	r.dump("UpdateRuntimeConfig", req)
 	return r.client.UpdateRuntimeConfig(ctx, req)
 }
 
 func (r *relay) Status(ctx context.Context,
-	req *api.StatusRequest) (*api.StatusResponse, error) {
+	req *criv1.StatusRequest) (*criv1.StatusResponse, error) {
 	r.dump("Status", req)
 	return r.client.Status(ctx, req)
 }

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/apis/resmgr"

--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -28,7 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	extapi "github.com/intel/cri-resource-manager/pkg/apis/resmgr/v1alpha1"
 )

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -28,13 +28,13 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	extapi "github.com/intel/cri-resource-manager/pkg/apis/resmgr/v1alpha1"
 )
 
 // Create a container for a create request.
-func (c *container) fromCreateRequest(req *cri.CreateContainerRequest) error {
+func (c *container) fromCreateRequest(req *criv1.CreateContainerRequest) error {
 	c.PodID = req.PodSandboxId
 
 	pod, ok := c.cache.Pods[c.PodID]
@@ -142,7 +142,7 @@ func (c *container) fromCreateRequest(req *cri.CreateContainerRequest) error {
 }
 
 // Create container from a container list response.
-func (c *container) fromListResponse(lrc *cri.Container) error {
+func (c *container) fromListResponse(lrc *criv1.Container) error {
 	c.PodID = lrc.PodSandboxId
 
 	pod, ok := c.cache.Pods[c.PodID]
@@ -478,7 +478,7 @@ func (c *container) GetResourceRequirements() v1.ResourceRequirements {
 	return c.Resources
 }
 
-func (c *container) GetLinuxResources() *cri.LinuxContainerResources {
+func (c *container) GetLinuxResources() *criv1.LinuxContainerResources {
 	if c.LinuxReq == nil {
 		return nil
 	}
@@ -640,14 +640,14 @@ func (c *container) GetCpusetMems() string {
 	return c.LinuxReq.CpusetMems
 }
 
-func (c *container) SetLinuxResources(req *cri.LinuxContainerResources) {
+func (c *container) SetLinuxResources(req *criv1.LinuxContainerResources) {
 	c.LinuxReq = req
 	c.markPending(CRI)
 }
 
 func (c *container) SetCPUPeriod(value int64) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.CpuPeriod = value
 	c.markPending(CRI)
@@ -655,7 +655,7 @@ func (c *container) SetCPUPeriod(value int64) {
 
 func (c *container) SetCPUQuota(value int64) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.CpuQuota = value
 	c.markPending(CRI)
@@ -663,7 +663,7 @@ func (c *container) SetCPUQuota(value int64) {
 
 func (c *container) SetCPUShares(value int64) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.CpuShares = value
 	c.markPending(CRI)
@@ -671,7 +671,7 @@ func (c *container) SetCPUShares(value int64) {
 
 func (c *container) SetMemoryLimit(value int64) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.MemoryLimitInBytes = value
 	c.markPending(CRI)
@@ -679,7 +679,7 @@ func (c *container) SetMemoryLimit(value int64) {
 
 func (c *container) SetOomScoreAdj(value int64) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.OomScoreAdj = value
 	c.markPending(CRI)
@@ -687,7 +687,7 @@ func (c *container) SetOomScoreAdj(value int64) {
 
 func (c *container) SetCpusetCpus(value string) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.CpusetCpus = value
 	c.markPending(CRI)
@@ -695,7 +695,7 @@ func (c *container) SetCpusetCpus(value string) {
 
 func (c *container) SetCpusetMems(value string) {
 	if c.LinuxReq == nil {
-		c.LinuxReq = &cri.LinuxContainerResources{}
+		c.LinuxReq = &criv1.LinuxContainerResources{}
 	}
 	c.LinuxReq.CpusetMems = value
 	c.markPending(CRI)
@@ -870,11 +870,11 @@ func (c *container) ClearCRIRequest() (interface{}, bool) {
 	return req, ok
 }
 
-func (c *container) GetCRIEnvs() []*cri.KeyValue {
-	envs := make([]*cri.KeyValue, len(c.Env), len(c.Env))
+func (c *container) GetCRIEnvs() []*criv1.KeyValue {
+	envs := make([]*criv1.KeyValue, len(c.Env), len(c.Env))
 	idx := 0
 	for k, v := range c.Env {
-		envs[idx] = &cri.KeyValue{
+		envs[idx] = &criv1.KeyValue{
 			Key:   k,
 			Value: v,
 		}
@@ -883,33 +883,33 @@ func (c *container) GetCRIEnvs() []*cri.KeyValue {
 	return envs
 }
 
-func (c *container) GetCRIMounts() []*cri.Mount {
+func (c *container) GetCRIMounts() []*criv1.Mount {
 	if c.Mounts == nil {
 		return nil
 	}
-	mounts := make([]*cri.Mount, len(c.Mounts), len(c.Mounts))
+	mounts := make([]*criv1.Mount, len(c.Mounts), len(c.Mounts))
 	idx := 0
 	for _, m := range c.Mounts {
-		mounts[idx] = &cri.Mount{
+		mounts[idx] = &criv1.Mount{
 			ContainerPath:  m.Container,
 			HostPath:       m.Host,
 			Readonly:       m.Readonly,
 			SelinuxRelabel: m.Relabel,
-			Propagation:    cri.MountPropagation(m.Propagation),
+			Propagation:    criv1.MountPropagation(m.Propagation),
 		}
 		idx++
 	}
 	return mounts
 }
 
-func (c *container) GetCRIDevices() []*cri.Device {
+func (c *container) GetCRIDevices() []*criv1.Device {
 	if c.Devices == nil {
 		return nil
 	}
-	devices := make([]*cri.Device, len(c.Devices), len(c.Devices))
+	devices := make([]*criv1.Device, len(c.Devices), len(c.Devices))
 	idx := 0
 	for _, d := range c.Devices {
-		devices[idx] = &cri.Device{
+		devices[idx] = &criv1.Device{
 			ContainerPath: d.Container,
 			HostPath:      d.Host,
 			Permissions:   d.Permissions,

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/apis/resmgr"
 	"github.com/intel/cri-resource-manager/pkg/cgroups"

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/apis/resmgr"
 	"github.com/intel/cri-resource-manager/pkg/cgroups"
@@ -33,7 +33,7 @@ const (
 )
 
 // Create a pod from a run request.
-func (p *pod) fromRunRequest(req *cri.RunPodSandboxRequest) error {
+func (p *pod) fromRunRequest(req *criv1.RunPodSandboxRequest) error {
 	cfg := req.Config
 	if cfg == nil {
 		return cacheError("pod %s has no config", p.ID)
@@ -62,7 +62,7 @@ func (p *pod) fromRunRequest(req *cri.RunPodSandboxRequest) error {
 }
 
 // Create a pod from a list response.
-func (p *pod) fromListResponse(pod *cri.PodSandbox, status *PodStatus) error {
+func (p *pod) fromListResponse(pod *criv1.PodSandbox, status *PodStatus) error {
 	meta := pod.Metadata
 	if meta == nil {
 		return cacheError("pod %s has no reply metadata", p.ID)
@@ -510,7 +510,7 @@ func (p *pod) getTasks(recursive, processes bool) ([]string, error) {
 }
 
 // ParsePodStatus parses a PodSandboxStatusResponse into a PodStatus.
-func ParsePodStatus(response *cri.PodSandboxStatusResponse) (*PodStatus, error) {
+func ParsePodStatus(response *criv1.PodSandboxStatusResponse) (*PodStatus, error) {
 	var name string
 
 	type infoRuntimeSpec struct {

--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
 
 	"github.com/intel/cri-resource-manager/pkg/cgroups"
@@ -42,7 +42,7 @@ func IsPodQOSClassName(class string) bool {
 }
 
 // estimateComputeResources calculates resource requests/limits from a CRI request.
-func estimateComputeResources(lnx *cri.LinuxContainerResources, cgroupParent string) corev1.ResourceRequirements {
+func estimateComputeResources(lnx *criv1.LinuxContainerResources, cgroupParent string) corev1.ResourceRequirements {
 	var qos corev1.PodQOSClass
 
 	resources := corev1.ResourceRequirements{

--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
 
 	"github.com/intel/cri-resource-manager/pkg/cgroups"

--- a/pkg/cri/resource-manager/control/cri/cri.go
+++ b/pkg/cri/resource-manager/control/cri/cri.go
@@ -20,7 +20,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/client"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
-	criapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	criapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )

--- a/pkg/cri/resource-manager/control/cri/cri.go
+++ b/pkg/cri/resource-manager/control/cri/cri.go
@@ -20,7 +20,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/client"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
-	criapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
@@ -75,7 +75,7 @@ func (ctl *crictl) PreCreateHook(c cache.Container) error {
 	if !ok {
 		return criError("pre-create hook: no pending CRI request")
 	}
-	create, ok := request.(*criapi.CreateContainerRequest)
+	create, ok := request.(*criv1.CreateContainerRequest)
 	if !ok {
 		return criError("pre-create hook: pending CRI request of wrong type (%T)", request)
 	}
@@ -88,7 +88,7 @@ func (ctl *crictl) PreCreateHook(c cache.Container) error {
 	create.Config.Mounts = c.GetCRIMounts()
 	create.Config.Devices = c.GetCRIDevices()
 	if create.Config.Linux == nil {
-		create.Config.Linux = &criapi.LinuxContainerConfig{}
+		create.Config.Linux = &criv1.LinuxContainerConfig{}
 	}
 	create.Config.Linux.Resources = c.GetLinuxResources()
 
@@ -109,7 +109,7 @@ func (ctl *crictl) PostStartHook(c cache.Container) error {
 
 // PostUpdateHook is the CRI controller post-update hook.
 func (ctl *crictl) PostUpdateHook(c cache.Container) error {
-	var update *criapi.UpdateContainerResourcesRequest
+	var update *criv1.UpdateContainerResourcesRequest
 
 	if !c.HasPending(CRIController) {
 		log.Debug("post-update hook: no changes for %s", c.PrettyName())
@@ -124,12 +124,12 @@ func (ctl *crictl) PostUpdateHook(c cache.Container) error {
 	}
 	request, ok := c.GetCRIRequest()
 	if !ok {
-		update = &criapi.UpdateContainerResourcesRequest{
+		update = &criv1.UpdateContainerResourcesRequest{
 			ContainerId: c.GetID(),
 		}
 		c.SetCRIRequest(update)
 	} else {
-		if update, ok = request.(*criapi.UpdateContainerResourcesRequest); !ok {
+		if update, ok = request.(*criv1.UpdateContainerResourcesRequest); !ok {
 			return criError("post-update hook: CRI request of wrong type (%T)", request)
 		}
 	}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/intel/goresctrl/pkg/sst"
 	idset "github.com/intel/goresctrl/pkg/utils"
 	v1 "k8s.io/api/core/v1"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/intel/goresctrl/pkg/sst"
 	idset "github.com/intel/goresctrl/pkg/utils"
 	v1 "k8s.io/api/core/v1"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
@@ -376,7 +376,7 @@ func (m *mockContainer) GetDeviceByContainer(string) *cache.Device {
 func (m *mockContainer) GetResourceRequirements() v1.ResourceRequirements {
 	return m.returnValueForGetResourceRequirements
 }
-func (m *mockContainer) GetLinuxResources() *cri.LinuxContainerResources {
+func (m *mockContainer) GetLinuxResources() *criv1.LinuxContainerResources {
 	panic("unimplemented")
 }
 func (m *mockContainer) SetCommand([]string) {
@@ -439,7 +439,7 @@ func (m *mockContainer) GetCpusetCpus() string {
 func (m *mockContainer) GetCpusetMems() string {
 	panic("unimplemented")
 }
-func (m *mockContainer) SetLinuxResources(*cri.LinuxContainerResources) {
+func (m *mockContainer) SetLinuxResources(*criv1.LinuxContainerResources) {
 	panic("unimplemented")
 }
 func (m *mockContainer) SetCPUPeriod(int64) {
@@ -460,10 +460,10 @@ func (m *mockContainer) SetCpusetCpus(string) {
 }
 func (m *mockContainer) SetCpusetMems(string) {
 }
-func (m *mockContainer) UpdateCriCreateRequest(*cri.CreateContainerRequest) error {
+func (m *mockContainer) UpdateCriCreateRequest(*criv1.CreateContainerRequest) error {
 	panic("unimplemented")
 }
-func (m *mockContainer) CriUpdateRequest() (*cri.UpdateContainerResourcesRequest, error) {
+func (m *mockContainer) CriUpdateRequest() (*criv1.UpdateContainerResourcesRequest, error) {
 	panic("unimplemented")
 }
 func (m *mockContainer) GetAffinity() ([]*cache.Affinity, error) {
@@ -502,13 +502,13 @@ func (m *mockContainer) GetCRIRequest() (interface{}, bool) {
 func (m *mockContainer) ClearCRIRequest() (interface{}, bool) {
 	panic("unimplemented")
 }
-func (m *mockContainer) GetCRIEnvs() []*cri.KeyValue {
+func (m *mockContainer) GetCRIEnvs() []*criv1.KeyValue {
 	panic("unimplemented")
 }
-func (m *mockContainer) GetCRIMounts() []*cri.Mount {
+func (m *mockContainer) GetCRIMounts() []*criv1.Mount {
 	panic("unimplemented")
 }
-func (m *mockContainer) GetCRIDevices() []*cri.Device {
+func (m *mockContainer) GetCRIDevices() []*criv1.Device {
 	panic("unimplemented")
 }
 func (m *mockContainer) GetPending() []string {
@@ -735,10 +735,10 @@ func (m *mockCache) SetAdjustment(*config.Adjustment) (bool, map[string]error) {
 func (m *mockCache) Save() error {
 	return nil
 }
-func (m *mockCache) RefreshPods(*cri.ListPodSandboxResponse, map[string]*cache.PodStatus) ([]cache.Pod, []cache.Pod, []cache.Container) {
+func (m *mockCache) RefreshPods(*criv1.ListPodSandboxResponse, map[string]*cache.PodStatus) ([]cache.Pod, []cache.Pod, []cache.Container) {
 	panic("unimplemented")
 }
-func (m *mockCache) RefreshContainers(*cri.ListContainersResponse) ([]cache.Container, []cache.Container) {
+func (m *mockCache) RefreshContainers(*criv1.ListContainersResponse) ([]cache.Container, []cache.Container) {
 	panic("unimplemented")
 }
 func (m *mockCache) ContainerDirectory(string) string {

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	criapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	criapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	criapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
@@ -71,24 +71,24 @@ func (m *resmgr) disambiguate(msg interface{}) string {
 	defer m.RUnlock()
 
 	switch req := msg.(type) {
-	case *criapi.RunPodSandboxRequest:
+	case *criv1.RunPodSandboxRequest:
 		if req.Config != nil && req.Config.Metadata != nil {
 			qualifier = req.Config.Metadata.Name
 		}
-	case *criapi.StopPodSandboxRequest:
+	case *criv1.StopPodSandboxRequest:
 		if pod, ok := m.cache.LookupPod(req.PodSandboxId); ok {
 			qualifier = pod.GetName()
 		} else {
 			qualifier = "unknown pod " + req.PodSandboxId
 		}
-	case *criapi.RemovePodSandboxRequest:
+	case *criv1.RemovePodSandboxRequest:
 		if pod, ok := m.cache.LookupPod(req.PodSandboxId); ok {
 			qualifier = pod.GetName()
 		} else {
 			qualifier = "unknown pod " + req.PodSandboxId
 		}
 
-	case *criapi.CreateContainerRequest:
+	case *criv1.CreateContainerRequest:
 		switch {
 		case req.SandboxConfig == nil || req.SandboxConfig.Metadata == nil:
 			qualifier = "missing pod metadata in request"
@@ -98,26 +98,26 @@ func (m *resmgr) disambiguate(msg interface{}) string {
 			qualifier = req.SandboxConfig.Metadata.Name + ":" + req.Config.Metadata.Name
 		}
 
-	case *criapi.StartContainerRequest:
+	case *criv1.StartContainerRequest:
 		if container, ok := m.cache.LookupContainer(req.ContainerId); ok {
 			qualifier = container.PrettyName()
 		} else {
 			qualifier = "unknown container " + req.ContainerId
 		}
-	case *criapi.StopContainerRequest:
+	case *criv1.StopContainerRequest:
 		if container, ok := m.cache.LookupContainer(req.ContainerId); ok {
 			qualifier = container.PrettyName()
 		} else {
 			qualifier = "unknown container " + req.ContainerId
 		}
-	case *criapi.RemoveContainerRequest:
+	case *criv1.RemoveContainerRequest:
 		if container, ok := m.cache.LookupContainer(req.ContainerId); ok {
 			qualifier = container.PrettyName()
 		} else {
 			qualifier = "unknown container " + req.ContainerId
 		}
 
-	case *criapi.UpdateContainerResourcesRequest:
+	case *criv1.UpdateContainerResourcesRequest:
 		if container, ok := m.cache.LookupContainer(req.ContainerId); ok {
 			qualifier = container.PrettyName()
 		} else {
@@ -175,7 +175,7 @@ func (m *resmgr) syncWithCRI(ctx context.Context) ([]cache.Container, []cache.Co
 	m.Info("synchronizing cache state with CRI runtime...")
 
 	add, del := []cache.Container{}, []cache.Container{}
-	pods, err := m.relay.Client().ListPodSandbox(ctx, &criapi.ListPodSandboxRequest{})
+	pods, err := m.relay.Client().ListPodSandbox(ctx, &criv1.ListPodSandboxRequest{})
 	if err != nil {
 		return nil, nil, resmgrError("cache synchronization pod query failed: %v", err)
 	}
@@ -194,7 +194,7 @@ func (m *resmgr) syncWithCRI(ctx context.Context) ([]cache.Container, []cache.Co
 		del = append(del, c)
 	}
 
-	containers, err := m.relay.Client().ListContainers(ctx, &criapi.ListContainersRequest{})
+	containers, err := m.relay.Client().ListContainers(ctx, &criv1.ListContainersRequest{})
 	if err != nil {
 		return nil, nil, resmgrError("cache synchronization container query failed: %v", err)
 	}
@@ -218,7 +218,7 @@ func (m *resmgr) syncWithCRI(ctx context.Context) ([]cache.Container, []cache.Co
 
 func (m *resmgr) queryPodStatus(ctx context.Context, podID string) (*cache.PodStatus, error) {
 	response, err := m.relay.Client().PodSandboxStatus(ctx,
-		&criapi.PodSandboxStatusRequest{
+		&criv1.PodSandboxStatusRequest{
 			PodSandboxId: podID,
 			Verbose:      true,
 		})
@@ -239,7 +239,7 @@ func (m *resmgr) RunPod(ctx context.Context, method string, request interface{},
 		return reply, rqerr
 	}
 
-	podID := reply.(*criapi.RunPodSandboxResponse).PodSandboxId
+	podID := reply.(*criv1.RunPodSandboxResponse).PodSandboxId
 
 	m.Lock()
 	defer m.Unlock()
@@ -296,7 +296,7 @@ func (m *resmgr) StopPod(ctx context.Context, method string, request interface{}
 	m.Lock()
 	defer m.Unlock()
 
-	podID := request.(*criapi.StopPodSandboxRequest).PodSandboxId
+	podID := request.(*criv1.StopPodSandboxRequest).PodSandboxId
 	pod, ok := m.cache.LookupPod(podID)
 
 	if !ok {
@@ -348,7 +348,7 @@ func (m *resmgr) RemovePod(ctx context.Context, method string, request interface
 	m.Lock()
 	defer m.Unlock()
 
-	podID := request.(*criapi.RemovePodSandboxRequest).PodSandboxId
+	podID := request.(*criv1.RemovePodSandboxRequest).PodSandboxId
 	pod, ok := m.cache.LookupPod(podID)
 
 	if !ok {
@@ -399,7 +399,7 @@ func (m *resmgr) CreateContainer(ctx context.Context, method string, request int
 	defer m.Unlock()
 
 	// kubelet doesn't always clean up crashed containers so we try doing it here
-	if msg, ok := request.(*criapi.CreateContainerRequest); ok {
+	if msg, ok := request.(*criv1.CreateContainerRequest); ok {
 		if pod, ok := m.cache.LookupPod(msg.PodSandboxId); ok {
 			if msg.Config != nil && msg.Config.Metadata != nil {
 				if c, ok := pod.GetContainer(msg.Config.Metadata.Name); ok {
@@ -468,7 +468,7 @@ func (m *resmgr) StartContainer(ctx context.Context, method string, request inte
 	m.Lock()
 	defer m.Unlock()
 
-	containerID := request.(*criapi.StartContainerRequest).ContainerId
+	containerID := request.(*criv1.StartContainerRequest).ContainerId
 	container, ok := m.cache.LookupContainer(containerID)
 
 	if !ok {
@@ -523,7 +523,7 @@ func (m *resmgr) StopContainer(ctx context.Context, method string, request inter
 	m.Lock()
 	defer m.Unlock()
 
-	containerID := request.(*criapi.StopContainerRequest).ContainerId
+	containerID := request.(*criv1.StopContainerRequest).ContainerId
 	container, ok := m.cache.LookupContainer(containerID)
 
 	if !ok {
@@ -569,7 +569,7 @@ func (m *resmgr) RemoveContainer(ctx context.Context, method string, request int
 	m.Lock()
 	defer m.Unlock()
 
-	containerID := request.(*criapi.RemoveContainerRequest).ContainerId
+	containerID := request.(*criv1.RemoveContainerRequest).ContainerId
 	container, ok := m.cache.LookupContainer(containerID)
 
 	if !ok {
@@ -611,7 +611,7 @@ func (m *resmgr) ListContainers(ctx context.Context, method string, request inte
 		return reply, rqerr
 	}
 
-	if f := request.(*criapi.ListContainersRequest).Filter; f != nil {
+	if f := request.(*criv1.ListContainersRequest).Filter; f != nil {
 		if f.Id != "" || f.State != nil || f.PodSandboxId != "" || len(f.LabelSelector) > 0 {
 			return reply, nil
 		}
@@ -620,11 +620,11 @@ func (m *resmgr) ListContainers(ctx context.Context, method string, request inte
 	m.Lock()
 	defer m.Unlock()
 
-	clistmap := map[string]*criapi.Container{}
+	clistmap := map[string]*criv1.Container{}
 	released := []cache.Container{}
-	for _, listed := range reply.(*criapi.ListContainersResponse).Containers {
+	for _, listed := range reply.(*criv1.ListContainersResponse).Containers {
 		clistmap[listed.Id] = listed
-		if listed.State != criapi.ContainerState_CONTAINER_EXITED {
+		if listed.State != criv1.ContainerState_CONTAINER_EXITED {
 			continue
 		}
 		if c, ok := m.cache.LookupContainer(listed.Id); ok {
@@ -673,7 +673,7 @@ func (m *resmgr) UpdateContainer(ctx context.Context, method string, request int
 	m.Lock()
 	defer m.Unlock()
 
-	containerID := request.(*criapi.UpdateContainerResourcesRequest).ContainerId
+	containerID := request.(*criv1.UpdateContainerResourcesRequest).ContainerId
 	container, ok := m.cache.LookupContainer(containerID)
 
 	if !ok {
@@ -688,7 +688,7 @@ func (m *resmgr) UpdateContainer(ctx context.Context, method string, request int
 
 	m.updateIntrospection()
 
-	return &criapi.UpdateContainerResourcesResponse{}, nil
+	return &criv1.UpdateContainerResourcesResponse{}, nil
 }
 
 // RebalanceContainers tries to find a more optimal container resource allocation if necessary.
@@ -904,8 +904,8 @@ func (m *resmgr) runPostUpdateHooks(ctx context.Context, method string) error {
 func (m *resmgr) sendCRIRequest(ctx context.Context, request interface{}) (interface{}, error) {
 	client := m.relay.Client()
 	switch request.(type) {
-	case *criapi.UpdateContainerResourcesRequest:
-		req := request.(*criapi.UpdateContainerResourcesRequest)
+	case *criv1.UpdateContainerResourcesRequest:
+		req := request.(*criv1.UpdateContainerResourcesRequest)
 		m.Debug("sending update request for container %s...", req.ContainerId)
 		return client.UpdateContainerResources(ctx, req)
 	default:
@@ -914,7 +914,7 @@ func (m *resmgr) sendCRIRequest(ctx context.Context, request interface{}) (inter
 }
 
 func (m *resmgr) checkRuntime(ctx context.Context) error {
-	version, err := m.relay.Client().Version(ctx, &criapi.VersionRequest{
+	version, err := m.relay.Client().Version(ctx, &criv1.VersionRequest{
 		Version: kubeAPIVersion,
 	})
 	if err != nil {

--- a/pkg/cri/server/server.go
+++ b/pkg/cri/server/server.go
@@ -27,7 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
 	"github.com/intel/cri-resource-manager/pkg/dump"

--- a/pkg/cri/server/services.go
+++ b/pkg/cri/server/services.go
@@ -20,11 +20,11 @@ import (
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (
-	apiVersion = "v1alpha2"
+	apiVersion = "v1"
 
 	imageService = "ImageService"
 	listImages   = "ListImages"

--- a/pkg/cri/server/services.go
+++ b/pkg/cri/server/services.go
@@ -20,7 +20,7 @@ import (
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
 
-	api "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (
@@ -78,406 +78,406 @@ func (s *server) interceptRequest(ctx context.Context, service, method string,
 }
 
 func (s *server) ListImages(ctx context.Context,
-	req *api.ListImagesRequest) (*api.ListImagesResponse, error) {
+	req *criv1.ListImagesRequest) (*criv1.ListImagesResponse, error) {
 	rsp, err := s.interceptRequest(ctx, imageService, listImages, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.image).ListImages(ctx, req.(*api.ListImagesRequest))
+			return (*s.image).ListImages(ctx, req.(*criv1.ListImagesRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ListImagesResponse), err
+	return rsp.(*criv1.ListImagesResponse), err
 }
 
 func (s *server) ImageStatus(ctx context.Context,
-	req *api.ImageStatusRequest) (*api.ImageStatusResponse, error) {
+	req *criv1.ImageStatusRequest) (*criv1.ImageStatusResponse, error) {
 	rsp, err := s.interceptRequest(ctx, imageService, imageStatus, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.image).ImageStatus(ctx, req.(*api.ImageStatusRequest))
+			return (*s.image).ImageStatus(ctx, req.(*criv1.ImageStatusRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ImageStatusResponse), err
+	return rsp.(*criv1.ImageStatusResponse), err
 }
 
 func (s *server) PullImage(ctx context.Context,
-	req *api.PullImageRequest) (*api.PullImageResponse, error) {
+	req *criv1.PullImageRequest) (*criv1.PullImageResponse, error) {
 	rsp, err := s.interceptRequest(ctx, imageService, pullImage, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.image).PullImage(ctx, req.(*api.PullImageRequest))
+			return (*s.image).PullImage(ctx, req.(*criv1.PullImageRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.PullImageResponse), err
+	return rsp.(*criv1.PullImageResponse), err
 }
 
 func (s *server) RemoveImage(ctx context.Context,
-	req *api.RemoveImageRequest) (*api.RemoveImageResponse, error) {
+	req *criv1.RemoveImageRequest) (*criv1.RemoveImageResponse, error) {
 	rsp, err := s.interceptRequest(ctx, imageService, removeImage, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.image).RemoveImage(ctx, req.(*api.RemoveImageRequest))
+			return (*s.image).RemoveImage(ctx, req.(*criv1.RemoveImageRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.RemoveImageResponse), err
+	return rsp.(*criv1.RemoveImageResponse), err
 }
 
 func (s *server) ImageFsInfo(ctx context.Context,
-	req *api.ImageFsInfoRequest) (*api.ImageFsInfoResponse, error) {
+	req *criv1.ImageFsInfoRequest) (*criv1.ImageFsInfoResponse, error) {
 	rsp, err := s.interceptRequest(ctx, imageService, imageFsInfo, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.image).ImageFsInfo(ctx, req.(*api.ImageFsInfoRequest))
+			return (*s.image).ImageFsInfo(ctx, req.(*criv1.ImageFsInfoRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ImageFsInfoResponse), err
+	return rsp.(*criv1.ImageFsInfoResponse), err
 }
 
 func (s *server) Version(ctx context.Context,
-	req *api.VersionRequest) (*api.VersionResponse, error) {
+	req *criv1.VersionRequest) (*criv1.VersionResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, version, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).Version(ctx, req.(*api.VersionRequest))
+			return (*s.runtime).Version(ctx, req.(*criv1.VersionRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.VersionResponse), err
+	return rsp.(*criv1.VersionResponse), err
 }
 
 func (s *server) RunPodSandbox(ctx context.Context,
-	req *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+	req *criv1.RunPodSandboxRequest) (*criv1.RunPodSandboxResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, runPodSandbox, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).RunPodSandbox(ctx, req.(*api.RunPodSandboxRequest))
+			return (*s.runtime).RunPodSandbox(ctx, req.(*criv1.RunPodSandboxRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.RunPodSandboxResponse), err
+	return rsp.(*criv1.RunPodSandboxResponse), err
 }
 
 func (s *server) StopPodSandbox(ctx context.Context,
-	req *api.StopPodSandboxRequest) (*api.StopPodSandboxResponse, error) {
+	req *criv1.StopPodSandboxRequest) (*criv1.StopPodSandboxResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, stopPodSandbox, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).StopPodSandbox(ctx, req.(*api.StopPodSandboxRequest))
+			return (*s.runtime).StopPodSandbox(ctx, req.(*criv1.StopPodSandboxRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.StopPodSandboxResponse), err
+	return rsp.(*criv1.StopPodSandboxResponse), err
 }
 
 func (s *server) RemovePodSandbox(ctx context.Context,
-	req *api.RemovePodSandboxRequest) (*api.RemovePodSandboxResponse, error) {
+	req *criv1.RemovePodSandboxRequest) (*criv1.RemovePodSandboxResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, removePodSandbox, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).RemovePodSandbox(ctx, req.(*api.RemovePodSandboxRequest))
+			return (*s.runtime).RemovePodSandbox(ctx, req.(*criv1.RemovePodSandboxRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.RemovePodSandboxResponse), err
+	return rsp.(*criv1.RemovePodSandboxResponse), err
 }
 
 func (s *server) PodSandboxStatus(ctx context.Context,
-	req *api.PodSandboxStatusRequest) (*api.PodSandboxStatusResponse, error) {
+	req *criv1.PodSandboxStatusRequest) (*criv1.PodSandboxStatusResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, podSandboxStatus, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).PodSandboxStatus(ctx, req.(*api.PodSandboxStatusRequest))
+			return (*s.runtime).PodSandboxStatus(ctx, req.(*criv1.PodSandboxStatusRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.PodSandboxStatusResponse), err
+	return rsp.(*criv1.PodSandboxStatusResponse), err
 }
 
 func (s *server) ListPodSandbox(ctx context.Context,
-	req *api.ListPodSandboxRequest) (*api.ListPodSandboxResponse, error) {
+	req *criv1.ListPodSandboxRequest) (*criv1.ListPodSandboxResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, listPodSandbox, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ListPodSandbox(ctx, req.(*api.ListPodSandboxRequest))
+			return (*s.runtime).ListPodSandbox(ctx, req.(*criv1.ListPodSandboxRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ListPodSandboxResponse), err
+	return rsp.(*criv1.ListPodSandboxResponse), err
 }
 
 func (s *server) CreateContainer(ctx context.Context,
-	req *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
+	req *criv1.CreateContainerRequest) (*criv1.CreateContainerResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, createContainer, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).CreateContainer(ctx, req.(*api.CreateContainerRequest))
+			return (*s.runtime).CreateContainer(ctx, req.(*criv1.CreateContainerRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.CreateContainerResponse), err
+	return rsp.(*criv1.CreateContainerResponse), err
 }
 
 func (s *server) StartContainer(ctx context.Context,
-	req *api.StartContainerRequest) (*api.StartContainerResponse, error) {
+	req *criv1.StartContainerRequest) (*criv1.StartContainerResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, startContainer, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).StartContainer(ctx, req.(*api.StartContainerRequest))
+			return (*s.runtime).StartContainer(ctx, req.(*criv1.StartContainerRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.StartContainerResponse), err
+	return rsp.(*criv1.StartContainerResponse), err
 }
 
 func (s *server) StopContainer(ctx context.Context,
-	req *api.StopContainerRequest) (*api.StopContainerResponse, error) {
+	req *criv1.StopContainerRequest) (*criv1.StopContainerResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, stopContainer, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).StopContainer(ctx, req.(*api.StopContainerRequest))
+			return (*s.runtime).StopContainer(ctx, req.(*criv1.StopContainerRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.StopContainerResponse), err
+	return rsp.(*criv1.StopContainerResponse), err
 }
 
 func (s *server) RemoveContainer(ctx context.Context,
-	req *api.RemoveContainerRequest) (*api.RemoveContainerResponse, error) {
+	req *criv1.RemoveContainerRequest) (*criv1.RemoveContainerResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, removeContainer, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).RemoveContainer(ctx, req.(*api.RemoveContainerRequest))
+			return (*s.runtime).RemoveContainer(ctx, req.(*criv1.RemoveContainerRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.RemoveContainerResponse), err
+	return rsp.(*criv1.RemoveContainerResponse), err
 }
 
 func (s *server) ListContainers(ctx context.Context,
-	req *api.ListContainersRequest) (*api.ListContainersResponse, error) {
+	req *criv1.ListContainersRequest) (*criv1.ListContainersResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, listContainers, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ListContainers(ctx, req.(*api.ListContainersRequest))
+			return (*s.runtime).ListContainers(ctx, req.(*criv1.ListContainersRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ListContainersResponse), err
+	return rsp.(*criv1.ListContainersResponse), err
 }
 
 func (s *server) ContainerStatus(ctx context.Context,
-	req *api.ContainerStatusRequest) (*api.ContainerStatusResponse, error) {
+	req *criv1.ContainerStatusRequest) (*criv1.ContainerStatusResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, containerStatus, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ContainerStatus(ctx, req.(*api.ContainerStatusRequest))
+			return (*s.runtime).ContainerStatus(ctx, req.(*criv1.ContainerStatusRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ContainerStatusResponse), err
+	return rsp.(*criv1.ContainerStatusResponse), err
 }
 
 func (s *server) UpdateContainerResources(ctx context.Context,
-	req *api.UpdateContainerResourcesRequest) (*api.UpdateContainerResourcesResponse, error) {
+	req *criv1.UpdateContainerResourcesRequest) (*criv1.UpdateContainerResourcesResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, updateContainerResources, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
 			return (*s.runtime).UpdateContainerResources(ctx,
-				req.(*api.UpdateContainerResourcesRequest))
+				req.(*criv1.UpdateContainerResourcesRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.UpdateContainerResourcesResponse), err
+	return rsp.(*criv1.UpdateContainerResourcesResponse), err
 }
 
 func (s *server) ReopenContainerLog(ctx context.Context,
-	req *api.ReopenContainerLogRequest) (*api.ReopenContainerLogResponse, error) {
+	req *criv1.ReopenContainerLogRequest) (*criv1.ReopenContainerLogResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, reopenContainerLog, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ReopenContainerLog(ctx, req.(*api.ReopenContainerLogRequest))
+			return (*s.runtime).ReopenContainerLog(ctx, req.(*criv1.ReopenContainerLogRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ReopenContainerLogResponse), err
+	return rsp.(*criv1.ReopenContainerLogResponse), err
 }
 
 func (s *server) ExecSync(ctx context.Context,
-	req *api.ExecSyncRequest) (*api.ExecSyncResponse, error) {
+	req *criv1.ExecSyncRequest) (*criv1.ExecSyncResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, execSync, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ExecSync(ctx, req.(*api.ExecSyncRequest))
+			return (*s.runtime).ExecSync(ctx, req.(*criv1.ExecSyncRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ExecSyncResponse), err
+	return rsp.(*criv1.ExecSyncResponse), err
 }
 
 func (s *server) Exec(ctx context.Context,
-	req *api.ExecRequest) (*api.ExecResponse, error) {
+	req *criv1.ExecRequest) (*criv1.ExecResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, exec, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).Exec(ctx, req.(*api.ExecRequest))
+			return (*s.runtime).Exec(ctx, req.(*criv1.ExecRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ExecResponse), err
+	return rsp.(*criv1.ExecResponse), err
 }
 
 func (s *server) Attach(ctx context.Context,
-	req *api.AttachRequest) (*api.AttachResponse, error) {
+	req *criv1.AttachRequest) (*criv1.AttachResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, attach, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).Attach(ctx, req.(*api.AttachRequest))
+			return (*s.runtime).Attach(ctx, req.(*criv1.AttachRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.AttachResponse), err
+	return rsp.(*criv1.AttachResponse), err
 }
 
 func (s *server) PortForward(ctx context.Context,
-	req *api.PortForwardRequest) (*api.PortForwardResponse, error) {
+	req *criv1.PortForwardRequest) (*criv1.PortForwardResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, portForward, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).PortForward(ctx, req.(*api.PortForwardRequest))
+			return (*s.runtime).PortForward(ctx, req.(*criv1.PortForwardRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.PortForwardResponse), err
+	return rsp.(*criv1.PortForwardResponse), err
 }
 
 func (s *server) ContainerStats(ctx context.Context,
-	req *api.ContainerStatsRequest) (*api.ContainerStatsResponse, error) {
+	req *criv1.ContainerStatsRequest) (*criv1.ContainerStatsResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, containerStats, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ContainerStats(ctx, req.(*api.ContainerStatsRequest))
+			return (*s.runtime).ContainerStats(ctx, req.(*criv1.ContainerStatsRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ContainerStatsResponse), err
+	return rsp.(*criv1.ContainerStatsResponse), err
 }
 
 func (s *server) ListContainerStats(ctx context.Context,
-	req *api.ListContainerStatsRequest) (*api.ListContainerStatsResponse, error) {
+	req *criv1.ListContainerStatsRequest) (*criv1.ListContainerStatsResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, listContainerStats, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ListContainerStats(ctx, req.(*api.ListContainerStatsRequest))
+			return (*s.runtime).ListContainerStats(ctx, req.(*criv1.ListContainerStatsRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ListContainerStatsResponse), err
+	return rsp.(*criv1.ListContainerStatsResponse), err
 }
 
-func (s *server) PodSandboxStats(ctx context.Context, req *api.PodSandboxStatsRequest) (*api.PodSandboxStatsResponse, error) {
+func (s *server) PodSandboxStats(ctx context.Context, req *criv1.PodSandboxStatsRequest) (*criv1.PodSandboxStatsResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, podSandboxStats, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).PodSandboxStats(ctx, req.(*api.PodSandboxStatsRequest))
+			return (*s.runtime).PodSandboxStats(ctx, req.(*criv1.PodSandboxStatsRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.PodSandboxStatsResponse), err
+	return rsp.(*criv1.PodSandboxStatsResponse), err
 }
 
-func (s *server) ListPodSandboxStats(ctx context.Context, req *api.ListPodSandboxStatsRequest) (*api.ListPodSandboxStatsResponse, error) {
+func (s *server) ListPodSandboxStats(ctx context.Context, req *criv1.ListPodSandboxStatsRequest) (*criv1.ListPodSandboxStatsResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, listPodSandboxStats, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).ListPodSandboxStats(ctx, req.(*api.ListPodSandboxStatsRequest))
+			return (*s.runtime).ListPodSandboxStats(ctx, req.(*criv1.ListPodSandboxStatsRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.ListPodSandboxStatsResponse), err
+	return rsp.(*criv1.ListPodSandboxStatsResponse), err
 }
 
 func (s *server) UpdateRuntimeConfig(ctx context.Context,
-	req *api.UpdateRuntimeConfigRequest) (*api.UpdateRuntimeConfigResponse, error) {
+	req *criv1.UpdateRuntimeConfigRequest) (*criv1.UpdateRuntimeConfigResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, updateRuntimeConfig, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).UpdateRuntimeConfig(ctx, req.(*api.UpdateRuntimeConfigRequest))
+			return (*s.runtime).UpdateRuntimeConfig(ctx, req.(*criv1.UpdateRuntimeConfigRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.UpdateRuntimeConfigResponse), err
+	return rsp.(*criv1.UpdateRuntimeConfigResponse), err
 }
 
 func (s *server) Status(ctx context.Context,
-	req *api.StatusRequest) (*api.StatusResponse, error) {
+	req *criv1.StatusRequest) (*criv1.StatusResponse, error) {
 	rsp, err := s.interceptRequest(ctx, runtimeService, status, req,
 		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return (*s.runtime).Status(ctx, req.(*api.StatusRequest))
+			return (*s.runtime).Status(ctx, req.(*criv1.StatusRequest))
 		})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rsp.(*api.StatusResponse), err
+	return rsp.(*criv1.StatusResponse), err
 }

--- a/pkg/cri/server/v1alpha2/server.go
+++ b/pkg/cri/server/v1alpha2/server.go
@@ -1,0 +1,747 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1alpha2 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+type Server struct {
+	server  *grpc.Server
+	runtime criv1.RuntimeServiceServer
+	image   criv1.ImageServiceServer
+}
+
+func NewServer(s *grpc.Server) *Server {
+	return &Server{
+		server: s,
+	}
+}
+
+func (s *Server) RegisterImageService(image criv1.ImageServiceServer) {
+	if s == nil {
+		return
+	}
+	s.image = image
+	criv1alpha2.RegisterImageServiceServer(s.server, s)
+}
+
+func (s *Server) RegisterRuntimeService(runtime criv1.RuntimeServiceServer) {
+	if s == nil {
+		return
+	}
+	s.runtime = runtime
+	criv1alpha2.RegisterRuntimeServiceServer(s.server, s)
+}
+
+func (s *Server) ListImages(ctx context.Context,
+	in *criv1alpha2.ListImagesRequest) (*criv1alpha2.ListImagesResponse, error) {
+	var (
+		v1req     = &criv1.ListImagesRequest{}
+		alpharesp = &criv1alpha2.ListImagesResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.image.ListImages(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ImageStatus(ctx context.Context,
+	in *criv1alpha2.ImageStatusRequest) (*criv1alpha2.ImageStatusResponse, error) {
+	var (
+		v1req     = &criv1.ImageStatusRequest{}
+		alpharesp = &criv1alpha2.ImageStatusResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.image.ImageStatus(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) PullImage(ctx context.Context,
+	in *criv1alpha2.PullImageRequest) (*criv1alpha2.PullImageResponse, error) {
+	var (
+		v1req     = &criv1.PullImageRequest{}
+		alpharesp = &criv1alpha2.PullImageResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.image.PullImage(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) RemoveImage(ctx context.Context,
+	in *criv1alpha2.RemoveImageRequest) (*criv1alpha2.RemoveImageResponse, error) {
+	var (
+		v1req     = &criv1.RemoveImageRequest{}
+		alpharesp = &criv1alpha2.RemoveImageResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.image.RemoveImage(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ImageFsInfo(ctx context.Context,
+	in *criv1alpha2.ImageFsInfoRequest) (*criv1alpha2.ImageFsInfoResponse, error) {
+	var (
+		v1req     = &criv1.ImageFsInfoRequest{}
+		alpharesp = &criv1alpha2.ImageFsInfoResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.image.ImageFsInfo(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) Version(ctx context.Context,
+	in *criv1alpha2.VersionRequest) (*criv1alpha2.VersionResponse, error) {
+	var (
+		v1req     = &criv1.VersionRequest{}
+		alpharesp = &criv1alpha2.VersionResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.Version(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) RunPodSandbox(ctx context.Context,
+	in *criv1alpha2.RunPodSandboxRequest) (*criv1alpha2.RunPodSandboxResponse, error) {
+	var (
+		v1req     = &criv1.RunPodSandboxRequest{}
+		alpharesp = &criv1alpha2.RunPodSandboxResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.RunPodSandbox(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) StopPodSandbox(ctx context.Context,
+	in *criv1alpha2.StopPodSandboxRequest) (*criv1alpha2.StopPodSandboxResponse, error) {
+	var (
+		v1req     = &criv1.StopPodSandboxRequest{}
+		alpharesp = &criv1alpha2.StopPodSandboxResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.StopPodSandbox(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) RemovePodSandbox(ctx context.Context,
+	in *criv1alpha2.RemovePodSandboxRequest) (*criv1alpha2.RemovePodSandboxResponse, error) {
+	var (
+		v1req     = &criv1.RemovePodSandboxRequest{}
+		alpharesp = &criv1alpha2.RemovePodSandboxResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.RemovePodSandbox(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) PodSandboxStatus(ctx context.Context,
+	in *criv1alpha2.PodSandboxStatusRequest) (*criv1alpha2.PodSandboxStatusResponse, error) {
+	var (
+		v1req     = &criv1.PodSandboxStatusRequest{}
+		alpharesp = &criv1alpha2.PodSandboxStatusResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.PodSandboxStatus(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ListPodSandbox(ctx context.Context,
+	in *criv1alpha2.ListPodSandboxRequest) (*criv1alpha2.ListPodSandboxResponse, error) {
+	var (
+		v1req     = &criv1.ListPodSandboxRequest{}
+		alpharesp = &criv1alpha2.ListPodSandboxResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ListPodSandbox(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) CreateContainer(ctx context.Context,
+	in *criv1alpha2.CreateContainerRequest) (*criv1alpha2.CreateContainerResponse, error) {
+	var (
+		v1req     = &criv1.CreateContainerRequest{}
+		alpharesp = &criv1alpha2.CreateContainerResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.CreateContainer(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) StartContainer(ctx context.Context,
+	in *criv1alpha2.StartContainerRequest) (*criv1alpha2.StartContainerResponse, error) {
+	var (
+		v1req     = &criv1.StartContainerRequest{}
+		alpharesp = &criv1alpha2.StartContainerResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.StartContainer(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) StopContainer(ctx context.Context,
+	in *criv1alpha2.StopContainerRequest) (*criv1alpha2.StopContainerResponse, error) {
+	var (
+		v1req     = &criv1.StopContainerRequest{}
+		alpharesp = &criv1alpha2.StopContainerResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.StopContainer(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) RemoveContainer(ctx context.Context,
+	in *criv1alpha2.RemoveContainerRequest) (*criv1alpha2.RemoveContainerResponse, error) {
+	var (
+		v1req     = &criv1.RemoveContainerRequest{}
+		alpharesp = &criv1alpha2.RemoveContainerResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.RemoveContainer(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ListContainers(ctx context.Context,
+	in *criv1alpha2.ListContainersRequest) (*criv1alpha2.ListContainersResponse, error) {
+	var (
+		v1req     = &criv1.ListContainersRequest{}
+		alpharesp = &criv1alpha2.ListContainersResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ListContainers(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ContainerStatus(ctx context.Context,
+	in *criv1alpha2.ContainerStatusRequest) (*criv1alpha2.ContainerStatusResponse, error) {
+	var (
+		v1req     = &criv1.ContainerStatusRequest{}
+		alpharesp = &criv1alpha2.ContainerStatusResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ContainerStatus(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) UpdateContainerResources(ctx context.Context,
+	in *criv1alpha2.UpdateContainerResourcesRequest) (*criv1alpha2.UpdateContainerResourcesResponse, error) {
+	var (
+		v1req     = &criv1.UpdateContainerResourcesRequest{}
+		alpharesp = &criv1alpha2.UpdateContainerResourcesResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.UpdateContainerResources(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ReopenContainerLog(ctx context.Context,
+	in *criv1alpha2.ReopenContainerLogRequest) (*criv1alpha2.ReopenContainerLogResponse, error) {
+	var (
+		v1req     = &criv1.ReopenContainerLogRequest{}
+		alpharesp = &criv1alpha2.ReopenContainerLogResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ReopenContainerLog(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ExecSync(ctx context.Context,
+	in *criv1alpha2.ExecSyncRequest) (*criv1alpha2.ExecSyncResponse, error) {
+	var (
+		v1req     = &criv1.ExecSyncRequest{}
+		alpharesp = &criv1alpha2.ExecSyncResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ExecSync(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) Exec(ctx context.Context,
+	in *criv1alpha2.ExecRequest) (*criv1alpha2.ExecResponse, error) {
+	var (
+		v1req     = &criv1.ExecRequest{}
+		alpharesp = &criv1alpha2.ExecResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.Exec(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) Attach(ctx context.Context,
+	in *criv1alpha2.AttachRequest) (*criv1alpha2.AttachResponse, error) {
+	var (
+		v1req     = &criv1.AttachRequest{}
+		alpharesp = &criv1alpha2.AttachResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.Attach(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) PortForward(ctx context.Context,
+	in *criv1alpha2.PortForwardRequest) (*criv1alpha2.PortForwardResponse, error) {
+	var (
+		v1req     = &criv1.PortForwardRequest{}
+		alpharesp = &criv1alpha2.PortForwardResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.PortForward(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ContainerStats(ctx context.Context,
+	in *criv1alpha2.ContainerStatsRequest) (*criv1alpha2.ContainerStatsResponse, error) {
+	var (
+		v1req     = &criv1.ContainerStatsRequest{}
+		alpharesp = &criv1alpha2.ContainerStatsResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ContainerStats(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ListContainerStats(ctx context.Context,
+	in *criv1alpha2.ListContainerStatsRequest) (*criv1alpha2.ListContainerStatsResponse, error) {
+	var (
+		v1req     = &criv1.ListContainerStatsRequest{}
+		alpharesp = &criv1alpha2.ListContainerStatsResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ListContainerStats(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) PodSandboxStats(ctx context.Context, in *criv1alpha2.PodSandboxStatsRequest) (*criv1alpha2.PodSandboxStatsResponse, error) {
+	var (
+		v1req     = &criv1.PodSandboxStatsRequest{}
+		alpharesp = &criv1alpha2.PodSandboxStatsResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.PodSandboxStats(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) ListPodSandboxStats(ctx context.Context, in *criv1alpha2.ListPodSandboxStatsRequest) (*criv1alpha2.ListPodSandboxStatsResponse, error) {
+	var (
+		v1req     = &criv1.ListPodSandboxStatsRequest{}
+		alpharesp = &criv1alpha2.ListPodSandboxStatsResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.ListPodSandboxStats(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) UpdateRuntimeConfig(ctx context.Context,
+	in *criv1alpha2.UpdateRuntimeConfigRequest) (*criv1alpha2.UpdateRuntimeConfigResponse, error) {
+	var (
+		v1req     = &criv1.UpdateRuntimeConfigRequest{}
+		alpharesp = &criv1alpha2.UpdateRuntimeConfigResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.UpdateRuntimeConfig(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func (s *Server) Status(ctx context.Context,
+	in *criv1alpha2.StatusRequest) (*criv1alpha2.StatusResponse, error) {
+	var (
+		v1req     = &criv1.StatusRequest{}
+		alpharesp = &criv1alpha2.StatusResponse{}
+	)
+
+	if err := alphaReqToV1(in, v1req); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.runtime.Status(ctx, v1req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v1RespToAlpha(resp, alpharesp); err != nil {
+		return nil, err
+	}
+
+	return alpharesp, nil
+}
+
+func alphaReqToV1(
+	alpha interface{ Marshal() ([]byte, error) },
+	v1req interface{ Unmarshal(_ []byte) error },
+) error {
+	p, err := alpha.Marshal()
+	if err != nil {
+		return err
+	}
+
+	if err = v1req.Unmarshal(p); err != nil {
+		return err
+	}
+	return nil
+}
+
+func v1RespToAlpha(
+	v1res interface{ Marshal() ([]byte, error) },
+	alpha interface{ Unmarshal(_ []byte) error },
+) error {
+	p, err := v1res.Marshal()
+	if err != nil {
+		return err
+	}
+
+	if err = alpha.Unmarshal(p); err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/functional/e2e_test.go
+++ b/test/functional/e2e_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/dump"
 	"google.golang.org/grpc"
-	api "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )
@@ -52,7 +52,7 @@ func init() {
 type testEnv struct {
 	t           *testing.T
 	handlers    map[string]interface{}
-	client      api.RuntimeServiceClient
+	client      criv1.RuntimeServiceClient
 	forceConfig string
 	mgr         resmgr.ResourceManager
 	cache       cache.Cache
@@ -132,7 +132,7 @@ func (env *testEnv) Run(name string, testFunction func(context.Context, *testEnv
 		}
 		defer conn.Close()
 
-		client := api.NewRuntimeServiceClient(conn)
+		client := criv1.NewRuntimeServiceClient(conn)
 
 		env.client = client
 		env.mgr = resMgr
@@ -149,7 +149,7 @@ func (env *testEnv) Run(name string, testFunction func(context.Context, *testEnv
 func TestListPodSandbox(t *testing.T) {
 	tcases := []struct {
 		name         string
-		pods         []*api.PodSandbox
+		pods         []*criv1.PodSandbox
 		expectedPods int
 	}{
 		{
@@ -157,14 +157,14 @@ func TestListPodSandbox(t *testing.T) {
 		},
 		{
 			name:         "list one pod",
-			pods:         []*api.PodSandbox{{}},
+			pods:         []*criv1.PodSandbox{{}},
 			expectedPods: 1,
 		},
 	}
 	for _, tc := range tcases {
 		criHandlers := map[string]interface{}{
-			"ListPodSandbox": func(*fakeCriServer, context.Context, *api.ListPodSandboxRequest) (*api.ListPodSandboxResponse, error) {
-				return &api.ListPodSandboxResponse{
+			"ListPodSandbox": func(*fakeCriServer, context.Context, *criv1.ListPodSandboxRequest) (*criv1.ListPodSandboxResponse, error) {
+				return &criv1.ListPodSandboxResponse{
 					Items: tc.pods,
 				}, nil
 			},
@@ -176,7 +176,7 @@ func TestListPodSandbox(t *testing.T) {
 		env.Run(tc.name, func(ctx context.Context, env *testEnv) {
 			t := env.t
 			client := env.client
-			resp, err := client.ListPodSandbox(ctx, &api.ListPodSandboxRequest{})
+			resp, err := client.ListPodSandbox(ctx, &criv1.ListPodSandboxRequest{})
 			if err != nil {
 				t.Errorf("Unexpected error: %+v", err)
 				return
@@ -191,7 +191,7 @@ func TestListPodSandbox(t *testing.T) {
 func TestListContainers(t *testing.T) {
 	tcases := []struct {
 		name               string
-		containers         []*api.Container
+		containers         []*criv1.Container
 		expectedContainers int
 	}{
 		{
@@ -199,14 +199,14 @@ func TestListContainers(t *testing.T) {
 		},
 		{
 			name:               "list one container",
-			containers:         []*api.Container{{}},
+			containers:         []*criv1.Container{{}},
 			expectedContainers: 1,
 		},
 	}
 	for _, tc := range tcases {
 		criHandlers := map[string]interface{}{
-			"ListContainers": func(*fakeCriServer, context.Context, *api.ListContainersRequest) (*api.ListContainersResponse, error) {
-				return &api.ListContainersResponse{
+			"ListContainers": func(*fakeCriServer, context.Context, *criv1.ListContainersRequest) (*criv1.ListContainersResponse, error) {
+				return &criv1.ListContainersResponse{
 					Containers: tc.containers,
 				}, nil
 			},
@@ -218,7 +218,7 @@ func TestListContainers(t *testing.T) {
 		env.Run(tc.name, func(ctx context.Context, env *testEnv) {
 			t := env.t
 			client := env.client
-			resp, err := client.ListContainers(ctx, &api.ListContainersRequest{})
+			resp, err := client.ListContainers(ctx, &criv1.ListContainersRequest{})
 			if err != nil {
 				t.Errorf("Unexpected error: %+v", err)
 				return
@@ -239,19 +239,19 @@ policy:
 `
 	tcases := []struct {
 		name         string
-		reqs         []*api.RunPodSandboxRequest
+		reqs         []*criv1.RunPodSandboxRequest
 		expectedPods int
 	}{
 		{
 			name: "create Pod #1",
-			reqs: []*api.RunPodSandboxRequest{
+			reqs: []*criv1.RunPodSandboxRequest{
 				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
 			},
 			expectedPods: 1,
 		},
 		{
 			name: "create Pods #1 and #2",
-			reqs: []*api.RunPodSandboxRequest{
+			reqs: []*criv1.RunPodSandboxRequest{
 				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
 				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
 			},
@@ -259,7 +259,7 @@ policy:
 		},
 		{
 			name: "create Pods #1, #2, and #3",
-			reqs: []*api.RunPodSandboxRequest{
+			reqs: []*criv1.RunPodSandboxRequest{
 				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
 				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
 				createPodRequest("Pod#3", "UID#3", "", nil, nil, ""),
@@ -268,7 +268,7 @@ policy:
 		},
 		{
 			name: "create Pods #1, #2, #3, #4, '1, '2, '3",
-			reqs: []*api.RunPodSandboxRequest{
+			reqs: []*criv1.RunPodSandboxRequest{
 				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
 				createPodRequest("Pod#2", "UID#2", "", nil, nil, ""),
 				createPodRequest("Pod#3", "UID#3", "", nil, nil, ""),
@@ -291,9 +291,9 @@ policy:
 	numPods := 0
 	for _, tc := range tcases {
 		criHandlers := map[string]interface{}{
-			"RunPodSandbox": func(*fakeCriServer, context.Context, *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+			"RunPodSandbox": func(*fakeCriServer, context.Context, *criv1.RunPodSandboxRequest) (*criv1.RunPodSandboxResponse, error) {
 				numPods++
-				return &api.RunPodSandboxResponse{
+				return &criv1.RunPodSandboxResponse{
 					PodSandboxId: fmt.Sprintf("Pod#%d", numPods),
 				}, nil
 			},
@@ -331,25 +331,25 @@ policy:
 	type pod struct {
 		UID string
 		ID  string
-		req *api.RunPodSandboxRequest
+		req *criv1.RunPodSandboxRequest
 	}
 
 	type container struct {
 		pod    string
 		name   string
 		expect int
-		req    *api.CreateContainerRequest
+		req    *criv1.CreateContainerRequest
 		ID     string
 	}
 
 	tcases := []struct {
 		name       string
-		pods       []*api.RunPodSandboxRequest
+		pods       []*criv1.RunPodSandboxRequest
 		containers []*container
 	}{
 		{
 			name: "create containers per one pod",
-			pods: []*api.RunPodSandboxRequest{
+			pods: []*criv1.RunPodSandboxRequest{
 				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
 			},
 			containers: []*container{
@@ -359,7 +359,7 @@ policy:
 		},
 		{
 			name: "create lingering containers per one pod",
-			pods: []*api.RunPodSandboxRequest{
+			pods: []*criv1.RunPodSandboxRequest{
 				createPodRequest("Pod#1", "UID#1", "", nil, nil, ""),
 			},
 			containers: []*container{
@@ -377,15 +377,15 @@ policy:
 	numContainers := 0
 	for _, tc := range tcases {
 		criHandlers := map[string]interface{}{
-			"RunPodSandbox": func(*fakeCriServer, context.Context, *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+			"RunPodSandbox": func(*fakeCriServer, context.Context, *criv1.RunPodSandboxRequest) (*criv1.RunPodSandboxResponse, error) {
 				numPods++
-				return &api.RunPodSandboxResponse{
+				return &criv1.RunPodSandboxResponse{
 					PodSandboxId: fmt.Sprintf("Pod#%d", numPods),
 				}, nil
 			},
-			"CreateContainer": func(*fakeCriServer, context.Context, *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
+			"CreateContainer": func(*fakeCriServer, context.Context, *criv1.CreateContainerRequest) (*criv1.CreateContainerResponse, error) {
 				numContainers++
-				return &api.CreateContainerResponse{
+				return &criv1.CreateContainerResponse{
 					ContainerId: fmt.Sprintf("Container#%d", numContainers),
 				}, nil
 			},
@@ -442,7 +442,7 @@ policy:
 
 func createPodRequest(name, uid, namespace string,
 	labels, annotations map[string]string,
-	cgroupParent string) *api.RunPodSandboxRequest {
+	cgroupParent string) *criv1.RunPodSandboxRequest {
 	if namespace == "" {
 		namespace = "default"
 	}
@@ -450,16 +450,16 @@ func createPodRequest(name, uid, namespace string,
 		labels = map[string]string{}
 	}
 	labels[kubetypes.KubernetesPodUIDLabel] = uid
-	return &api.RunPodSandboxRequest{
-		Config: &api.PodSandboxConfig{
-			Metadata: &api.PodSandboxMetadata{
+	return &criv1.RunPodSandboxRequest{
+		Config: &criv1.PodSandboxConfig{
+			Metadata: &criv1.PodSandboxMetadata{
 				Name:      name,
 				Uid:       uid,
 				Namespace: namespace,
 			},
 			Labels:      labels,
 			Annotations: annotations,
-			Linux: &api.LinuxPodSandboxConfig{
+			Linux: &criv1.LinuxPodSandboxConfig{
 				CgroupParent: cgroupParent,
 			},
 		},
@@ -467,14 +467,14 @@ func createPodRequest(name, uid, namespace string,
 }
 
 func createContainerRequest(podID, name string,
-	podReq *api.RunPodSandboxRequest) *api.CreateContainerRequest {
-	return &api.CreateContainerRequest{
+	podReq *criv1.RunPodSandboxRequest) *criv1.CreateContainerRequest {
+	return &criv1.CreateContainerRequest{
 		PodSandboxId: podID,
-		Config: &api.ContainerConfig{
-			Metadata: &api.ContainerMetadata{
+		Config: &criv1.ContainerConfig{
+			Metadata: &criv1.ContainerMetadata{
 				Name: name,
 			},
-			Linux: &api.LinuxContainerConfig{},
+			Linux: &criv1.LinuxContainerConfig{},
 		},
 		SandboxConfig: podReq.Config,
 	}

--- a/test/functional/e2e_test.go
+++ b/test/functional/e2e_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/dump"
 	"google.golang.org/grpc"
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 )

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -205,7 +205,11 @@ func (s *fakeCriServer) ContainerStatus(ctx context.Context, req *api.ContainerS
 }
 
 func (s *fakeCriServer) UpdateContainerResources(ctx context.Context, req *api.UpdateContainerResourcesRequest) (*api.UpdateContainerResourcesResponse, error) {
-	response, err := s.callHandler(ctx, req, nil)
+	response, err := s.callHandler(ctx, req,
+		func(*fakeCriServer, context.Context, *api.UpdateContainerResourcesRequest) (*api.UpdateContainerResourcesResponse, error) {
+			return &api.UpdateContainerResourcesResponse{}, nil
+		},
+	)
 	return response.(*api.UpdateContainerResourcesResponse), err
 }
 
@@ -267,7 +271,11 @@ func (s *fakeCriServer) Status(ctx context.Context, req *api.StatusRequest) (*ap
 // Implementation of api.ImageServiceServer
 
 func (s *fakeCriServer) ListImages(ctx context.Context, req *api.ListImagesRequest) (*api.ListImagesResponse, error) {
-	response, err := s.callHandler(ctx, req, nil)
+	response, err := s.callHandler(ctx, req,
+		func(*fakeCriServer, context.Context, *api.ListImagesRequest) (*api.ListImagesResponse, error) {
+			return &api.ListImagesResponse{}, nil
+		},
+	)
 	return response.(*api.ListImagesResponse), err
 }
 

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/utils"
 	"google.golang.org/grpc"
-	api "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (
@@ -63,8 +63,8 @@ func newFakeCriServer(t *testing.T, socket string, fakeHandlers map[string]inter
 		fakeHandlers: fakeHandlers,
 	}
 
-	api.RegisterRuntimeServiceServer(srv.grpcServer, srv)
-	api.RegisterImageServiceServer(srv.grpcServer, srv)
+	criv1.RegisterRuntimeServiceServer(srv.grpcServer, srv)
+	criv1.RegisterImageServiceServer(srv.grpcServer, srv)
 
 	lis, err := net.Listen("unix", socket)
 	if err != nil {
@@ -129,12 +129,12 @@ func (s *fakeCriServer) callHandler(ctx context.Context, request interface{}, de
 	return out[0].Interface(), err
 }
 
-// Implementation of api.RuntimeServiceServer
+// Implementation of criv1.RuntimeServiceServer
 
-func (s *fakeCriServer) Version(ctx context.Context, req *api.VersionRequest) (*api.VersionResponse, error) {
+func (s *fakeCriServer) Version(ctx context.Context, req *criv1.VersionRequest) (*criv1.VersionResponse, error) {
 	response, err := s.callHandler(ctx, req,
-		func(*fakeCriServer, context.Context, *api.VersionRequest) (*api.VersionResponse, error) {
-			return &api.VersionResponse{
+		func(*fakeCriServer, context.Context, *criv1.VersionRequest) (*criv1.VersionResponse, error) {
+			return &criv1.VersionResponse{
 				Version:           fakeKubeAPIVersion,
 				RuntimeName:       fakeRuntimeName,
 				RuntimeVersion:    fakeRuntimeVersion,
@@ -142,159 +142,159 @@ func (s *fakeCriServer) Version(ctx context.Context, req *api.VersionRequest) (*
 			}, nil
 		},
 	)
-	return response.(*api.VersionResponse), err
+	return response.(*criv1.VersionResponse), err
 }
 
-func (s *fakeCriServer) RunPodSandbox(ctx context.Context, req *api.RunPodSandboxRequest) (*api.RunPodSandboxResponse, error) {
+func (s *fakeCriServer) RunPodSandbox(ctx context.Context, req *criv1.RunPodSandboxRequest) (*criv1.RunPodSandboxResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.RunPodSandboxResponse), err
+	return response.(*criv1.RunPodSandboxResponse), err
 }
 
-func (s *fakeCriServer) StopPodSandbox(ctx context.Context, req *api.StopPodSandboxRequest) (*api.StopPodSandboxResponse, error) {
+func (s *fakeCriServer) StopPodSandbox(ctx context.Context, req *criv1.StopPodSandboxRequest) (*criv1.StopPodSandboxResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.StopPodSandboxResponse), err
+	return response.(*criv1.StopPodSandboxResponse), err
 }
 
-func (s *fakeCriServer) RemovePodSandbox(ctx context.Context, req *api.RemovePodSandboxRequest) (*api.RemovePodSandboxResponse, error) {
+func (s *fakeCriServer) RemovePodSandbox(ctx context.Context, req *criv1.RemovePodSandboxRequest) (*criv1.RemovePodSandboxResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.RemovePodSandboxResponse), err
+	return response.(*criv1.RemovePodSandboxResponse), err
 }
 
-func (s *fakeCriServer) PodSandboxStatus(ctx context.Context, req *api.PodSandboxStatusRequest) (*api.PodSandboxStatusResponse, error) {
+func (s *fakeCriServer) PodSandboxStatus(ctx context.Context, req *criv1.PodSandboxStatusRequest) (*criv1.PodSandboxStatusResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.PodSandboxStatusResponse), err
+	return response.(*criv1.PodSandboxStatusResponse), err
 }
 
-func (s *fakeCriServer) ListPodSandbox(ctx context.Context, req *api.ListPodSandboxRequest) (*api.ListPodSandboxResponse, error) {
-	response, err := s.callHandler(ctx, req, func(*fakeCriServer, context.Context, *api.ListPodSandboxRequest) (*api.ListPodSandboxResponse, error) {
-		return &api.ListPodSandboxResponse{}, nil
+func (s *fakeCriServer) ListPodSandbox(ctx context.Context, req *criv1.ListPodSandboxRequest) (*criv1.ListPodSandboxResponse, error) {
+	response, err := s.callHandler(ctx, req, func(*fakeCriServer, context.Context, *criv1.ListPodSandboxRequest) (*criv1.ListPodSandboxResponse, error) {
+		return &criv1.ListPodSandboxResponse{}, nil
 	})
-	return response.(*api.ListPodSandboxResponse), err
+	return response.(*criv1.ListPodSandboxResponse), err
 }
 
-func (s *fakeCriServer) CreateContainer(ctx context.Context, req *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
+func (s *fakeCriServer) CreateContainer(ctx context.Context, req *criv1.CreateContainerRequest) (*criv1.CreateContainerResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.CreateContainerResponse), err
+	return response.(*criv1.CreateContainerResponse), err
 }
 
-func (s *fakeCriServer) StartContainer(ctx context.Context, req *api.StartContainerRequest) (*api.StartContainerResponse, error) {
+func (s *fakeCriServer) StartContainer(ctx context.Context, req *criv1.StartContainerRequest) (*criv1.StartContainerResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.StartContainerResponse), err
+	return response.(*criv1.StartContainerResponse), err
 }
 
-func (s *fakeCriServer) StopContainer(ctx context.Context, req *api.StopContainerRequest) (*api.StopContainerResponse, error) {
+func (s *fakeCriServer) StopContainer(ctx context.Context, req *criv1.StopContainerRequest) (*criv1.StopContainerResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.StopContainerResponse), err
+	return response.(*criv1.StopContainerResponse), err
 }
 
-func (s *fakeCriServer) RemoveContainer(ctx context.Context, req *api.RemoveContainerRequest) (*api.RemoveContainerResponse, error) {
+func (s *fakeCriServer) RemoveContainer(ctx context.Context, req *criv1.RemoveContainerRequest) (*criv1.RemoveContainerResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.RemoveContainerResponse), err
+	return response.(*criv1.RemoveContainerResponse), err
 }
 
-func (s *fakeCriServer) ListContainers(ctx context.Context, req *api.ListContainersRequest) (*api.ListContainersResponse, error) {
-	response, err := s.callHandler(ctx, req, func(*fakeCriServer, context.Context, *api.ListContainersRequest) (*api.ListContainersResponse, error) {
-		return &api.ListContainersResponse{}, nil
+func (s *fakeCriServer) ListContainers(ctx context.Context, req *criv1.ListContainersRequest) (*criv1.ListContainersResponse, error) {
+	response, err := s.callHandler(ctx, req, func(*fakeCriServer, context.Context, *criv1.ListContainersRequest) (*criv1.ListContainersResponse, error) {
+		return &criv1.ListContainersResponse{}, nil
 	})
-	return response.(*api.ListContainersResponse), err
+	return response.(*criv1.ListContainersResponse), err
 }
 
-func (s *fakeCriServer) ContainerStatus(ctx context.Context, req *api.ContainerStatusRequest) (*api.ContainerStatusResponse, error) {
+func (s *fakeCriServer) ContainerStatus(ctx context.Context, req *criv1.ContainerStatusRequest) (*criv1.ContainerStatusResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ContainerStatusResponse), err
+	return response.(*criv1.ContainerStatusResponse), err
 }
 
-func (s *fakeCriServer) UpdateContainerResources(ctx context.Context, req *api.UpdateContainerResourcesRequest) (*api.UpdateContainerResourcesResponse, error) {
+func (s *fakeCriServer) UpdateContainerResources(ctx context.Context, req *criv1.UpdateContainerResourcesRequest) (*criv1.UpdateContainerResourcesResponse, error) {
 	response, err := s.callHandler(ctx, req,
-		func(*fakeCriServer, context.Context, *api.UpdateContainerResourcesRequest) (*api.UpdateContainerResourcesResponse, error) {
-			return &api.UpdateContainerResourcesResponse{}, nil
+		func(*fakeCriServer, context.Context, *criv1.UpdateContainerResourcesRequest) (*criv1.UpdateContainerResourcesResponse, error) {
+			return &criv1.UpdateContainerResourcesResponse{}, nil
 		},
 	)
-	return response.(*api.UpdateContainerResourcesResponse), err
+	return response.(*criv1.UpdateContainerResourcesResponse), err
 }
 
-func (s *fakeCriServer) ReopenContainerLog(ctx context.Context, req *api.ReopenContainerLogRequest) (*api.ReopenContainerLogResponse, error) {
+func (s *fakeCriServer) ReopenContainerLog(ctx context.Context, req *criv1.ReopenContainerLogRequest) (*criv1.ReopenContainerLogResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ReopenContainerLogResponse), err
+	return response.(*criv1.ReopenContainerLogResponse), err
 }
 
-func (s *fakeCriServer) ExecSync(ctx context.Context, req *api.ExecSyncRequest) (*api.ExecSyncResponse, error) {
+func (s *fakeCriServer) ExecSync(ctx context.Context, req *criv1.ExecSyncRequest) (*criv1.ExecSyncResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ExecSyncResponse), err
+	return response.(*criv1.ExecSyncResponse), err
 }
 
-func (s *fakeCriServer) Exec(ctx context.Context, req *api.ExecRequest) (*api.ExecResponse, error) {
+func (s *fakeCriServer) Exec(ctx context.Context, req *criv1.ExecRequest) (*criv1.ExecResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ExecResponse), err
+	return response.(*criv1.ExecResponse), err
 }
 
-func (s *fakeCriServer) Attach(ctx context.Context, req *api.AttachRequest) (*api.AttachResponse, error) {
+func (s *fakeCriServer) Attach(ctx context.Context, req *criv1.AttachRequest) (*criv1.AttachResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.AttachResponse), err
+	return response.(*criv1.AttachResponse), err
 }
 
-func (s *fakeCriServer) PortForward(ctx context.Context, req *api.PortForwardRequest) (*api.PortForwardResponse, error) {
+func (s *fakeCriServer) PortForward(ctx context.Context, req *criv1.PortForwardRequest) (*criv1.PortForwardResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.PortForwardResponse), err
+	return response.(*criv1.PortForwardResponse), err
 }
 
-func (s *fakeCriServer) ContainerStats(ctx context.Context, req *api.ContainerStatsRequest) (*api.ContainerStatsResponse, error) {
+func (s *fakeCriServer) ContainerStats(ctx context.Context, req *criv1.ContainerStatsRequest) (*criv1.ContainerStatsResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ContainerStatsResponse), err
+	return response.(*criv1.ContainerStatsResponse), err
 }
 
-func (s *fakeCriServer) ListContainerStats(ctx context.Context, req *api.ListContainerStatsRequest) (*api.ListContainerStatsResponse, error) {
+func (s *fakeCriServer) ListContainerStats(ctx context.Context, req *criv1.ListContainerStatsRequest) (*criv1.ListContainerStatsResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ListContainerStatsResponse), err
+	return response.(*criv1.ListContainerStatsResponse), err
 }
 
-func (s *fakeCriServer) PodSandboxStats(ctx context.Context, req *api.PodSandboxStatsRequest) (*api.PodSandboxStatsResponse, error) {
+func (s *fakeCriServer) PodSandboxStats(ctx context.Context, req *criv1.PodSandboxStatsRequest) (*criv1.PodSandboxStatsResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.PodSandboxStatsResponse), err
+	return response.(*criv1.PodSandboxStatsResponse), err
 }
 
-func (s *fakeCriServer) ListPodSandboxStats(ctx context.Context, req *api.ListPodSandboxStatsRequest) (*api.ListPodSandboxStatsResponse, error) {
+func (s *fakeCriServer) ListPodSandboxStats(ctx context.Context, req *criv1.ListPodSandboxStatsRequest) (*criv1.ListPodSandboxStatsResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ListPodSandboxStatsResponse), err
+	return response.(*criv1.ListPodSandboxStatsResponse), err
 }
 
-func (s *fakeCriServer) UpdateRuntimeConfig(ctx context.Context, req *api.UpdateRuntimeConfigRequest) (*api.UpdateRuntimeConfigResponse, error) {
+func (s *fakeCriServer) UpdateRuntimeConfig(ctx context.Context, req *criv1.UpdateRuntimeConfigRequest) (*criv1.UpdateRuntimeConfigResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.UpdateRuntimeConfigResponse), err
+	return response.(*criv1.UpdateRuntimeConfigResponse), err
 }
 
-func (s *fakeCriServer) Status(ctx context.Context, req *api.StatusRequest) (*api.StatusResponse, error) {
+func (s *fakeCriServer) Status(ctx context.Context, req *criv1.StatusRequest) (*criv1.StatusResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.StatusResponse), err
+	return response.(*criv1.StatusResponse), err
 }
 
-// Implementation of api.ImageServiceServer
+// Implementation of criv1.ImageServiceServer
 
-func (s *fakeCriServer) ListImages(ctx context.Context, req *api.ListImagesRequest) (*api.ListImagesResponse, error) {
+func (s *fakeCriServer) ListImages(ctx context.Context, req *criv1.ListImagesRequest) (*criv1.ListImagesResponse, error) {
 	response, err := s.callHandler(ctx, req,
-		func(*fakeCriServer, context.Context, *api.ListImagesRequest) (*api.ListImagesResponse, error) {
-			return &api.ListImagesResponse{}, nil
+		func(*fakeCriServer, context.Context, *criv1.ListImagesRequest) (*criv1.ListImagesResponse, error) {
+			return &criv1.ListImagesResponse{}, nil
 		},
 	)
-	return response.(*api.ListImagesResponse), err
+	return response.(*criv1.ListImagesResponse), err
 }
 
-func (s *fakeCriServer) ImageStatus(ctx context.Context, req *api.ImageStatusRequest) (*api.ImageStatusResponse, error) {
+func (s *fakeCriServer) ImageStatus(ctx context.Context, req *criv1.ImageStatusRequest) (*criv1.ImageStatusResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ImageStatusResponse), err
+	return response.(*criv1.ImageStatusResponse), err
 }
 
-func (s *fakeCriServer) PullImage(ctx context.Context, req *api.PullImageRequest) (*api.PullImageResponse, error) {
+func (s *fakeCriServer) PullImage(ctx context.Context, req *criv1.PullImageRequest) (*criv1.PullImageResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.PullImageResponse), err
+	return response.(*criv1.PullImageResponse), err
 }
 
-func (s *fakeCriServer) RemoveImage(ctx context.Context, req *api.RemoveImageRequest) (*api.RemoveImageResponse, error) {
+func (s *fakeCriServer) RemoveImage(ctx context.Context, req *criv1.RemoveImageRequest) (*criv1.RemoveImageResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.RemoveImageResponse), err
+	return response.(*criv1.RemoveImageResponse), err
 }
 
-func (s *fakeCriServer) ImageFsInfo(ctx context.Context, req *api.ImageFsInfoRequest) (*api.ImageFsInfoResponse, error) {
+func (s *fakeCriServer) ImageFsInfo(ctx context.Context, req *criv1.ImageFsInfoRequest) (*criv1.ImageFsInfoResponse, error) {
 	response, err := s.callHandler(ctx, req, nil)
-	return response.(*api.ImageFsInfoResponse), err
+	return response.(*criv1.ImageFsInfoResponse), err
 }

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/utils"
 	"google.golang.org/grpc"
-	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	api "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (


### PR DESCRIPTION
Switch the native/internal representation of pods and containers everywhere to CRI v1.
Implement ingress and egress protocol conversion between v1alpha2 and v1 to support
both pre-v1 clients and runtimes.
