### PR TITLE
Statically linked binaries in container images

### DIFF
--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -1,27 +1,6 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
-#
-# This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+ARG BUILDER_BASE=golang:1.17.8-bullseye
 
-FROM ${CLEAR_LINUX_BASE} as builder
-
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN swupd bundle-add make ${CLEAR_LINUX_VERSION}
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --bundles=os-core \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+FROM ${BUILDER_BASE} as builder
 
 WORKDIR /go/build
 
@@ -30,11 +9,13 @@ COPY go.mod go.sum ./
 COPY pkg/topology/ pkg/topology/
 RUN go mod download
 
-# Build agent
+# Build webhook, fully statically linked binary
 COPY . .
-RUN make BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
+
+RUN CGO_ENABLED=0 make BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
 
 FROM scratch as final
-COPY --from=builder /install_root /
+
 COPY --from=builder /go/build/bin/* /bin/
+
 ENTRYPOINT ["/bin/cri-resmgr-agent"]

--- a/cmd/cri-resmgr-webhook/Dockerfile
+++ b/cmd/cri-resmgr-webhook/Dockerfile
@@ -1,27 +1,6 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
-#
-# This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+ARG BUILDER_BASE=golang:1.17.8-bullseye
 
-FROM ${CLEAR_LINUX_BASE} as builder
-
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN swupd bundle-add make ${CLEAR_LINUX_VERSION}
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --bundles=os-core \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+FROM ${BUILDER_BASE} as builder
 
 WORKDIR /go/build
 
@@ -30,15 +9,15 @@ COPY go.mod go.sum ./
 COPY pkg/topology/ pkg/topology/
 RUN go mod download
 
-# Build webhook
+# Build webhook, fully statically linked binary
 COPY . .
-RUN make BUILD_DIRS=cri-resmgr-webhook
+
+RUN CGO_ENABLED=0 make BUILD_DIRS=cri-resmgr-webhook
 
 FROM scratch as final
 
 USER 65534:65534
 
-COPY --from=builder /install_root /
 COPY --from=builder /go/build/bin/cri-resmgr-webhook /bin/cri-resmgr-webhook
 
 ENTRYPOINT ["/bin/cri-resmgr-webhook"]


### PR DESCRIPTION
Use statically linked binaries in the agent and webhook container
images. We now have scratch-based images than only contain one file
(which is the agent or webhook binary) - clean and simple. With this we
also ditch the cumbersome clearlinux based build which does not even
support go v1.17 (or later).