### PR TITLE
e2e: update ./run.sh debug to work with recent golang and dlv

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -784,7 +784,7 @@ EOF'
 vm-install-dlv() {
     vm-install-golang
     vm-install-pkg rsync
-    vm-command "go get github.com/go-delve/delve/cmd/dlv" || {
+    vm-command "go install github.com/go-delve/delve/cmd/dlv@latest" || {
         command-error "installing delve failed"
     }
     echo '[ "`id -u`" -eq 0 ] && PATH=$PATH:/root/go/bin' | vm-pipe-to-file /etc/profile.d/root-path-go.sh
@@ -872,14 +872,14 @@ EOF
 vm-dlv-add-src() {
     local host_src_dir="$1"
     [ -d "$host_src_dir" ] || error "vm-dlv-add-src: invalid source directory \"$host_src_dir\", existing go project directory expected"
-    vm-command "mkdir -p /home/$VM_SSH_USER/src; chmod a+rwX /home/$VM_SSH_USER/src"
+    vm-command "mkdir -p /home/$VM_SSH_USER/src; chmod a+rwX /home/$VM_SSH_USER/src; mkdir -p \$HOME/.config/dlv/config.yml.d"
     host-command "cd \"$host_src_dir/..\" && rsync -avz --include \"*/\" --include \"**/*.go\" --exclude \"*\" \"$(basename "$host_src_dir")\" $VM_SSH_USER@$VM_IP:src/"
     vm-command "echo ' - {from: \"$host_src_dir\", to: \"/home/$VM_SSH_USER/src/$(basename "$host_src_dir")\"}' > \"\$HOME/.config/dlv/config.yml.d/01-$(basename "$host_src_dir")\""
     vm-dlv-update-config
 }
 
 vm-dlv-update-config() {
-    vm-command "cat \$HOME/.config/dlv/config.yml.d/* > \$HOME/.config/dlv/config.yml"
+    vm-command "( echo 'substitute-path:'; cat \$HOME/.config/dlv/config.yml.d/* ) > \$HOME/.config/dlv/config.yml"
 }
 
 vm-install-k8s() {


### PR DESCRIPTION
- Use "go install" instead of "go get".
- Update dlv configuration file syntax to work with latest dlv.
- Now crirm_src=/path/to/project vm=vm-name ./run.sh debug
  works again: copies sources to vm and sets up dlv for debugging.