### PR TITLE
resmgr: disallow talking to untested runtimes by default.

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -341,36 +341,11 @@ Starting from scratch:
    * [Cgroup and Kata containers](https://github.com/kata-containers/kata-containers/blob/stable-2.0.0/docs/design/host-cgroups.md)
 
 
-## Using Docker\* as the runtime
+## Running with Untested Runtimes
 
-If you must use `docker` as the runtime then the proxying setup is slightly
-more complex. Docker does not natively support the CRI API. Normally kubelet
-runs an internal protocol translator, `dockershim` to translate between CRI
-and the native docker API. To let CRI Resource Manager effectively proxy
-between kubelet and `docker` it needs to actually proxy between kubelet and
-`dockershim`. For this to be possible, you need to run two instances of
-kubelet:
-
-  1. The real instance, talking to CRI Resource Manager/CRI
-  2. The dockershim instance, acting as a CRI-docker protocol translator
-
-Run the real kubelet instance as you would normally with any other real CRI
-runtime, but specify the dockershim socket for the CRI Image Service, as
-shown below:
-
-```
-   kubelet <other-kubelet-options> --container-runtime=remote \
-     --container-runtime-endpoint=unix:///var/run/cri-resmgr/cri-resmgr.sock \
-     --image-service-endpoint=unix:///var/run/dockershim.sock
-```
-
-Run the dockershim instance as shown below, picking the cgroupfs driver
-according to the configuration of the real kubelet instance:
-
-```
-  kubelet --experimental-dockershim --port 11250 --cgroup-driver {systemd|cgroupfs}
-
-```
+CRI Resource Manager is tested with `containerd` and `CRI-O`. If any other runtime is
+detected during startup, `cri-resmgr` will refuse to start. This default behavior can
+be changed using the `--allow-untested-runtimes` command line option.
 
 ## Logging and debugging
 

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -24,27 +24,32 @@ import (
 
 // Options captures our command line parameters.
 type options struct {
-	ImageSocket         string
-	RuntimeSocket       string
-	RelaySocket         string
-	RelayDir            string
-	AgentSocket         string
-	ConfigSocket        string
-	PidFile             string
-	ResctrlPath         string
-	FallbackConfig      string
-	ForceConfig         string
-	ForceConfigSignal   string
-	DisablePolicySwitch bool
-	ResetPolicy         bool
-	ResetConfig         bool
-	MetricsTimer        time.Duration
-	RebalanceTimer      time.Duration
-	DisableUI           bool
+	ImageSocket           string
+	RuntimeSocket         string
+	RelaySocket           string
+	RelayDir              string
+	AllowUntestedRuntimes bool
+	AgentSocket           string
+	ConfigSocket          string
+	PidFile               string
+	ResctrlPath           string
+	FallbackConfig        string
+	ForceConfig           string
+	ForceConfigSignal     string
+	DisablePolicySwitch   bool
+	ResetPolicy           bool
+	ResetConfig           bool
+	MetricsTimer          time.Duration
+	RebalanceTimer        time.Duration
+	DisableUI             bool
 }
 
 // Relay command line options.
 var opt = options{}
+
+const (
+	allowUntestedRuntimesFlag = "allow-untested-runtimes"
+)
 
 // Register us for command line option processing.
 func init() {
@@ -56,6 +61,9 @@ func init() {
 		"Unix domain socket path where the resource manager should serve requests on.")
 	flag.StringVar(&opt.RelayDir, "relay-dir", "/var/lib/cri-resmgr",
 		"Permanent storage directory path for the resource manager to store its state in.")
+	flag.BoolVar(&opt.AllowUntestedRuntimes, allowUntestedRuntimesFlag, false,
+		"Allow proxying for untested CRI runtimes. Usually this is not a good idea.")
+
 	flag.StringVar(&opt.AgentSocket, "agent-socket", sockets.ResourceManagerAgent,
 		"local socket of the cri-resmgr agent to connect")
 	flag.StringVar(&opt.ConfigSocket, "config-socket", sockets.ResourceManagerConfig,

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -15,6 +15,7 @@
 package resmgr
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -151,6 +152,10 @@ func (m *resmgr) Start() error {
 
 	m.Lock()
 	defer m.Unlock()
+
+	if err := m.checkRuntime(context.Background()); err != nil {
+		return err
+	}
 
 	if err := m.startControllers(); err != nil {
 		return err

--- a/test/functional/e2e_test.go
+++ b/test/functional/e2e_test.go
@@ -88,6 +88,9 @@ func (env *testEnv) Run(name string, testFunction func(context.Context, *testEnv
 		if err := flag.Set("config-socket", filepath.Join(tmpDir, "config.sock")); err != nil {
 			t.Fatalf("unable to set config-socket")
 		}
+		if err := flag.Set("allow-untested-runtimes", "true"); err != nil {
+			t.Fatalf("unable to allow untested runtimes: %v", err)
+		}
 
 		if env.forceConfig != "" {
 			path := filepath.Join(tmpDir, "forcedconfig.cfg")

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -31,6 +31,13 @@ import (
 	api "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
+const (
+	fakeKubeAPIVersion    = "0.1.0"
+	fakeRuntimeName       = "fake-CRI-runtime"
+	fakeRuntimeVersion    = "v0.0.0"
+	fakeRuntimeAPIVersion = "v1"
+)
+
 type fakeCriServer struct {
 	t            *testing.T
 	socket       string
@@ -125,7 +132,16 @@ func (s *fakeCriServer) callHandler(ctx context.Context, request interface{}, de
 // Implementation of api.RuntimeServiceServer
 
 func (s *fakeCriServer) Version(ctx context.Context, req *api.VersionRequest) (*api.VersionResponse, error) {
-	response, err := s.callHandler(ctx, req, nil)
+	response, err := s.callHandler(ctx, req,
+		func(*fakeCriServer, context.Context, *api.VersionRequest) (*api.VersionResponse, error) {
+			return &api.VersionResponse{
+				Version:           fakeKubeAPIVersion,
+				RuntimeName:       fakeRuntimeName,
+				RuntimeVersion:    fakeRuntimeVersion,
+				RuntimeApiVersion: fakeRuntimeAPIVersion,
+			}, nil
+		},
+	)
 	return response.(*api.VersionResponse), err
 }
 


### PR DESCRIPTION
Disallow talking to/proxying for unknown runtimes, unless explicitly told to do so on the command line. This could save us quite a bit of time from chasing ghosts.

Inspired by an idea from @jukkar over a lunch discussion. Thanks !