### PR TITLE
resmgr: rediscover container resources on startup.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -135,7 +135,7 @@ func createFakeContainer(cch Cache, fc *fakeContainer) (Container, error) {
 	}
 
 	cch.(*cache).Debug("*** => creating Container: %+v\n", *req)
-	c, err := cch.InsertContainer(req)
+	c, err := cch.InsertContainer(req, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -612,6 +613,22 @@ func (c *container) GetCPUShares() int64 {
 	return c.LinuxReq.CpuShares
 }
 
+func (c *container) HasCPURequestAnnotation() bool {
+	_, ok := c.Annotations[CPURequestKey]
+	return ok
+}
+
+func (c *container) ParseCPURequestAnnotation(value string) int {
+	if value == "" {
+		return 0
+	}
+	req, err := strconv.Atoi(value)
+	if err != nil || req <= 0 {
+		return 0
+	}
+	return req
+}
+
 func (c *container) GetMemoryLimit() int64 {
 	if c.LinuxReq == nil {
 		return 0
@@ -667,6 +684,10 @@ func (c *container) SetCPUShares(value int64) {
 	}
 	c.LinuxReq.CpuShares = value
 	c.markPending(CRI)
+}
+
+func (c *container) AnnotateCPURequest(value int) {
+	c.SetAnnotation(CPURequestKey, fmt.Sprintf("%d", value))
 }
 
 func (c *container) SetMemoryLimit(value int64) {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -427,6 +427,12 @@ func (m *mockContainer) GetCPUQuota() int64 {
 func (m *mockContainer) GetCPUShares() int64 {
 	panic("unimplemented")
 }
+func (m *mockContainer) HasCPURequestAnnotation() bool {
+	return false
+}
+func (m *mockContainer) ParseCPURequestAnnotation(string) int {
+	panic("unimplemented")
+}
 func (m *mockContainer) GetMemoryLimit() int64 {
 	return m.memoryLimit
 }
@@ -449,6 +455,8 @@ func (m *mockContainer) SetCPUQuota(int64) {
 	panic("unimplemented")
 }
 func (m *mockContainer) SetCPUShares(int64) {
+}
+func (m *mockContainer) AnnotateCPURequest(int) {
 }
 func (m *mockContainer) SetMemoryLimit(int64) {
 	panic("unimplemented")

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -665,7 +665,7 @@ func (m *mockCache) DeletePod(string) cache.Pod {
 func (m *mockCache) LookupPod(string) (cache.Pod, bool) {
 	panic("unimplemented")
 }
-func (m *mockCache) InsertContainer(interface{}) (cache.Container, error) {
+func (m *mockCache) InsertContainer(interface{}, *cri.ContainerStatusResponse) (cache.Container, error) {
 	panic("unimplemented")
 }
 func (m *mockCache) UpdateContainerID(string, interface{}) (cache.Container, error) {
@@ -738,7 +738,7 @@ func (m *mockCache) Save() error {
 func (m *mockCache) RefreshPods(*cri.ListPodSandboxResponse, map[string]*cache.PodStatus) ([]cache.Pod, []cache.Pod, []cache.Container) {
 	panic("unimplemented")
 }
-func (m *mockCache) RefreshContainers(*cri.ListContainersResponse) ([]cache.Container, []cache.Container) {
+func (m *mockCache) RefreshContainers(*cri.ListContainersResponse, map[string]*cri.ContainerStatusResponse) ([]cache.Container, []cache.Container) {
 	panic("unimplemented")
 }
 func (m *mockCache) ContainerDirectory(string) string {


### PR DESCRIPTION
This PR improves startup-time resource discovery of running containers.

It does this primarily by sending each discovered container a `ContainerStatus` request with the `Verbose` flag set, digging out the bits corresponding to the original `CRI LinuxContainerResources`, and reconstructing that from the data. This reconstructed synthetic version is then used as the original one to estimate the container's resource requirements.

In addition to this, the CPU shares setup logic has been altered to allow more correct/accurater rediscovery of CPU requests of running containers, in case the stored cache on disk of `cri-resource-manager` has been nuked and it needs to start with zero knowledge about the system state. See the committed comment changes for more details.
