### PR TITLE
Add CPU controller calls to balloons policy

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -38,6 +38,8 @@ import (
 )
 
 const (
+	// CPU marks changes that can be applied by the CPU controller.
+	CPU = "cpu"
 	// CRI marks changes that can be applied by the CRI controller.
 	CRI = "cri"
 	// RDT marks changes that can be applied by the RDT controller.
@@ -70,7 +72,7 @@ const (
 )
 
 // allControllers is a slice of all controller domains.
-var allControllers = []string{CRI, RDT, BlockIO, Memory}
+var allControllers = []string{CPU, CRI, RDT, BlockIO, Memory}
 
 // PodState is the pod state in the runtime.
 type PodState int32

--- a/pkg/cri/resource-manager/control/blockio/blockio.go
+++ b/pkg/cri/resource-manager/control/blockio/blockio.go
@@ -108,6 +108,10 @@ func (ctl *blockioctl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
+func (ctl *blockioctl) UpdateConfig(cache cache.Cache) error {
+	return nil
+}
+
 // isImplicitlyDisabled checks if we run without any classes confiured
 func (ctl *blockioctl) isImplicitlyDisabled() bool {
 	if ctl.idle != nil {

--- a/pkg/cri/resource-manager/control/cpu/cpu.go
+++ b/pkg/cri/resource-manager/control/cpu/cpu.go
@@ -140,7 +140,13 @@ func (ctl *cpuctl) assign(class string, cpus ...int) error {
 		return fmt.Errorf("non-existent cpu class %q", class)
 	}
 
-	//TODO: configure cpus (sysfs)
+	if err := utils.SetCPUsScalingMinFreq(cpus, (int)(ctl.config.Classes[class].MinFreq)); err != nil {
+		return fmt.Errorf("Cannot set min freq %d: %w", ctl.config.Classes[class].MinFreq, err)
+	}
+
+	if err := utils.SetCPUsScalingMaxFreq(cpus, (int)(ctl.config.Classes[class].MaxFreq)); err != nil {
+		return fmt.Errorf("Cannot set max freq %d: %w", ctl.config.Classes[class].MaxFreq, err)
+	}
 
 	// Store the class assignment. Assign cpus to a class and remove them from
 	// other classes

--- a/pkg/cri/resource-manager/control/cpu/cpu.go
+++ b/pkg/cri/resource-manager/control/cpu/cpu.go
@@ -129,6 +129,11 @@ func (ctl *cpuctl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
+// UpdateHWConfig handler for the CPU controller.
+func (ctl *cpuctl) UpdateConfig(cache cache.Cache) error {
+	return cache.TraversePendingConfig(Assign)
+}
+
 // assign assigns a cpuset to a class
 func (ctl *cpuctl) assign(class string, cpus ...int) error {
 	if _, ok := ctl.config.Classes[class]; !ok {
@@ -157,6 +162,8 @@ func (ctl *cpuctl) assign(class string, cpus ...int) error {
 			}
 		}
 	}
+
+	ctl.setClassAssignments(&assignments)
 
 	return nil
 }

--- a/pkg/cri/resource-manager/control/cpu/cpu.go
+++ b/pkg/cri/resource-manager/control/cpu/cpu.go
@@ -1,0 +1,240 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpu
+
+import (
+	"fmt"
+
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/cri/client"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/goresctrl/pkg/utils"
+)
+
+const (
+	// ConfigModuleName is the configuration section for the CPU controller.
+	ConfigModuleName = "cpu"
+
+	// CPUController is the name of the CPU controller.
+	CPUController = cache.CPU
+)
+
+// cpuctl encapsulates the runtime state of our CPU enforcement/controller.
+type cpuctl struct {
+	cache  cache.Cache // resource manager cache
+	config *config
+}
+
+type config struct {
+	Classes map[string]Class `json:"classes"`
+}
+
+type Class struct {
+	MinFreq                     uint `json:"minFreq"`
+	MaxFreq                     uint `json:"maxFreq"`
+	EnergyPerformancePreference uint `json:"energyPerformancePreference"`
+}
+
+// cpuClassAllocations contains the information about how cpus are assigned to
+// classes
+type cpuClassAssignments map[string]utils.IDSet
+
+const (
+	cacheKeyCPUAssignments = "CPUClassAssignments"
+)
+
+var log logger.Logger = logger.NewLogger(CPUController)
+
+// Ccontroller singleton instance.
+var singleton *cpuctl
+
+// GetClasses returns all available CPU classes.
+func GetClasses() map[string]Class {
+	return getCPUController().config.getClasses()
+}
+
+// Assign assigns a set of cpus to a class.
+func Assign(class string, cpus ...int) error {
+	// NOTE: no locking implemented anywhere around -> we don't expect multiple parallel callers
+	return getCPUController().assign(class, cpus...)
+}
+
+// getCPUController returns the (singleton) CPU controller instance.
+func getCPUController() *cpuctl {
+	if singleton == nil {
+		singleton = &cpuctl{}
+		singleton.config = singleton.defaultOptions().(*config)
+	}
+	return singleton
+}
+
+// Start initializes the controller for enforcing decisions.
+func (ctl *cpuctl) Start(cache cache.Cache, client client.Client) error {
+	ctl.cache = cache
+
+	// DEBUG: dump the class assignments we have stored in the cache
+	log.Debug("retrieved cpu class assignments from cache:\n%s", utils.DumpJSON(*ctl.getClassAssignments()))
+
+	if err := ctl.configure(); err != nil {
+		// Just print an error. A config update later on may be valid.
+		log.Error("failed apply initial configuration: %v", err)
+	}
+
+	// TODO: We probably could just remove this and the hooks if they are not used
+	pkgcfg.GetModule(ConfigModuleName).AddNotify(getCPUController().configNotify)
+
+	return nil
+}
+
+// Stop shuts down the controller.
+func (ctl *cpuctl) Stop() {
+}
+
+// PreCreateHook handler for the CPU controller.
+func (ctl *cpuctl) PreCreateHook(c cache.Container) error {
+	return nil
+}
+
+// PreStartHook handler for the CPU controller.
+func (ctl *cpuctl) PreStartHook(c cache.Container) error {
+	return nil
+}
+
+// PostStartHook handler for the CPU controller.
+func (ctl *cpuctl) PostStartHook(c cache.Container) error {
+	return nil
+}
+
+// PostUpdateHook handler for the CPU controller.
+func (ctl *cpuctl) PostUpdateHook(c cache.Container) error {
+	return nil
+}
+
+// PostStopHook handler for the CPU controller.
+func (ctl *cpuctl) PostStopHook(c cache.Container) error {
+	return nil
+}
+
+// assign assigns a cpuset to a class
+func (ctl *cpuctl) assign(class string, cpus ...int) error {
+	if _, ok := ctl.config.Classes[class]; !ok {
+		return fmt.Errorf("non-existent cpu class %q", class)
+	}
+
+	//TODO: configure cpus (sysfs)
+
+	// Store the class assignment. Assign cpus to a class and remove them from
+	// other classes
+	assignments := *ctl.getClassAssignments()
+
+	if this, ok := assignments[class]; !ok {
+		assignments[class] = utils.NewIDSetFromIntSlice(cpus...)
+	} else {
+		this.Add(cpus...)
+	}
+
+	for k, v := range assignments {
+		if k != class {
+			v.Del(cpus...)
+
+			// Don't store empty classes, serves as a garbage collector, too
+			if v.Size() == 0 {
+				delete(assignments, k)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (ctl *cpuctl) configure() error {
+	// Re-configure CPUs that are assigned to some known class
+	assignments := *ctl.getClassAssignments()
+
+	for class, cpus := range assignments {
+		if _, ok := ctl.config.Classes[class]; ok {
+			// TODO: re-configure cpus (sysfs) according to new class parameters
+
+		} else {
+			// TODO: what should we really do with classes that do not exist in
+			// the configuration anymore? Now we remember the CPUs assigned to
+			// them. A further config update might re-introduce the class in
+			// which case the CPUs will be reconfigured.
+			log.Warn("class %q with cpus %v missing from the configuration", class, cpus)
+		}
+	}
+
+	log.Debug("cpu controller configured")
+
+	return nil
+}
+
+// Callback for runtime configuration notifications.
+func (ctl *cpuctl) configNotify(event pkgcfg.Event, source pkgcfg.Source) error {
+	log.Info("configuration update, applying new config")
+	return ctl.configure()
+}
+
+func (ctl *cpuctl) defaultOptions() interface{} {
+	return &config{}
+}
+
+// Get the state of CPU class assignments from cache
+func (ctl *cpuctl) getClassAssignments() *cpuClassAssignments {
+	c := &cpuClassAssignments{}
+
+	if !ctl.cache.GetPolicyEntry(cacheKeyCPUAssignments, c) {
+		log.Error("no cached state of CPU class assignments found")
+	}
+
+	return c
+}
+
+// Save the state of CPU class assignments in cache
+func (ctl *cpuctl) setClassAssignments(c *cpuClassAssignments) {
+	ctl.cache.SetPolicyEntry(cacheKeyCPUAssignments, cache.Cachable(c))
+}
+
+func (c *config) getClasses() map[string]Class {
+	ret := make(map[string]Class, len(c.Classes))
+	for k, v := range c.Classes {
+		ret[k] = v
+	}
+	return ret
+}
+
+// Set the value of cached cpuClassAssignments
+func (c *cpuClassAssignments) Set(value interface{}) {
+	switch value.(type) {
+	case cpuClassAssignments:
+		*c = value.(cpuClassAssignments)
+	case *cpuClassAssignments:
+		cp := value.(*cpuClassAssignments)
+		*c = *cp
+	}
+}
+
+// Get cached cpuClassAssignments
+func (c *cpuClassAssignments) Get() interface{} {
+	return *c
+}
+
+// Register us as a controller.
+func init() {
+	control.Register(CPUController, "CPU controller", getCPUController())
+	pkgcfg.Register(ConfigModuleName, "CPU control", getCPUController().config, getCPUController().defaultOptions)
+}

--- a/pkg/cri/resource-manager/control/cri/cri.go
+++ b/pkg/cri/resource-manager/control/cri/cri.go
@@ -145,6 +145,10 @@ func (ctl *crictl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
+func (ctl *crictl) UpdateConfig(cache cache.Cache) error {
+	return nil
+}
+
 // criError creates an CRI-controller-specific formatted error message.
 func criError(format string, args ...interface{}) error {
 	return fmt.Errorf("cri: "+format, args...)

--- a/pkg/cri/resource-manager/control/memory/memory.go
+++ b/pkg/cri/resource-manager/control/memory/memory.go
@@ -115,6 +115,10 @@ func (ctl *memctl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
+func (ctl *memctl) UpdateConfig(cache cache.Cache) error {
+	return nil
+}
+
 // Check if memory cgroup controller supports top tier soft limits.
 func (ctl *memctl) checkToptierLimitSupport() bool {
 	_, err := os.Stat(memoryCgroupPath + "/" + toptierSoftLimitControl)

--- a/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
+++ b/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
@@ -144,6 +144,10 @@ func (m *migration) PostStopHook(cc cache.Container) error {
 	return nil
 }
 
+func (m *migration) UpdateConfig(cache cache.Cache) error {
+	return nil
+}
+
 // syncWithCache synchronizes tracked containers with the cache.
 func (m *migration) syncWithCache() {
 	m.Lock()

--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -156,6 +156,10 @@ func (ctl *rdtctl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
+func (ctl *rdtctl) UpdateConfig(cache cache.Cache) error {
+	return nil
+}
+
 // assign assigns all processes/threads in a container to the correct class
 func (ctl *rdtctl) assign(c cache.Container) error {
 	if ctl.opt.Options.Mode == OperatingModeDisabled {

--- a/pkg/cri/resource-manager/controllers.go
+++ b/pkg/cri/resource-manager/controllers.go
@@ -17,6 +17,7 @@ package resmgr
 import (
 	// List of controllers to pull in.
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/blockio"
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/cpu"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/cri"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/memory"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/page-migrate"

--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
@@ -417,7 +417,8 @@ func (p *balloons) resetCpuClass() error {
 	//
 	// Note: p.useCpuClass(balloon) will be called before assigning
 	// containers on the balloon, including the reserved balloon.
-	log.Errorf("NOT IMPLEMENTED: resetCpuClass available: %s; reserved: %s", p.allowed, p.reserved)
+	p.cch.SetCPUClass(p.bpoptions.IdleCpuClass, p.allowed.ToSliceNoSort()...)
+	log.Debugf("resetCpuClass available: %s; reserved: %s", p.allowed, p.reserved)
 	return nil
 }
 
@@ -441,7 +442,8 @@ func (p *balloons) useCpuClass(bln *Balloon) error {
 	// - User-defined CPU AllocatorPriority: bln.Def.AllocatorPriority.
 	// - All existing balloon instances: p.balloons.
 	// - CPU configurations by user: bln.Def.CpuClass (for bln in p.balloons)
-	log.Errorf("NOT IMPLEMENTED: useCpuClass Cpus: %s; CpuClass: %s", bln.Cpus, bln.Def.CpuClass)
+	p.cch.SetCPUClass(bln.Def.CpuClass, bln.Cpus.ToSliceNoSort()...)
+	log.Debugf("useCpuClass Cpus: %s; CpuClass: %s", bln.Cpus, bln.Def.CpuClass)
 	return nil
 }
 
@@ -449,7 +451,8 @@ func (p *balloons) useCpuClass(bln *Balloon) error {
 func (p *balloons) forgetCpuClass(bln *Balloon) {
 	// Use p.IdleCpuClass for bln.Cpus.
 	// Usual inputs: see useCpuClass
-	log.Errorf("NOT IMPLEMENTED: forgetCpuClass Cpus: %s; CpuClass: %s", bln.Cpus, bln.Def.CpuClass)
+	p.cch.SetCPUClass(p.bpoptions.IdleCpuClass, bln.Cpus.ToSliceNoSort()...)
+	log.Debugf("forgetCpuClass Cpus: %s; CpuClass: %s", bln.Cpus, bln.Def.CpuClass)
 }
 
 func (p *balloons) newBalloon(blnDef *BalloonDef, confCpus bool) (*Balloon, error) {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -750,3 +750,12 @@ func (m *mockCache) OpenFile(string, string, os.FileMode) (*os.File, error) {
 func (m *mockCache) WriteFile(string, string, os.FileMode, []byte) error {
 	panic("unimplemented")
 }
+func (m *mockCache) SetCPUClass(string, ...int) {
+	panic("unimplemented")
+}
+func (m *mockCache) ClearPendingConfig() {
+	panic("unimplemented")
+}
+func (m *mockCache) TraversePendingConfig(func(string, ...int) error) error {
+	panic("unimplemented")
+}

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -813,7 +813,7 @@ func (m *resmgr) runPostAllocateHooks(ctx context.Context, method string) error 
 				c.PrettyName(), c.GetState())
 		}
 	}
-	return nil
+	return m.runUpdateConfigHooks(ctx, method)
 }
 
 // runPostStartHooks runs the necessary hooks after having started a container.
@@ -858,7 +858,7 @@ func (m *resmgr) runPostReleaseHooks(ctx context.Context, method string, release
 				method, c.PrettyName(), c.GetState())
 		}
 	}
-	return nil
+	return m.runUpdateConfigHooks(ctx, method)
 }
 
 // runPostUpdateHooks runs the necessary hooks after reconcilation.
@@ -883,6 +883,17 @@ func (m *resmgr) runPostUpdateHooks(ctx context.Context, method string) error {
 				c.PrettyName(), c.GetState())
 		}
 	}
+
+	return m.runUpdateConfigHooks(ctx, method)
+}
+
+// runUpdateConfigHooks runs the necessary hooks after configuration changes
+func (m *resmgr) runUpdateConfigHooks(ctx context.Context, method string) error {
+	if err := m.control.RunUpdateConfigHooks(m.cache); err != nil {
+		m.Warn("updateconfig hook failed: %v", err)
+	}
+
+	m.cache.ClearPendingConfig()
 	return nil
 }
 

--- a/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
@@ -41,6 +41,27 @@ policy:
         AllocatorPriority: 3
         PreferSpreadingPods: true
         PreferNewBalloons: true
+        CPUClass: class5
 
 logger:
   Debug: policy
+
+cpu:
+  classes:
+    default:
+      minFreq: 800
+      maxFreq: 2800
+    class2:
+      minFreq: 900
+      maxFreq: 2900
+    class3:
+      minFreq: 1000
+      maxFreq: 3000
+    class4:
+      minFreq: 1100
+      maxFreq: 3100
+      energyPerformancePreference: 1
+    class5:
+      minFreq: 1200
+      maxFreq: 3200
+      energyPerformancePreference: 2


### PR DESCRIPTION
This PR adds calls to the CPU controller to set a CPUs to a given CPU class for the balloons policy.
First patch is from @marquiz and can be found here #799 

