### PR TITLE
e2e: enable running tests on multi-node clusters

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -903,16 +903,23 @@ default-setup-proxies() {
     local file scope="" append="--append" hn
     hn="$(vm-command-q hostname)"
 
+    local master_node_ip_comma=""
+    if [ -n "$k8smaster" ]; then
+        local master_user_ip
+        master_user_ip="$(vm-ssh-user-ip $k8smaster)"
+        master_node_ip_comma=${master_user_ip/*@},
+    fi
+
     for file in /etc/environment /etc/profile.d/proxy.sh; do
         cat <<EOF |
 ${scope}http_proxy=$http_proxy
 ${scope}https_proxy=$https_proxy
 ${scope}ftp_proxy=$ftp_proxy
-${scope}no_proxy=$no_proxy,$VM_IP,10.96.0.0/12,$CNI_SUBNET,$hn,.svc
+${scope}no_proxy=$no_proxy,$master_node_ip_comma$VM_IP,10.96.0.0/12,$CNI_SUBNET,$hn,.svc
 ${scope}HTTP_PROXY=$http_proxy
 ${scope}HTTPS_PROXY=$https_proxy
 ${scope}FTP_PROXY=$ftp_proxy
-${scope}NO_PROXY=$no_proxy,$VM_IP,10.96.0.0/12,$CNI_SUBNET,$hn,.svc
+${scope}NO_PROXY=$no_proxy,$master_node_ip_comma$VM_IP,10.96.0.0/12,$CNI_SUBNET,$hn,.svc
 EOF
       vm-pipe-to-file $append $file
       scope="export "
@@ -924,7 +931,7 @@ EOF
 [Service]
 Environment=HTTP_PROXY=$http_proxy
 Environment=HTTPS_PROXY=$https_proxy
-Environment=NO_PROXY=$no_proxy,$VM_IP,10.96.0.0/12,$CNI_SUBNET,$hn,.svc
+Environment=NO_PROXY=$no_proxy,$master_node_ip_comma$VM_IP,10.96.0.0/12,$CNI_SUBNET,$hn,.svc
 EOF
         vm-pipe-to-file $file
     done
@@ -936,7 +943,7 @@ EOF
         "default": {
             "httpProxy": "$http_proxy",
             "httpsProxy": "$https_proxy",
-            "noProxy": "$no_proxy,$VM_IP,$hn"
+            "noProxy": "$no_proxy,$master_node_ip_comma$VM_IP,$hn"
         }
     }
 }


### PR DESCRIPTION
If k8smaster environment variable is set, test/e2e/run.sh will join
new vm to an existing cluster instead of creating its own single-node
cluster.