### PR TITLE
Add NRI support to e2e scripts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
         go-version: 1.18

--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -43,6 +43,8 @@ distro-install-kernel-dev() { distro-resolve "$@"; }
 distro-k8s-cni()            { distro-resolve "$@"; }
 distro-k8s-cni-subnet()     { distro-resolve "$@"; }
 distro-set-kernel-cmdline() { distro-resolve "$@"; }
+distro-add-kernel-cmdline-arg() { distro-resolve "$@"; }
+distro-del-kernel-cmdline-arg() { distro-resolve "$@"; }
 distro-bootstrap-commands() { distro-resolve "$@"; }
 distro-env-file-dir()       { distro-resolve "$@"; }
 
@@ -399,6 +401,7 @@ fedora-ssh-user() {
 
 fedora-install-utils() {
     distro-install-pkg /usr/bin/pidof
+    distro-install-pkg grubby
 }
 
 fedora-install-repo() {
@@ -560,6 +563,33 @@ EOF
 
 fedora-33-install-crio-pre() {
     fedora-install-crio-version 1.20
+}
+
+fedora-add-kernel-cmdline-arg() {
+    local e2e_opts="$*"
+
+    vm-command "grubby --args=\"$e2e_opts\" --update-kernel=DEFAULT" || {
+        command-error "adding new command line parameters failed"
+    }
+}
+
+fedora-del-kernel-cmdline-arg() {
+    local e2e_opts="$*"
+
+    vm-command "grubby --remove-args=\"$e2e_opts\" --update-kernel=DEFAULT" || {
+        command-error "removing new command line parameters failed"
+    }
+}
+
+fedora-set-kernel-cmdline() {
+    local e2e_defaults="$*"
+    vm-command "mkdir -p /etc/default; touch /etc/default/grub; sed -i '/e2e:fedora-set-kernel-cmdline/d' /etc/default/grub"
+    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\" # by e2e:fedora-set-kernel-cmdline' >> /etc/default/grub" || {
+        command-error "writing new command line parameters failed"
+    }
+    vm-command "grub2-mkconfig -o /boot/grub2/grub.cfg" || {
+        command-error "updating grub failed"
+    }
 }
 
 ###########################################################################
@@ -987,6 +1017,17 @@ default-install-utils() {
     # utilities, such as pidof and killall, that the test framework
     # and tests in general can expect to be found on VM.
     :
+}
+
+# For distros that do not have grubby, use the set-kernel-cmdline function.
+default-add-kernel-cmdline-arg() {
+    local e2e_opts="$*"
+
+    default-set-kernel-cmdline $e2e_opts
+}
+
+default-del-kernel-cmdline-arg() {
+    default-set-kernel-cmdline ""
 }
 
 default-k8s-cni() {

--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -29,11 +29,14 @@ distro-setup-oneshot()      { distro-resolve "$@"; }
 distro-install-utils()      { distro-resolve "$@"; }
 distro-install-golang()     { distro-resolve "$@"; }
 distro-install-runc()       { distro-resolve "$@"; }
+distro-install-toml()       { distro-resolve "$@"; }
 distro-install-containerd() { distro-resolve "$@"; }
 distro-config-containerd()  { distro-resolve "$@"; }
+distro-reconfig-containerd(){ distro-resolve "$@"; }
 distro-restart-containerd() { distro-resolve "$@"; }
 distro-install-crio()       { distro-resolve "$@"; }
 distro-config-crio()        { distro-resolve "$@"; }
+distro-reconfig-crio()      { distro-resolve "$@"; }
 distro-restart-crio()       { distro-resolve "$@"; }
 distro-install-k8s()        { distro-resolve "$@"; }
 distro-install-kernel-dev() { distro-resolve "$@"; }
@@ -1002,9 +1005,20 @@ default-install-runc() {
     distro-install-pkg runc
 }
 
+default-install-toml() {
+    distro-install-pkg python3-pip
+    vm-command "pip3 install toml tomli_w"
+}
+
 default-install-containerd() {
     vm-command-q "[ -f /usr/bin/containerd ]" || {
         distro-install-pkg containerd
+
+	# We need toml python libs in order to modify containerd config.toml
+	# file when NRI is used.
+	if [ "$VM_NRI" == "1" ]; then
+	    distro-install-toml
+	fi
     }
 }
 
@@ -1022,8 +1036,29 @@ default-config-containerd() {
     vm-sed-file /etc/containerd/config.toml 's/SystemdCgroup = false/SystemdCgroup = true/g'
 }
 
+default-reconfig-containerd() {
+    if [ "$VM_NRI" == "1" ]; then
+	# Make sure NRI plugin will be there in the config file by removing the config file
+	# and then re-creating it with defaults that contain the NRI stuff.
+	vm-command "rm -f /etc/containerd/config.toml"
+	default-config-containerd
+
+	vm-put-file "containerd-nri-enable" "/usr/bin/containerd-nri-enable"
+	vm-command "containerd-nri-enable" ||
+	    command-error "failed to enable NRI in containerd"
+
+	if vm-command-q "[ ! -f /etc/nri/nri.conf ]"; then
+	    vm-command "mkdir -p /etc/nri"
+	    echo "disablePluginConnections: false" | vm-pipe-to-file "/etc/nri/nri.conf"
+	fi
+
+	distro-restart-containerd
+	sleep 2
+    fi
+}
+
 default-restart-containerd() {
-    vm-command "systemctl daemon-reload && systemctl restart containerd" ||
+    vm-command "systemctl daemon-reload && (killall containerd-shim-runc-v2; systemctl restart containerd)" ||
         command-error "failed to restart containerd systemd service"
 }
 

--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -36,7 +36,7 @@ host-get-vm-config() {
         return 1
     fi
     source "$VM_DATA_CONFIG"
-    if [ -z "$VM_NAME" ] || [ -z "$VM_DISTRO" ] || [ -z "$VM_CRI" ] || [ -z "$VM_SSH_USER" ]; then
+    if [ -z "$VM_NAME" ] || [ -z "$VM_DISTRO" ] || [ -z "$VM_CRI" ] || [ -z "$VM_SSH_USER" ] || [ -z "$VM_NRI" ]; then
         return 1
     fi
     VM_COMPOSE_YAML="$HOST_VM_DATA_DIR/govm-compose.yaml"
@@ -55,6 +55,7 @@ host-set-vm-config() {
     VM_NAME="$1"
     VM_DISTRO="$2"
     VM_CRI="$3"
+    VM_NRI="$4"
     VM_SSH_USER="$(vm-ssh-user)"
     HOST_VM_DATA_DIR="$(eval "echo $HOST_VM_DATA_DIR_TEMPLATE")"
     mkdir -p "$HOST_VM_DATA_DIR"
@@ -65,6 +66,7 @@ VM_NAME="$VM_NAME"
 VM_DISTRO="$VM_DISTRO"
 VM_CRI="$VM_CRI"
 VM_SSH_USER="$VM_SSH_USER"
+VM_NRI="$VM_NRI"
 EOF
 }
 
@@ -177,6 +179,7 @@ host-create-vm() {
     echo "# VM name        : $VM_NAME"
     echo "# VM Linux distro: $VM_DISTRO"
     echo "# VM CRI         : $VM_CRI"
+    echo "# VM NRI         : $VM_NRI"
     echo "# VM Docker image: $VM_CONTAINER_IMAGE"
     echo "# VM Docker cntnr: $VM_CONTAINER_ID"
     if [ -n "$VM_CONTAINER_IMAGE" ]; then

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -849,6 +849,11 @@ vm-install-cri() {
             vm-command "systemctl enable --now crio"
         fi
     fi
+
+    # Make sure we have proper CRI version (either the distro one or the user specific one)
+    # running and then do the reconfig for it. Important if NRI is used with containerd in
+    # order to enable NRI support.
+    distro-reconfig-"$VM_CRI"
 }
 
 vm-install-containernetworking() {
@@ -1015,7 +1020,7 @@ vm-create-singlenode-cluster() {
 }
 
 vm-create-cluster() {
-    vm-command "kubeadm init --pod-network-cidr=$CNI_SUBNET --cri-socket ${k8scri_sock}"
+    vm-command "kubeadm init --pod-network-cidr=$CNI_SUBNET --cri-socket unix://${k8scri_sock}"
     if ! grep -q "initialized successfully" <<< "$COMMAND_OUTPUT"; then
         command-error "kubeadm init failed"
     fi

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -608,6 +608,32 @@ vm-set-kernel-cmdline() { # script API
     distro-set-kernel-cmdline "$@"
 }
 
+vm-add-kernel-cmdline-arg() { # script API
+    # Usage: vm-add-kernel-cmdline-arg E2E-DEFAULTS
+    #
+    # Adds E2E-DEFAULTS to kernel command line"
+    #
+    # Example:
+    #   vm-add-kernel-cmdline nr_cpus=4
+    #   vm-reboot
+    #   vm-command "cat /proc/cmdline"
+    #   launch cri-resmgr
+    distro-add-kernel-cmdline-arg "$@"
+}
+
+vm-del-kernel-cmdline-arg() { # script API
+    # Usage: vm-del-kernel-cmdline-arg E2E-DEFAULTS
+    #
+    # Remove E2E-DEFAULTS to kernel command line"
+    #
+    # Example:
+    #   vm-del-kernel-cmdline nr_cpus=4
+    #   vm-reboot
+    #   vm-command "cat /proc/cmdline"
+    #   launch cri-resmgr
+    distro-del-kernel-cmdline-arg "$@"
+}
+
 vm-reboot() { # script API
     # Usage: vm-reboot
     #

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -1091,4 +1091,14 @@ vm-print-usage() {
     echo "- Delete VM:    govm delete $VM_NAME"
 }
 
+# Return cgroup version (1 or 2)
+vm-cgroup-version() {
+    vm-command-q "mount | grep -q cgroup2"
+    if [ $? -eq 0 ]; then
+	echo "2"
+    fi
+
+    echo "1"
+}
+
 vm-check-env || exit 1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.1-0.20191218042359-6151c48ac7fa
 	github.com/cilium/ebpf v0.7.0
+	github.com/containerd/nri v0.1.0
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7
@@ -45,8 +46,8 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/checkpoint-restore/go-criu/v5 v5.3.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
-	github.com/containerd/containerd v1.4.12 // indirect
-	github.com/containerd/ttrpc v1.0.2 // indirect
+	github.com/containerd/containerd v1.6.0 // indirect
+	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
@@ -129,6 +130,10 @@ require (
 )
 
 replace (
+	// Temporarily divert repo for updated/extended NRI.
+	github.com/containerd/nri => github.com/klihub/nri v0.0.0-20220601202555-929d59e54bbd
+	github.com/containerd/ttrpc v1.1.0 => github.com/containerd/ttrpc v0.0.0-20220421210857-74421d10189e
+
 	github.com/intel/cri-resource-manager/pkg/topology v0.0.0 => ./pkg/topology
 
 	go.opentelemetry.io/contrib => go.opentelemetry.io/contrib v0.20.0

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -25,8 +25,10 @@ import (
 	"strings"
 	"sync"
 
+	nri "github.com/containerd/nri/v2alpha1/pkg/api"
 	v1 "k8s.io/api/core/v1"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/apis/resmgr"
@@ -583,9 +585,9 @@ type Cache interface {
 	Save() error
 
 	// RefreshPods purges/inserts stale/new pods/containers using a pod sandbox list response.
-	RefreshPods(*cri.ListPodSandboxResponse, map[string]*PodStatus) ([]Pod, []Pod, []Container)
+	RefreshPods(interface{}, map[string]*PodStatus) ([]Pod, []Pod, []Container)
 	// RefreshContainers purges/inserts stale/new containers using a container list response.
-	RefreshContainers(*cri.ListContainersResponse) ([]Container, []Container)
+	RefreshContainers(interface{}) ([]Container, []Container)
 
 	// Get the container (data) directory for a container.
 	ContainerDirectory(string) string
@@ -865,6 +867,8 @@ func (cch *cache) InsertPod(id string, msg interface{}, status *PodStatus) (Pod,
 		err = p.fromRunRequest(msg.(*cri.RunPodSandboxRequest))
 	case *cri.PodSandbox:
 		err = p.fromListResponse(msg.(*cri.PodSandbox), status)
+	case *nri.PodSandbox:
+		err = p.fromNRI(msg.(*nri.PodSandbox))
 	default:
 		err = fmt.Errorf("cannot create pod from message %T", msg)
 	}
@@ -915,6 +919,8 @@ func (cch *cache) InsertContainer(msg interface{}) (Container, error) {
 		err = c.fromCreateRequest(msg.(*cri.CreateContainerRequest))
 	case *cri.Container:
 		err = c.fromListResponse(msg.(*cri.Container))
+	case *nri.Container:
+		err = c.fromNRI(msg.(*nri.Container))
 	default:
 		err = fmt.Errorf("cannot create container from message %T", msg)
 	}
@@ -1021,42 +1027,65 @@ func (cch *cache) LookupContainerByCgroup(path string) (Container, bool) {
 }
 
 // RefreshPods purges/inserts stale/new pods/containers using a pod sandbox list response.
-func (cch *cache) RefreshPods(msg *cri.ListPodSandboxResponse, status map[string]*PodStatus) ([]Pod, []Pod, []Container) {
+func (cch *cache) RefreshPods(msg interface{}, status map[string]*PodStatus) ([]Pod, []Pod, []Container) {
 	valid := make(map[string]struct{})
 
 	add := []Pod{}
 	del := []Pod{}
 	containers := []Container{}
 
-	for _, item := range msg.Items {
-		valid[item.Id] = struct{}{}
-		if _, ok := cch.Pods[item.Id]; !ok {
-			cch.Debug("inserting discovered pod %s...", item.Id)
-			pod, err := cch.InsertPod(item.Id, item, status[item.Id])
-			if err != nil {
-				cch.Error("failed to insert discovered pod %s to cache: %v",
-					item.Id, err)
-			} else {
+	switch pods := msg.(type) {
+	case *cri.ListPodSandboxResponse:
+		for _, item := range pods.Items {
+			valid[item.Id] = struct{}{}
+			if _, ok := cch.Pods[item.Id]; !ok {
+				cch.Debug("inserting discovered pod %s...", item.Id)
+				pod := cch.InsertPod(item.Id, item, status[item.Id])
 				add = append(add, pod)
 			}
 		}
-	}
-
-	for _, pod := range cch.Pods {
-		if _, ok := valid[pod.ID]; !ok {
-			cch.Debug("purging stale pod %s...", pod.ID)
-			pod.State = PodStateStale
-			del = append(del, cch.DeletePod(pod.ID))
+		for _, pod := range cch.Pods {
+			if _, ok := valid[pod.ID]; !ok {
+				cch.Debug("purging stale pod %s...", pod.ID)
+				pod.State = PodStateStale
+				del = append(del, cch.DeletePod(pod.ID))
+			}
 		}
-	}
+		for id, c := range cch.Containers {
+			if _, ok := valid[c.PodID]; !ok {
+				cch.Debug("purging container %s of stale pod %s...", c.CacheID, c.PodID)
+				cch.DeleteContainer(c.CacheID)
+				c.State = ContainerStateStale
+				if id == c.CacheID {
+		x			containers = append(containers, c)
+				}
+			}
+		}
 
-	for id, c := range cch.Containers {
-		if _, ok := valid[c.PodID]; !ok {
-			cch.Debug("purging container %s of stale pod %s...", c.CacheID, c.PodID)
-			cch.DeleteContainer(c.CacheID)
-			c.State = ContainerStateStale
-			if id == c.CacheID {
-				containers = append(containers, c)
+	case []*nri.PodSandbox:
+		for _, item := range pods {
+			valid[item.Id] = struct{}{}
+			if _, ok := cch.Pods[item.Id]; !ok {
+				cch.Debug("inserting discovered pod %s...", item.Id)
+				pod := cch.InsertPod(item.Id, item, status[item.Id])
+				add = append(add, pod)
+			}
+		}
+		for _, pod := range cch.Pods {
+			if _, ok := valid[pod.ID]; !ok {
+				cch.Debug("purging stale pod %s...", pod.ID)
+				pod.State = PodStateStale
+				del = append(del, cch.DeletePod(pod.ID))
+			}
+		}
+		for id, c := range cch.Containers {
+			if _, ok := valid[c.PodID]; !ok {
+				cch.Debug("purging container %s of stale pod %s...", c.CacheID, c.PodID)
+				cch.DeleteContainer(c.CacheID)
+				c.State = ContainerStateStale
+				if id == c.CacheID {
+					containers = append(containers, c)
+				}
 			}
 		}
 	}
@@ -1065,26 +1094,43 @@ func (cch *cache) RefreshPods(msg *cri.ListPodSandboxResponse, status map[string
 }
 
 // RefreshContainers purges/inserts stale/new containers using a container list response.
-func (cch *cache) RefreshContainers(msg *cri.ListContainersResponse) ([]Container, []Container) {
+func (cch *cache) RefreshContainers(msg interface{}) ([]Container, []Container) {
 	valid := make(map[string]struct{})
 
 	add := []Container{}
 	del := []Container{}
 
-	for _, c := range msg.Containers {
-		if ContainerState(c.State) == ContainerStateExited {
-			continue
+	switch containers := msg.(type) {
+	case *cri.ListContainersResponse:
+		for _, c := range containers.Containers {
+			if ContainerState(c.State) == ContainerStateExited {
+				continue
+			}
+			valid[c.Id] = struct{}{}
+			if _, ok := cch.Containers[c.Id]; !ok {
+				cch.Debug("inserting discovered container %s...", c.Id)
+				inserted, err := cch.InsertContainer(c)
+				if err != nil {
+					cch.Error("failed to insert discovered container %s to cache: %v",
+						c.Id, err)
+				} else {
+					add = append(add, inserted)
+				}
+			}
 		}
 
-		valid[c.Id] = struct{}{}
-		if _, ok := cch.Containers[c.Id]; !ok {
-			cch.Debug("inserting discovered container %s...", c.Id)
-			inserted, err := cch.InsertContainer(c)
-			if err != nil {
-				cch.Error("failed to insert discovered container %s to cache: %v",
-					c.Id, err)
-			} else {
-				add = append(add, inserted)
+	case []*nri.Container:
+		for _, c := range containers {
+			valid[c.Id] = struct{}{}
+			if _, ok := cch.Containers[c.Id]; !ok {
+				cch.Debug("inserting discovered container %s...", c.Id)
+				inserted, err := cch.InsertContainer(c)
+				if err != nil {
+					cch.Error("failed to insert discovered container %s to cache: %v",
+						c.Id, err)
+				} else {
+					add = append(add, inserted)
+				}
 			}
 		}
 	}

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"encoding/json"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -26,6 +27,8 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/topology"
 
+	"github.com/containerd/nri/v2alpha1/pkg/api"
+	nri "github.com/containerd/nri/v2alpha1/pkg/api"
 	v1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -181,6 +184,156 @@ func (c *container) fromListResponse(lrc *cri.Container) error {
 	}
 
 	return nil
+}
+
+// Create container from an NRI request.
+func (c *container) fromNRI(nric *nri.Container) error {
+	c.PodID = nric.PodSandboxId
+
+	pod, ok := c.cache.Pods[c.PodID]
+	if !ok {
+		return cacheError("can't find cached pod %s for listed container", c.PodID)
+	}
+
+	c.ID = nric.Id
+	c.Name = nric.Name
+	c.Namespace = pod.Namespace
+	c.State = ContainerState(int32(cri.ContainerState_CONTAINER_RUNNING)) // XXX TODO
+	c.Image = "unknown"
+	c.Labels = nric.Labels
+	c.Annotations = nric.Annotations
+	c.Tags = make(map[string]string)
+
+	genHints := true
+	if hintSetting, ok := c.GetEffectiveAnnotation(TopologyHintsKey); ok {
+		preference, err := strconv.ParseBool(hintSetting)
+		if err != nil {
+			c.cache.Error("invalid annotation %q=%q: %v", TopologyHintsKey, hintSetting, err)
+		} else {
+			genHints = preference
+		}
+	}
+	c.cache.Info("automatic topology hint generation %s for %q",
+		map[bool]string{false: "disabled", true: "enabled"}[genHints], c.PrettyName())
+
+	c.Mounts = make(map[string]*Mount)
+	for _, m := range nric.Mounts {
+		var (
+			propagation MountType
+			readOnly    bool
+			relabel     bool
+		)
+		for _, o := range m.Options {
+			switch o {
+			case "ro":
+				readOnly = true
+			case "rprivate":
+				propagation = MountPrivate
+			case "rshared":
+				propagation = MountBidirectional
+			case "rslave":
+				propagation = MountHostToContainer
+			case api.SELinuxRelabel:
+				relabel = true
+			}
+		}
+
+		c.Mounts[m.Destination] = &Mount{
+			Container:   m.Destination,
+			Host:        m.Source,
+			Readonly:    readOnly,
+			Relabel:     relabel,
+			Propagation: propagation,
+		}
+
+		if genHints {
+			if hints := getTopologyHints(m.Destination, m.Source, readOnly); len(hints) > 0 {
+				c.TopologyHints = topology.MergeTopologyHints(c.TopologyHints, hints)
+			}
+		}
+	}
+
+	// Notes:
+	//   This is a way off/a bit wierd... Currently, we don't allow/handle altering
+	//   devices. We only convert these for topology hint generation.
+	c.Devices = make(map[string]*Device)
+	for _, d := range nric.GetLinux().GetDevices() {
+		var permissions string
+
+		if perm := d.FileMode.Get(); perm != nil {
+			if *perm&os.FileMode(0444) != os.FileMode(0) {
+				permissions = "r"
+			}
+			if *perm&os.FileMode(0222) != os.FileMode(0) {
+				permissions += "w"
+			}
+			permissions += "m"
+		} else {
+			permissions = "r"
+		}
+
+		c.Devices[d.Path] = &Device{
+			Container:   d.Path,
+			Host:        d.Path,
+			Permissions: permissions,
+		}
+
+		if genHints {
+			if hints := getTopologyHints(d.Path, d.Path, strings.IndexAny(permissions, "wm") == -1); len(hints) > 0 {
+				c.TopologyHints = topology.MergeTopologyHints(c.TopologyHints, hints)
+			}
+		}
+	}
+
+	if lcr := nric.GetLinux().GetResources(); lcr != nil {
+		c.LinuxReq = toCRILinuxResources(lcr, nric.GetLinux().GetOomScoreAdj().GetValue())
+	} else {
+		c.LinuxReq = &cri.LinuxContainerResources{}
+	}
+
+	if pod.Resources != nil {
+		if r, ok := pod.Resources.InitContainers[c.Name]; ok {
+			c.Resources = r
+		} else if r, ok := pod.Resources.Containers[c.Name]; ok {
+			c.Resources = r
+		}
+	}
+
+	if len(c.Resources.Requests) == 0 && len(c.Resources.Limits) == 0 {
+		c.Resources = estimateComputeResources(c.LinuxReq, pod.CgroupParent)
+	}
+
+	if err := c.setDefaults(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// toCRILinuxResources returns resources for CRI.
+func toCRILinuxResources(r *api.LinuxResources, oomScoreAdj int64) *cri.LinuxContainerResources {
+	if r == nil {
+		return nil
+	}
+	o := &cri.LinuxContainerResources{}
+	if r.Memory != nil {
+		o.MemoryLimitInBytes = r.Memory.GetLimit().GetValue()
+		o.OomScoreAdj = oomScoreAdj
+	}
+	if r.Cpu != nil {
+		o.CpuShares = int64(r.Cpu.GetShares().GetValue())
+		o.CpuPeriod = int64(r.Cpu.GetPeriod().GetValue())
+		o.CpuQuota = r.Cpu.GetQuota().GetValue()
+		o.CpusetCpus = r.Cpu.Cpus
+		o.CpusetMems = r.Cpu.Mems
+	}
+	for _, l := range r.HugepageLimits {
+		o.HugepageLimits = append(o.HugepageLimits, &cri.HugepageLimit{
+			PageSize: l.PageSize,
+			Limit:    l.Limit,
+		})
+	}
+	return o
 }
 
 func (c *container) setDefaults() error {

--- a/pkg/cri/resource-manager/cache/pod.go
+++ b/pkg/cri/resource-manager/cache/pod.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	nri "github.com/containerd/nri/v2alpha1/pkg/api"
 	v1 "k8s.io/api/core/v1"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -81,6 +82,26 @@ func (p *pod) fromListResponse(pod *cri.PodSandbox, status *PodStatus) error {
 	} else {
 		p.CgroupParent = status.CgroupParent
 	}
+
+	if err := p.discoverQOSClass(); err != nil {
+		p.cache.Error("%v", err)
+	}
+
+	p.parseResourceAnnotations()
+
+	return nil
+}
+
+// Create a pod from an NRI request.
+func (p *pod) fromNRI(pod *nri.PodSandbox) error {
+	p.containers = make(map[string]string)
+	p.UID = pod.Uid
+	p.Name = pod.Name
+	p.Namespace = pod.Namespace
+	p.State = PodState(int32(cri.PodSandboxState_SANDBOX_READY))
+	p.Labels = pod.Labels
+	p.Annotations = pod.Annotations
+	p.CgroupParent = pod.CgroupParent
 
 	if err := p.discoverQOSClass(); err != nil {
 		p.cache.Error("%v", err)

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -43,6 +43,8 @@ type options struct {
 	MetricsTimer          time.Duration
 	RebalanceTimer        time.Duration
 	DisableUI             bool
+
+	UseNRIPlugin bool
 }
 
 // Relay command line options.
@@ -92,4 +94,7 @@ func init() {
 
 	flag.BoolVar(&opt.DisableUI, "disable-ui", false,
 		"Disable serving container placement visualization UIs.")
+
+	flag.BoolVar(&opt.UseNRIPlugin, "use-nri-plugin", false,
+		"Use the NRI plugin interface instead of becoming a CRI proxy.")
 }

--- a/pkg/cri/resource-manager/nri.go
+++ b/pkg/cri/resource-manager/nri.go
@@ -1,0 +1,504 @@
+// Copyright 2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resmgr
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
+
+	"github.com/containerd/nri/v2alpha1/pkg/api"
+	stub "github.com/containerd/nri/v2alpha1/pkg/stub"
+)
+
+type nriPlugin struct {
+	stub   stub.Stub
+	resmgr *resmgr
+}
+
+func newNRIPlugin(resmgr *resmgr) (*nriPlugin, error) {
+	var err error
+
+	p := &nriPlugin{
+		resmgr: resmgr,
+	}
+	opts := []stub.Option{
+		stub.WithPluginName("resource-manager"),
+		stub.WithPluginIdx("99"),
+		stub.WithOnClose(p.onClose),
+	}
+
+	p.resmgr.Info("creating NRI plugin...")
+
+	if p.stub, err = stub.New(p, opts...); err != nil {
+		return nil, errors.Wrap(err, "failed to create NRI plugin stub")
+	}
+
+	return p, nil
+}
+
+func (p *nriPlugin) start() error {
+	if p == nil {
+		return nil
+	}
+
+	p.resmgr.Info("starting NRI plugin...")
+	if err := p.stub.Start(context.Background()); err != nil {
+		return errors.Wrap(err, "failed to start NRI plugin")
+	}
+
+	return nil
+}
+
+func (p *nriPlugin) stop() error {
+	if p == nil {
+		return nil
+	}
+	p.resmgr.Info("stopping NRI plugin...")
+	if err := p.stub.Stop(); err != nil {
+		return errors.Wrap(err, "failed to stop NRI plugins stub")
+	}
+
+	return nil
+}
+
+func (p *nriPlugin) onClose() {
+	p.resmgr.Warn("connection to NRI/runtime lost, exiting...")
+	os.Exit(0)
+}
+
+func (p *nriPlugin) Configure(data string) (stub.EventMask, error) {
+	p.dump("NRI-Configure", "data", data)
+	return stub.AllEvents, nil
+}
+
+func (p *nriPlugin) syncWithNRI(pods []*api.PodSandbox, containers []*api.Container) ([]cache.Container, []cache.Container, error) {
+	m := p.resmgr
+
+	if m.policy.Bypassed() {
+		return nil, nil, nil
+	}
+
+	m.Info("synchronizing cache state with NRI/CRI runtime...")
+
+	add, del := []cache.Container{}, []cache.Container{}
+	status := map[string]*cache.PodStatus{}
+
+	_, _, deleted := m.cache.RefreshPods(pods, status)
+	for _, c := range deleted {
+		m.Info("discovered stale container %s...", c.GetID())
+		del = append(del, c)
+	}
+
+	added, deleted := m.cache.RefreshContainers(containers)
+	for _, c := range added {
+		if c.GetState() != cache.ContainerStateRunning {
+			m.Info("ignoring discovered container %s (in state %v)...",
+				c.GetID(), c.GetState())
+			continue
+		}
+		m.Info("discovered out-of-sync running container %s...", c.GetID())
+		add = append(add, c)
+	}
+	for _, c := range deleted {
+		m.Info("discovered stale container %s...", c.GetID())
+		del = append(del, c)
+	}
+
+	return add, del, nil
+}
+
+func (p *nriPlugin) Synchronize(pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
+	m := p.resmgr
+
+	p.dump("NRI-Synchronize", "pods", pods, "containers", containers)
+
+	add, del, err := p.syncWithNRI(pods, containers)
+	if err != nil {
+		p.resmgr.Error("failed to synchronize with NRI: %v", err)
+		return nil, err
+	}
+
+	if err := m.policy.Start(add, del); err != nil {
+		return nil, errors.Wrapf(err,
+			"failed to start policy %s", policy.ActivePolicy())
+	}
+
+	return p.getPendingUpdates(nil), nil
+}
+
+func (p *nriPlugin) RunPodSandbox(pod *api.PodSandbox) {
+	p.dump("NRI-RunPodSandbox", "pod", pod)
+
+	m := p.resmgr
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.cache.InsertPod(pod.Id, pod, nil)
+}
+
+func (p *nriPlugin) StopPodSandbox(pod *api.PodSandbox) {
+	p.dump("NRI-StopPodSandbox", "pod", pod)
+}
+
+func (p *nriPlugin) RemovePodSandbox(pod *api.PodSandbox) {
+	p.dump("NRI-RemovePodSandbox", "pod", pod)
+
+	m := p.resmgr
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.cache.DeletePod(pod.Id)
+}
+
+func (p *nriPlugin) CreateContainer(pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+	p.dump("NRI-CreateContainer", "pod", pod, "container", container)
+
+	m := p.resmgr
+
+	m.Lock()
+	defer m.Unlock()
+
+	c, err := m.cache.InsertContainer(container)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to cache container")
+	}
+
+	if err := m.policy.AllocateResources(c); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to allocate resources")
+	}
+
+	c.InsertMount(&cache.Mount{
+		Container:   "/.cri-resmgr",
+		Host:        m.cache.ContainerDirectory(c.GetCacheID()),
+		Readonly:    true,
+		Propagation: cache.MountHostToContainer,
+	})
+	m.policy.ExportResourceData(c)
+
+	adjust := p.getPendingCreate(container)
+	updates := p.getPendingUpdates(container)
+
+	p.dump("<= CreateContainer", "adjustments", adjust, "updates", updates)
+
+	return adjust, updates, nil
+}
+
+func (p *nriPlugin) PostCreateContainer(pod *api.PodSandbox, container *api.Container) {
+}
+
+func (p *nriPlugin) StartContainer(pod *api.PodSandbox, container *api.Container) {
+	p.dump("NRI-StartContainer", "pod", pod, "container", container)
+
+	m := p.resmgr
+
+	m.Lock()
+	defer m.Unlock()
+
+	c, ok := m.cache.LookupContainer(container.Id)
+	if ok {
+		c.UpdateState(cache.ContainerStateRunning)
+	}
+}
+
+func (p *nriPlugin) PostStartContainer(pod *api.PodSandbox, container *api.Container) {
+	p.dump("NRI-PostStartContainer", "pod", pod, "container", container)
+}
+
+func (p *nriPlugin) UpdateContainer(pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+	p.dump("NRI-UpdateContainer", "pod", pod, "container", container)
+	return nil, nil
+}
+
+func (p *nriPlugin) PostUpdateContainer(pod *api.PodSandbox, container *api.Container) {
+	p.dump("NRI-PostUpdateContainer", "pod", pod, "container", container)
+}
+
+func (p *nriPlugin) StopContainer(pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+	p.dump("NRI-StopContainer", "pod", pod, "container", container)
+
+	m := p.resmgr
+
+	m.Lock()
+	defer m.Unlock()
+
+	c, ok := m.cache.LookupContainer(container.Id)
+	if !ok {
+		return nil, nil
+	}
+
+	if err := m.policy.ReleaseResources(c); err != nil {
+		return nil, errors.Wrap(err, "failed to release resources")
+	}
+
+	c.UpdateState(cache.ContainerStateExited)
+
+	updates := p.getPendingUpdates(container)
+	return updates, nil
+}
+
+func (p *nriPlugin) RemoveContainer(pod *api.PodSandbox, container *api.Container) {
+	p.dump("NRI-RemoveContainer", "pod", pod, "container", container)
+
+	m := p.resmgr
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.cache.DeleteContainer(container.Id)
+}
+
+func (p *nriPlugin) getPendingCreate(container *api.Container) *api.ContainerAdjustment {
+	m := p.resmgr
+	c, ok := m.cache.LookupContainer(container.GetId())
+	if !ok {
+		return nil
+	}
+
+	for _, ctrl := range c.GetPending() {
+		c.ClearPending(ctrl)
+	}
+
+	a := &api.ContainerAdjustment{}
+	p.adjustDevices(a, container, c)
+	p.adjustResources(a, container, c)
+	p.adjustLabels(a, container, c)
+	p.adjustAnnotations(a, container, c)
+	p.adjustEnv(a, container, c)
+	p.adjustMounts(a, container, c)
+
+	return a
+}
+
+func (p *nriPlugin) getPendingUpdates(creating *api.Container) []*api.ContainerUpdate {
+	m := p.resmgr
+	updates := []*api.ContainerUpdate{}
+	for _, container := range m.cache.GetPendingContainers() {
+		id := container.GetID()
+		if creating != nil && creating.GetId() == id {
+			continue
+		}
+
+		u := &api.ContainerUpdate{
+			ContainerId: id,
+		}
+		p.updateResources(u, container)
+		updates = append(updates, u)
+
+		for _, ctrl := range container.GetPending() {
+			container.ClearPending(ctrl)
+		}
+	}
+
+	return updates
+}
+
+func toNRILinuxResources(container cache.Container) *api.LinuxResources {
+	cr := container.GetLinuxResources()
+	if cr == nil {
+		return nil
+	}
+
+	r := &api.LinuxResources{
+		Cpu: &api.LinuxCPU{
+			Period: api.UInt64(cr.CpuPeriod),
+			Quota:  api.Int64(cr.CpuQuota),
+			Shares: api.UInt64(cr.CpuShares),
+			Cpus:   cr.CpusetCpus,
+			Mems:   cr.CpusetMems,
+		},
+		Memory: &api.LinuxMemory{
+			Limit: api.Int64(cr.MemoryLimitInBytes),
+		},
+	}
+	for _, l := range r.HugepageLimits {
+		r.HugepageLimits = append(r.HugepageLimits, &api.HugepageLimit{
+			PageSize: l.PageSize,
+			Limit:    l.Limit,
+		})
+	}
+	if bioc := container.GetBlockIOClass(); bioc != "" {
+		r.BlockioClass = api.String(bioc)
+	}
+	if rdtc := container.GetRDTClass(); rdtc != "" {
+		r.RdtClass = api.String(rdtc)
+	}
+
+	return r
+}
+
+func (p *nriPlugin) adjustDevices(a *api.ContainerAdjustment, c *api.Container, cc cache.Container) {
+	// Notes: we don't alter devices... but it should perhaps be checked.
+}
+
+func (p *nriPlugin) adjustResources(a *api.ContainerAdjustment, c *api.Container, cc cache.Container) {
+	ccr := cc.GetLinuxResources()
+	a.SetLinuxCPUPeriod(ccr.CpuPeriod)
+	a.SetLinuxCPUQuota(ccr.CpuQuota)
+	a.SetLinuxCPUShares(uint64(ccr.CpuShares))
+	a.SetLinuxCPUSetCPUs(ccr.CpusetCpus)
+	a.SetLinuxCPUSetMems(ccr.CpusetMems)
+	a.SetLinuxMemoryLimit(ccr.MemoryLimitInBytes)
+	for _, l := range ccr.HugepageLimits {
+		a.AddLinuxHugepageLimit(l.PageSize, l.Limit)
+	}
+	if bioc := cc.GetBlockIOClass(); bioc != "" {
+		a.SetLinuxBlockIOClass(bioc)
+	}
+	if rdtc := cc.GetRDTClass(); rdtc != "" {
+		a.SetLinuxRDTClass(rdtc)
+	}
+}
+
+func (p *nriPlugin) adjustMounts(a *api.ContainerAdjustment, c *api.Container, cc cache.Container) {
+	// Notes: we don't alter mounts, just inject new ones...
+nextMount:
+	for _, mnt := range cc.GetMounts() {
+		for _, m := range c.GetMounts() {
+			if m.Destination == mnt.Container {
+				continue nextMount
+			}
+		}
+
+		options := []string{"rbind"}
+
+		switch mnt.Propagation {
+		case cache.MountPrivate:
+			options = append(options, "rprivate")
+		case cache.MountHostToContainer:
+			options = append(options, "rslave")
+		case cache.MountBidirectional:
+			options = append(options, "rshared")
+		}
+		if mnt.Readonly {
+			options = append(options, "ro")
+		}
+		if mnt.Relabel {
+			options = append(options, api.SELinuxRelabel)
+		}
+
+		a.AddMount(&api.Mount{
+			Destination: mnt.Container,
+			Source:      mnt.Host,
+			Options:     options,
+		})
+	}
+}
+
+func (p *nriPlugin) adjustEnv(a *api.ContainerAdjustment, c *api.Container, cc cache.Container) {
+	old := map[string]string{}
+	for _, e := range c.GetEnv() {
+		kv := strings.SplitN(e, "=", 2)
+		if len(kv) < 2 || kv[0] == "" {
+			continue
+		}
+		old[kv[0]] = kv[1]
+	}
+	for _, k := range cc.GetEnvKeys() {
+		if _, ok := old[k]; ok {
+			a.RemoveEnv(k)
+		}
+		v, _ := cc.GetEnv(k)
+		if v != "" {
+			a.AddEnv(k, v)
+		}
+	}
+}
+
+func (p *nriPlugin) adjustLabels(a *api.ContainerAdjustment, c *api.Container, cc cache.Container) {
+	old := c.GetLabels()
+	for k, v := range cc.GetLabels() {
+		if ov, ok := old[k]; ok {
+			if ov == v {
+				continue
+			}
+			a.RemoveLabel(k)
+		}
+		a.AddLabel(k, v)
+	}
+}
+
+func (p *nriPlugin) adjustAnnotations(a *api.ContainerAdjustment, c *api.Container, cc cache.Container) {
+	old := c.GetAnnotations()
+	for k, v := range cc.GetAnnotations() {
+		if ov, ok := old[k]; ok {
+			if ov == v {
+				continue
+			}
+			a.RemoveAnnotation(k)
+		}
+		a.AddAnnotation(k, v)
+	}
+}
+
+func (p *nriPlugin) updateResources(u *api.ContainerUpdate, c cache.Container) {
+	cr := c.GetLinuxResources()
+	u.SetLinuxCPUPeriod(cr.CpuPeriod)
+	u.SetLinuxCPUQuota(cr.CpuQuota)
+	u.SetLinuxCPUShares(uint64(cr.CpuShares))
+	u.SetLinuxCPUSetCPUs(cr.CpusetCpus)
+	u.SetLinuxCPUSetMems(cr.CpusetMems)
+	u.SetLinuxMemoryLimit(cr.MemoryLimitInBytes)
+	for _, l := range cr.HugepageLimits {
+		u.AddLinuxHugepageLimit(l.PageSize, l.Limit)
+	}
+	if bioc := c.GetBlockIOClass(); bioc != "" {
+		u.SetLinuxBlockIOClass(bioc)
+	}
+	if rdtc := c.GetRDTClass(); rdtc != "" {
+		u.SetLinuxRDTClass(rdtc)
+	}
+}
+
+func (p *nriPlugin) dump(header string, args ...interface{}) {
+	for {
+		var (
+			prefix string
+			msg    []byte
+			ok     bool
+			err    error
+		)
+
+		if len(args) == 0 {
+			return
+		}
+		if len(args) == 1 {
+			p.resmgr.Error("invalid call to dump, expecting tag/obj pairs")
+			return
+		}
+		if prefix, ok = args[0].(string); !ok {
+			p.resmgr.Error("invalid call to dump, expecting string tags")
+			return
+		}
+
+		msg, err = yaml.Marshal(args[1])
+		if err != nil {
+			msg = []byte(fmt.Sprintf("<failed to YAML-marshal object: %v>", err))
+		}
+
+		p.resmgr.InfoBlock(header+" ", "%s:", prefix)
+		p.resmgr.InfoBlock(header+" ", "%s", msg)
+
+		args = args[2:]
+	}
+}

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -76,6 +76,7 @@ type resmgr struct {
 	stop         chan interface{}   // channel for signalling shutdown to goroutines
 	signals      chan os.Signal     // signal channel
 	introspect   *introspect.Server // server for external introspection
+	nri          *nriPlugin         // NRI plugins, if we're running as such
 }
 
 // NewResourceManager creates a new ResourceManager instance.
@@ -84,6 +85,17 @@ func NewResourceManager() (ResourceManager, error) {
 
 	if err := m.setupCache(); err != nil {
 		return nil, err
+	}
+
+	if opt.UseNRIPlugin {
+		m.Info("running as an NRI plugin...")
+		nrip, err := newNRIPlugin(m)
+		if err != nil {
+			return nil, err
+		}
+		m.nri = nrip
+	} else {
+		m.Info("running as a CRI proxy...")
 	}
 
 	switch {
@@ -119,23 +131,25 @@ func NewResourceManager() (ResourceManager, error) {
 		return nil, err
 	}
 
-	if err := m.setupRelay(); err != nil {
-		pid, _ := pidfile.OwnerPid()
-		if pid > 0 {
-			m.Error("looks like we're already running as pid %d...", pid)
+	if !opt.UseNRIPlugin {
+		if err := m.setupRelay(); err != nil {
+			pid, _ := pidfile.OwnerPid()
+			if pid > 0 {
+				m.Error("looks like we're already running as pid %d...", pid)
+			}
+			return nil, err
 		}
-		return nil, err
-	}
 
-	if err := m.setupRequestProcessing(); err != nil {
-		return nil, err
+		if err := m.setupRequestProcessing(); err != nil {
+			return nil, err
+		}
+
+		if err := m.setupControllers(); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := m.setupEventProcessing(); err != nil {
-		return nil, err
-	}
-
-	if err := m.setupControllers(); err != nil {
 		return nil, err
 	}
 
@@ -157,22 +171,29 @@ func (m *resmgr) Start() error {
 		return err
 	}
 
-	if err := m.startControllers(); err != nil {
-		return err
-	}
+	if !opt.UseNRIPlugin {
+		if err := m.startControllers(); err != nil {
+			return err
+		}
 
-	if err := m.startRequestProcessing(); err != nil {
-		return err
-	}
+		if err := m.startRequestProcessing(); err != nil {
+			return err
+		}
 
-	if err := m.startEventProcessing(); err != nil {
-		return err
-	}
+		// XXX TODO: these we should start for NRI as well, but
+		// event processing now depends on CRI request processing
 
-	m.startIntrospection()
+		if err := m.startEventProcessing(); err != nil {
+			return err
+		}
 
-	if err := m.relay.Start(); err != nil {
-		return resmgrError("failed to start CRI relay: %v", err)
+		m.startIntrospection()
+
+		if err := m.relay.Start(); err != nil {
+			return resmgrError("failed to start CRI relay: %v", err)
+		}
+	} else {
+		m.nri.start()
 	}
 
 	if err := pidfile.Remove(); err != nil {
@@ -215,9 +236,14 @@ func (m *resmgr) Stop() {
 	}
 
 	m.configServer.Stop()
-	m.relay.Stop()
-	m.stopIntrospection()
-	m.stopEventProcessing()
+
+	if !opt.UseNRIPlugin {
+		m.relay.Stop()
+		m.stopIntrospection()
+		m.stopEventProcessing()
+	} else {
+		m.nri.stop()
+	}
 }
 
 // SetConfig pushes new configuration to the resource manager.

--- a/test/e2e/containerd-nri-enable
+++ b/test/e2e/containerd-nri-enable
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+#
+# Enable containerd NRI plugin
+
+import tomli_w
+import toml
+
+data=toml.load("/etc/containerd/config.toml")
+((((data["plugins"])["io.containerd.grpc.v1.cri"])["nri"]))["enable"]=True
+
+with open("/etc/containerd/config.toml", "wb") as f:
+    tomli_w.dump(data, f)

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
@@ -1,5 +1,5 @@
 vm-command "grep isolcpus=8,9 /proc/cmdline" || {
-    vm-set-kernel-cmdline "isolcpus=8,9"
+    vm-add-kernel-cmdline-arg "isolcpus=8,9"
     vm-force-restart
     vm-command "grep isolcpus=8,9 /proc/cmdline" || {
         error "failed to set isolcpus kernel commandline parameter"
@@ -96,7 +96,7 @@ verify "disjoint_sets(set.union(cpus['pod7c0'], cpus['pod7c1'], cpus['pod7c2'], 
 
 # Cleanup kernel commandline, otherwise isolcpus will affect CPU
 # pinning and cause false negatives from other tests on this VM.
-vm-set-kernel-cmdline ""
+vm-del-kernel-cmdline-arg "isolcpus=8,9"
 vm-force-restart
 vm-command "grep isolcpus /proc/cmdline" && {
     error "failed to clean up isolcpus kernel commandline parameter"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1405,7 +1405,7 @@ if vm-command-q "[ ! -f /var/lib/kubelet/config.yaml ]"; then
     fi
 else
     # Wait for kube-apiserver to launch (may be down if the VM was just booted)
-    vm-wait-process kube-apiserver
+    vm-wait-process --timeout 180 kube-apiserver
 fi
 
 # Start cri-resmgr-agent if not already running

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1272,7 +1272,14 @@ if [ "$binsrc" == "local" ]; then
     fi
 fi
 
-host-get-vm-config "$vm" || host-set-vm-config "$vm" "$distro" "$cri"
+if [[ "$k8scri" == *"&cri-resmgr" ]]; then
+    # launch cri-resmgr as an NRI plugin to running container runtime
+    use_nri_plugin="1"
+else
+    use_nri_plugin="0"
+fi
+
+host-get-vm-config "$vm" || host-set-vm-config "$vm" "$distro" "$cri" "$use_nri_plugin"
 
 if [ -z "$VM_IP" ] || [ -z "$VM_SSH_USER" ]; then
     screen-create-vm


### PR DESCRIPTION
Make sure that e2e tests can be run with NRI support enabled in cri-rm and containerd. As of this writing, support with cri-o is not tested. This PR is still WIP.
Some tests report error randomly, it seems that if cri-resmgr exists (for whatever reason), it is not restarted, because it is not run under systemd in e2e tests, which then leads to test failures.
