### PR TITLE
sst: Pass around pointer to SST info struct

### DIFF
--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -446,6 +446,7 @@ func (c *topologyCache) discoverSstCPUPriority(sys sysfs.System, pkgID idset.ID)
 	// 2. SST-CP dictates over SST-BF
 	// 3. SST-BF is meaningful if neither SST-TF nor SST-CP is enabled
 	switch {
+	case sst == nil:
 	case sst.TFEnabled:
 		log.Debug("package #%d: using SST-TF based CPU prioritization", pkgID)
 		// We only look at the CLOS id as SST-TF (seems to) follows ordered CLOS priority
@@ -475,7 +476,7 @@ func (c *topologyCache) discoverSstCPUPriority(sys sysfs.System, pkgID idset.ID)
 		}
 	}
 
-	if !active && sst.BFEnabled {
+	if !active && sst != nil && sst.BFEnabled {
 		log.Debug("package #%d: using SST-BF based CPU prioritization", pkgID)
 		for _, i := range cpuIDs {
 			id := idset.ID(i)

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -104,8 +104,8 @@ func (p *mockCPUPackage) DieNodeIDs(idset.ID) []idset.ID {
 	return []idset.ID{}
 }
 
-func (p *mockCPUPackage) SstInfo() sst.SstPackageInfo {
-	return sst.SstPackageInfo{}
+func (p *mockCPUPackage) SstInfo() *sst.SstPackageInfo {
+	return &sst.SstPackageInfo{}
 }
 
 type mockCPU struct {

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -115,7 +115,7 @@ type CPUPackage interface {
 	NodeIDs() []idset.ID
 	DieNodeIDs(idset.ID) []idset.ID
 	DieCPUSet(idset.ID) cpuset.CPUSet
-	SstInfo() sst.SstPackageInfo
+	SstInfo() *sst.SstPackageInfo
 }
 
 type cpuPackage struct {
@@ -125,7 +125,7 @@ type cpuPackage struct {
 	dies     idset.IDSet              // dies in this package
 	dieCPUs  map[idset.ID]idset.IDSet // CPUs per die
 	dieNodes map[idset.ID]idset.IDSet // NUMA nodes per die
-	sstInfo  sst.SstPackageInfo       // Speed Select Technology info
+	sstInfo  *sst.SstPackageInfo      // Speed Select Technology info
 }
 
 // Node represents a NUMA node.
@@ -988,7 +988,7 @@ func (sys *system) discoverSst() error {
 				sys.cpus[id].sstClos = clos
 			}
 		}
-		pkg.sstInfo = *sstInfo[pkg.id]
+		pkg.sstInfo = sstInfo[pkg.id]
 	}
 
 	return nil
@@ -1030,7 +1030,7 @@ func (p *cpuPackage) DieCPUSet(id idset.ID) cpuset.CPUSet {
 	return cpuset.NewCPUSet()
 }
 
-func (p *cpuPackage) SstInfo() sst.SstPackageInfo {
+func (p *cpuPackage) SstInfo() *sst.SstPackageInfo {
 	return p.sstInfo
 }
 


### PR DESCRIPTION
Earlier code manipulated full SST info in CPU discovery, but this
is not needed as we can just use the pointer to SST info in the code.
This clarifies the usage, as the SstPackageInfo struct contains a slice
which can confuse the user if SstPackageInfo is not passed around as a
pointer value. This also saves some tiny amount of memory.