### PR TITLE
balloons: add PreferSpreadingDifferentNamespace option

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/fillmethod.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/fillmethod.go
@@ -40,6 +40,9 @@ const (
 	// it minimizes the amount of unused CPUs if the balloon is
 	// inflated to the maximum size.
 	FillPackedInflate
+	// FillSameNamespace: put a container into a balloon that already
+	// includes another container from the same namespace
+	FillSameNamespace
 	// FillSamePod: put a container into a balloon that already
 	// includes another container from the same pod.
 	FillSamePod
@@ -64,6 +67,7 @@ var fillMethodNames = map[FillMethod]string{
 	FillBalancedInflate: "balanced-inflate",
 	FillPacked:          "packed",
 	FillPackedInflate:   "packed-inflate",
+	FillSameNamespace:   "same-namespace",
 	FillSamePod:         "same-pod",
 	FillNewBalloon:      "new-balloon",
 	FillNewBalloonMust:  "new-balloon-must",

--- a/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
@@ -71,6 +71,13 @@ type BalloonDef struct {
 	// placed on separate balloons. The default is false: prefer
 	// placing containers of a pod to the same balloon(s).
 	PreferSpreadingPods bool
+	// PreferPerNamespaceBalloon: if true, containers in different
+	// namespaces are preferrably placed in separate balloons,
+	// even if the balloon type is the same for all of them. On
+	// the other hand, containers in the same namespace will be
+	// placed in the same balloon instances. The default is false:
+	// namespaces have no effect on placement.
+	PreferPerNamespaceBalloon bool
 	// PreferNewBalloons: prefer creating new balloons over adding
 	// containers to existing balloons. The default is false:
 	// prefer using filling free capacity and possibly inflating

--- a/sample-configs/balloons-policy.cfg
+++ b/sample-configs/balloons-policy.cfg
@@ -51,6 +51,13 @@ policy:
         # putting them in the same balloon.
         # The default is: false.
         PreferNewBalloons: true
+	# PreferSpreadingDifferentNamespaces: if true, containers in
+	# different namespaces are preferrably placed in separate
+	# balloons, even if the balloon type is the same for all of
+	# them. On the other hand, containers in the same namespace
+	# will be placed in the same balloon instances. The default is
+	# false: namespaces have no effect on placement.
+	PreferSpreadingDifferentNamespaces: false
         # PreferSpreadingPods: if true, containers of single pod can
         # be assigned in different balloons, based on which balloons
         # have most free CPU resources.

--- a/test/e2e/policies.test-suite/balloons/n4c16/test05-namespace/balloons-namespace.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test05-namespace/balloons-namespace.cfg
@@ -1,0 +1,14 @@
+policy:
+  Active: balloons
+  ReservedResources:
+    CPU: 1
+  balloons:
+    BalloonTypes:
+      - Name: nsballoon
+        Namespaces:
+          - "*"
+        MinCPUs: 2
+        MaxCPUs: 4
+        PreferSpreadingDifferentNamespaces: true
+logger:
+  Debug: policy

--- a/test/e2e/policies.test-suite/balloons/n4c16/test05-namespace/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test05-namespace/code.var.sh
@@ -1,0 +1,89 @@
+terminate cri-resmgr
+cri_resmgr_cfg=${TEST_DIR}/balloons-namespace.cfg launch cri-resmgr
+
+cleanup() {
+    vm-command \
+        "kubectl delete pods -n e2e-a --all --now
+         kubectl delete pods -n e2e-b --all --now
+         kubectl delete pods -n e2e-c --all --now
+         kubectl delete pods -n e2e-d --all --now
+         kubectl delete pods --all --now
+         kubectl delete namespace e2e-a
+         kubectl delete namespace e2e-b
+         kubectl delete namespace e2e-c
+         kubectl delete namespace e2e-d"
+    return 0
+}
+cleanup
+
+kubectl create namespace e2e-a
+kubectl create namespace e2e-b
+kubectl create namespace e2e-c
+kubectl create namespace e2e-d
+
+# pod0: create in the default namespace, both containers go to nsballoon[0]
+CPUREQ=""
+CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'len(cpus["pod0c0"]) == 2'
+
+# pod1: create in the e2e-a namespace, both containers go nsballoon[1] because
+# nsballoon[0] does not contain any containers in this namespace.
+CPUREQ=""
+namespace="e2e-a" CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod1c0"] == cpus["pod1c1"]' \
+       'len(cpus["pod0c0"]) == 2' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"])'
+
+# pod2: create in the default namespace, should go to nsballoon[0] as
+# pod0, and the balloon should inflate to 4 CPUs. cpusets with pod1
+# should not overlap after inflation.
+CPUREQ="2" MEMREQ="100M" CPULIM="2" MEMLIM="100M"
+CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod2c0"] == cpus["pod2c1"]' \
+       'len(cpus["pod2c0"]) == 4' \
+       'cpus["pod2c0"] == cpus["pod0c0"]' \
+       'cpus["pod2c0"] == cpus["pod0c1"]' \
+       'disjoint_sets(cpus["pod2c0"], cpus["pod1c0"])'
+
+# pod3: create again in the default namespace. nsballoon[0] has
+# reached the maximum capacity, nsballoon[2] should be created for
+# this pod.
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod3c0"] == cpus["pod3c1"]' \
+       'len(cpus["pod3c0"]) == 2' \
+       'disjoint_sets(cpus["pod3c0"], cpus["pod2c0"], cpus["pod1c0"])'
+
+# pod4: new namespace => nsballoon[3]
+CPUREQ="2" MEMREQ="100M" CPULIM="2" MEMLIM="100M"
+namespace="e2e-b" CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod4c0"] == cpus["pod4c1"]' \
+       'len(cpus["pod4c0"]) == 4' \
+       'disjoint_sets(cpus["pod4c0"], cpus["pod3c0"], cpus["pod2c0"], cpus["pod1c0"])'
+
+# pod5: new namespace => nsballoon[5]
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+namespace="e2e-c" CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod5c0"] == cpus["pod5c1"]' \
+       'len(cpus["pod5c0"]) == 2' \
+       'disjoint_sets(cpus["pod5c0"], cpus["pod4c0"], cpus["pod3c0"], cpus["pod2c0"], cpus["pod1c0"])'
+
+# pod6: new namespace, but nsballoon[6] cannot be created because all
+# CPUs are already allocated to balloons. Cannot honor the preference
+# of spreading different namespaces to different balloon instances
+# anymore, should fallback to balanced assignment.
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+namespace="e2e-d" CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'cpus["pod6c0"] == cpus["pod6c1"]'
+
+cleanup
+terminate cri-resmgr
+launch cri-resmgr


### PR DESCRIPTION
- Enables preferring new balloon instances of the same balloon type
  for containers that run in different namespaces. At the same time,
  starts preferring to place containers in the same namespace to the
  same balloon instance.