### PR TITLE
topology-aware: Clone also CPU type in grant

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
@@ -1274,6 +1274,7 @@ func (cg *grant) Clone() Grant {
 		memoryNode:   cg.GetMemoryNode(),
 		container:    cg.GetContainer(),
 		exclusive:    cg.ExclusiveCPUs(),
+		cpuType:      cg.CPUType(),
 		cpuPortion:   cg.SharedPortion(),
 		memType:      cg.MemoryType(),
 		memset:       cg.Memset().Clone(),


### PR DESCRIPTION
The CPU type field was not copied when cloning the grant.