### PR TITLE
control/cpu: add uncore frequency controls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0
-	github.com/intel/goresctrl v0.2.1-0.20220408111310-9f1bb7c427f7
+	github.com/intel/goresctrl v0.2.1-0.20220511084516-1b61a39df7b6
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63
-	golang.org/x/sys v0.0.0-20220207234003-57398862261d
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/grpc v1.40.0
 	k8s.io/api v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/intel/goresctrl v0.2.1-0.20220408111310-9f1bb7c427f7 h1:uE6GFCPzpeP9V47PQAz3ejpZRJ64eKQO1Z9r+AT+5sM=
-github.com/intel/goresctrl v0.2.1-0.20220408111310-9f1bb7c427f7/go.mod h1:Ksyuj15WP36VG7/86vKN4U4IZQuGNEqhQegjoKqRph0=
+github.com/intel/goresctrl v0.2.1-0.20220511084516-1b61a39df7b6 h1:XPyQAJzU5AKVZr9HZU84JRElFfk7QKx6HKDlznGJGZ4=
+github.com/intel/goresctrl v0.2.1-0.20220511084516-1b61a39df7b6/go.mod h1:DtH6keLT/YDQmDRAJ42ZWngdZDje80oX837/pl/qvfo=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -942,8 +942,8 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
-golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/cri/resource-manager/control/cpu/api.go
+++ b/pkg/cri/resource-manager/control/cpu/api.go
@@ -57,8 +57,12 @@ func Assign(c cache.Cache, class string, cpus ...int) error {
 	if getCPUController().started {
 		// We don't want to try to enforce until the controller has been fully
 		// started. Enforcement of all assignments happens on StarT(), anyway.
-		if err := getCPUController().enforce(class, cpus...); err != nil {
-			log.Error("cpu class enforcement failed: %v", err)
+		ctl := getCPUController()
+		if err := ctl.enforceCpufreq(class, cpus...); err != nil {
+			log.Error("cpufreq enforcement failed: %v", err)
+		}
+		if err := ctl.enforceUncore(assignments, cpus...); err != nil {
+			log.Error("uncore frequency enforcement failed: %v", err)
 		}
 	}
 

--- a/pkg/cri/resource-manager/control/cpu/cpu.go
+++ b/pkg/cri/resource-manager/control/cpu/cpu.go
@@ -17,11 +17,14 @@ package cpu
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/client"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
 	"github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -35,19 +38,25 @@ const (
 
 // cpuctl encapsulates the runtime state of our CPU enforcement/controller.
 type cpuctl struct {
-	cache   cache.Cache // resource manager cache
+	cache   cache.Cache  // resource manager cache
+	system  sysfs.System // system topology
 	config  *config
 	started bool
 }
 
 type config struct {
 	Classes map[string]Class `json:"classes"`
+
+	// Private field for storing info if we need to care about uncore
+	uncoreEnabled bool
 }
 
 type Class struct {
 	MinFreq                     uint `json:"minFreq"`
 	MaxFreq                     uint `json:"maxFreq"`
 	EnergyPerformancePreference uint `json:"energyPerformancePreference"`
+	UncoreMinFreq               uint `json:"uncoreMinFreq"`
+	UncoreMaxFreq               uint `json:"uncoreMaxFreq"`
 }
 
 var log logger.Logger = logger.NewLogger(CPUController)
@@ -66,6 +75,12 @@ func getCPUController() *cpuctl {
 
 // Start initializes the controller for enforcing decisions.
 func (ctl *cpuctl) Start(cache cache.Cache, client client.Client) error {
+	sys, err := sysfs.DiscoverSystem()
+	if err != nil {
+		return fmt.Errorf("failed to discover system topology: %w", err)
+	}
+
+	ctl.system = sys
 	ctl.cache = cache
 
 	// DEBUG: dump the class assignments we have stored in the cache
@@ -73,7 +88,7 @@ func (ctl *cpuctl) Start(cache cache.Cache, client client.Client) error {
 
 	if err := ctl.configure(); err != nil {
 		// Just print an error. A config update later on may be valid.
-		log.Error("failed apply initial configuration: %v", err)
+		log.Error("failed apply /cpuinitial configuration: %v", err)
 	}
 
 	// TODO: We probably could just remove this and the hooks if they are not used
@@ -113,36 +128,136 @@ func (ctl *cpuctl) PostStopHook(c cache.Container) error {
 	return nil
 }
 
-// enforce enforces a class-specific configuration to a cpuset
-func (ctl *cpuctl) enforce(class string, cpus ...int) error {
+// enforceCpufreq enforces a class-specific cpufreq configuration to a cpuset
+func (ctl *cpuctl) enforceCpufreq(class string, cpus ...int) error {
 	if _, ok := ctl.config.Classes[class]; !ok {
 		return fmt.Errorf("non-existent cpu class %q", class)
 	}
 
-	log.Debug("enforcing cpu class %q on %v", class, cpus)
+	min := int(ctl.config.Classes[class].MinFreq)
+	max := int(ctl.config.Classes[class].MaxFreq)
+	log.Debug("enforcing cpu frequency limits {%d, %d} from class %q on %v", min, max, class, cpus)
 
-	if err := utils.SetCPUsScalingMinFreq(cpus, (int)(ctl.config.Classes[class].MinFreq)); err != nil {
-		return fmt.Errorf("Cannot set min freq %d: %w", ctl.config.Classes[class].MinFreq, err)
+	if err := utils.SetCPUsScalingMinFreq(cpus, min); err != nil {
+		return fmt.Errorf("Cannot set min freq %d: %w", min, err)
 	}
 
-	if err := utils.SetCPUsScalingMaxFreq(cpus, (int)(ctl.config.Classes[class].MaxFreq)); err != nil {
-		return fmt.Errorf("Cannot set max freq %d: %w", ctl.config.Classes[class].MaxFreq, err)
+	if err := utils.SetCPUsScalingMaxFreq(cpus, max); err != nil {
+		return fmt.Errorf("Cannot set max freq %d: %w", max, err)
 	}
 
 	return nil
+}
+
+// enforceUncore enforces uncore frequency limits
+func (ctl *cpuctl) enforceUncore(assignments cpuClassAssignments, affectedCPUs ...int) error {
+	if !ctl.config.uncoreEnabled {
+		return nil
+	}
+
+	cpus := cpuset.NewCPUSet(affectedCPUs...)
+
+	for _, cpuPkgID := range ctl.system.PackageIDs() {
+		cpuPkg := ctl.system.Package(cpuPkgID)
+		for _, cpuDieID := range cpuPkg.DieIDs() {
+			dieCPUs := cpuPkg.DieCPUSet(cpuDieID)
+
+			// Check if this die is affected by the specified cpuset
+			if cpus.Size() == 0 || dieCPUs.Intersection(cpus).Size() > 0 {
+				min, max, minCls, maxCls := effectiveUncoreFreqs(utils.NewIDSet(dieCPUs.ToSlice()...), ctl.config.Classes, assignments)
+
+				if min == 0 && max == 0 {
+					log.Debug("no uncore frequency limits for cpu package/die %d/%d", cpuPkgID, cpuDieID)
+					continue
+				}
+
+				log.Debug("enforcing uncore min freq to %d (class %q), max freq to %d (class %q) on cpu package/die %d/%d", min, minCls, max, maxCls, cpuPkgID, cpuDieID)
+				if min > 0 {
+					if max > 0 && min > max {
+						log.Warn("uncore frequency limit min > max (%d > %d) on cpu package/die %d/%d", min, max, cpuPkgID, cpuDieID)
+					}
+
+					if err := utils.SetUncoreMinFreq(cpuPkgID, cpuDieID, int(min)); err != nil {
+						return err
+					}
+				}
+				if max > 0 {
+					if err := utils.SetUncoreMaxFreq(cpuPkgID, cpuDieID, int(max)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// effectiveUncoreClasses resolves the effective classes for setting the uncore
+// frequency limits for a cpu package/die. It has "performance preference" so
+// that the highest value (for both min and max) of the cpu classes effective
+// on the die is selected.
+func effectiveUncoreFreqs(cpus utils.IDSet, classes map[string]Class, assignments cpuClassAssignments) (minFreq, maxFreq uint, minCls, maxCls string) {
+	for className, assignedCPUs := range assignments {
+		// Check if this class is "effective" on the specified cpuset
+		if idSetIntersects(cpus, assignedCPUs) {
+			class := classes[className]
+			if class.UncoreMinFreq > minFreq {
+				minCls = className
+				minFreq = class.UncoreMinFreq
+			}
+			if class.UncoreMaxFreq > maxFreq {
+				maxCls = className
+				maxFreq = class.UncoreMaxFreq
+			}
+		}
+	}
+	return minFreq, maxFreq, minCls, maxCls
+}
+
+func idSetIntersects(a, b utils.IDSet) bool {
+	// Try to optimize the search for unbalanced idsets
+	if len(a) < len(b) {
+		for id := range a {
+			if _, ok := b[id]; ok {
+				return true
+			}
+		}
+	} else {
+		for id := range b {
+			if _, ok := a[id]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (ctl *cpuctl) configure() error {
 	// Re-configure CPUs that are assigned to some known class
 	assignments := *getClassAssignments(ctl.cache)
 
+	// DEBUG: dump the class assignments we have stored in the cache
+	log.Debug("applying cpu controller configuration:\n%s", utils.DumpJSON(ctl.config))
+
+	// Sanity check
+	uncoreAvailable := utils.UncoreFreqAvailable()
+	for name, conf := range ctl.config.Classes {
+		if conf.UncoreMinFreq != 0 || conf.UncoreMaxFreq != 0 {
+			if !uncoreAvailable {
+				return fmt.Errorf("uncore limits set in cpu class %q but uncore driver not available in the system, make sure that the intel_uncore_frequency driver is loaded", name)
+			}
+			ctl.config.uncoreEnabled = true
+			break
+		}
+	}
+
+	// Configure the system
 	for class, cpus := range assignments {
 		if _, ok := ctl.config.Classes[class]; ok {
 			// Re-configure cpus (sysfs) according to new class parameters
-			if err := ctl.enforce(class, cpus.SortedMembers()...); err != nil {
-				log.Error("cpu class enforcement on re-configure failed: %v", err)
+			if err := ctl.enforceCpufreq(class, cpus.SortedMembers()...); err != nil {
+				log.Error("cpufreq enforcement on re-configure failed: %v", err)
 			}
-
 		} else {
 			// TODO: what should we really do with classes that do not exist in
 			// the configuration anymore? Now we remember the CPUs assigned to
@@ -150,6 +265,9 @@ func (ctl *cpuctl) configure() error {
 			// which case the CPUs will be reconfigured.
 			log.Warn("class %q with cpus %v missing from the configuration", class, cpus)
 		}
+	}
+	if err := ctl.enforceUncore(assignments); err != nil {
+		log.Error("uncore frequency enforcement on re-configure failed: %v", err)
 	}
 
 	log.Debug("cpu controller configured")


### PR DESCRIPTION
Support uncore frequency limits in the cpu controller. This patch adds
new 'uncoreMinFreq' and 'uncoreMaxFreq' fields to the cpu class
configuration.

Uncore frequency limits are only controllable on the cpu die level in
the HW. When resolving the per-die effective uncore frequency the
controller prefers performance i.e. selects the highest requested value.
For every die it selects the highest value (for both min and max) of all
cpu classes that are effective on that die.

An example configuration with uncore limits:

```
    cpu:
      classes:
        high-prio:
            minFreq: 2000000
            maxFreq: 5000000
            uncoreMinFreq: 2000000
            uncoreMaxFreq: 2400000
        low-prio:
            minFreq: 1000000
            maxFreq: 1500000
            uncoreMinFreq: 1200000
            uncoreMaxFreq: 1800000
```