### PR TITLE
podpools: never count default pool CPUs in Instances percentages

### DIFF
--- a/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/code.var.sh
@@ -1,0 +1,39 @@
+# Launch cri-resmgr with a custom default pool and many highperf
+# pools. The CPUs in the custom default pool are disjoint from CPUs in
+# the reserved pool. 100 % of remaining CPUs are allocated to highperf
+# pools.
+terminate cri-resmgr
+cri_resmgr_cfg=${TEST_DIR}/podpools-custom-default.cfg launch cri-resmgr
+
+cleanup() {
+    ( kubectl delete pods --all --now )
+    ( kubectl delete pod -n kube-system pod0c-mysystem )
+    ( kubectl delete pod -n daemons pod0c-mydaemon )
+    ( kubectl delete namespace daemons )
+}
+
+cleanup
+
+namespace=kube-system NAME=pod0c-mysystem CONTCOUNT=2 create podpools-busybox
+kubectl create namespace daemons
+namespace=daemons NAME=pod0c-mydaemon CONTCOUNT=2 create podpools-busybox
+report allowed
+verify 'len(cpus["pod0c-mysystemc0"]) == 1' \
+       'len(cpus["pod0c-mydaemonc0"]) == 3' \
+       'disjoint_sets(cpus["pod0c-mysystemc0"], cpus["pod0c-mydaemonc0"])'
+
+NAME=pod1c-highperf POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: highperf" CPUREQ=2 CPULIM=2 MEMREQ="" MEMLIM="" create podpools-busybox
+NAME=pod2c-highperf POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: highperf" CPUREQ=2 CPULIM=2 MEMREQ="" MEMLIM="" create podpools-busybox
+NAME=pod3c-highperf POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: highperf" CPUREQ=2 CPULIM=2 MEMREQ="" MEMLIM="" create podpools-busybox
+NAME=pod4c-highperf POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: highperf" CPUREQ=2 CPULIM=2 MEMREQ="" MEMLIM="" create podpools-busybox
+report allowed
+verify 'len(cpus["pod1c-highperfc0"]) == 2' \
+       'len(cpus["pod2c-highperfc0"]) == 2' \
+       'len(cpus["pod3c-highperfc0"]) == 2' \
+       'len(cpus["pod4c-highperfc0"]) == 2' \
+       'disjoint_sets(cpus["pod1c-highperfc0"], cpus["pod2c-highperfc0"], cpus["pod3c-highperfc0"], cpus["pod4c-highperfc0"])'
+
+cleanup
+vm-command "cat < cri-resmgr.output.txt > cri-resmgr-podpools-single-pool.output.txt"
+terminate cri-resmgr
+launch cri-resmgr

--- a/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/podpools-custom-default.cfg
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/podpools-custom-default.cfg
@@ -1,0 +1,14 @@
+policy:
+  Active: podpools
+  ReservedResources:
+    CPU: cpuset:0
+  podpools:
+    Pools:
+      - Name: default
+        CPU: 3
+      - Name: highperf
+        Instances: 100%
+        CPU: 2
+        MaxPods: 1
+logger:
+  Debug: resource-manager,cache,policy,memory


### PR DESCRIPTION
- This change enables easy node configuration by using allowing syntax
  "Instances: 100%" in user-defined pod pools. This notation means
  "allocate all the remaining CPUs to this pool".
- The behavior is the same as previously, if the CPUs of the built-in
  "default" pool are not customized by the user.
- The behavior differs from previous when a new set of CPUs is
  allocated to the "default" pool, that is, CPUs of the default pool and
  the reserved pool are disjoint. The previous implementation did not
  subtract these default CPUs from the CPU count that is the basis
  for "n %" notation. As a result, it was impossible to guess the
  percentage that would mean "all the rest CPUs" when core count varies.