### PR TITLE
balloons: improve dynamic configuration update

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
@@ -1045,7 +1045,7 @@ func (p *balloons) dismissContainer(c cache.Container, bln *Balloon) {
 
 // pinCpuMem pins container to CPUs and memory nodes if flagged
 func (p *balloons) pinCpuMem(c cache.Container, cpus cpuset.CPUSet, mems idset.IDSet) {
-	if p.bpoptions.PinCPU {
+	if p.bpoptions.PinCPU == nil || *p.bpoptions.PinCPU {
 		log.Debug("  - pinning %s to cpuset: %s", c.PrettyName(), cpus)
 		c.SetCpusetCpus(cpus.String())
 		if reqCpu, ok := c.GetResourceRequirements().Requests[corev1.ResourceCPU]; ok {
@@ -1053,7 +1053,7 @@ func (p *balloons) pinCpuMem(c cache.Container, cpus cpuset.CPUSet, mems idset.I
 			c.SetCPUShares(int64(cache.MilliCPUToShares(mCpu)))
 		}
 	}
-	if p.bpoptions.PinMemory {
+	if p.bpoptions.PinMemory == nil || *p.bpoptions.PinMemory {
 		log.Debug("  - pinning %s to memory %s", c.PrettyName(), mems)
 		c.SetCpusetMems(mems.String())
 	}

--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy_test.go
@@ -37,66 +37,50 @@ func TestChangesBalloons(t *testing.T) {
 		{
 			name: "reserved pool namespaces differ by len",
 			opts1: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc0",
-					ReservedPoolNamespaces: []string{"ns0"},
-				},
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
 			},
 			opts2: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc0",
-					ReservedPoolNamespaces: []string{},
-				},
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{},
 			},
 			expectedValue: true,
 		},
 		{
 			name: "reserved pool namespaces differ by content",
 			opts1: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc0",
-					ReservedPoolNamespaces: []string{"ns0"},
-				},
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
 			},
 			opts2: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc0",
-					ReservedPoolNamespaces: []string{"ns1"},
-				},
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns1"},
 			},
 			expectedValue: true,
 		},
 		{
 			name: "idle cpu classes differ",
 			opts1: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc0",
-					ReservedPoolNamespaces: []string{"ns0"},
-				},
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
 			},
 			opts2: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc1",
-					ReservedPoolNamespaces: []string{"ns0"},
-				},
+				IdleCpuClass:           "icc1",
+				ReservedPoolNamespaces: []string{"ns0"},
 			},
 			expectedValue: false,
 		},
 		{
 			name: "balloon defs differ",
 			opts1: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc0",
-					ReservedPoolNamespaces: []string{"ns0"},
-					BalloonDefs:            []*BalloonDef{},
-				},
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
+				BalloonDefs:            []*BalloonDef{},
 			},
 			opts2: &BalloonsOptions{
-				BalloonsOptionsReal{
-					IdleCpuClass:           "icc1",
-					ReservedPoolNamespaces: []string{"ns0"},
-					BalloonDefs:            []*BalloonDef{},
-				},
+				IdleCpuClass:           "icc1",
+				ReservedPoolNamespaces: []string{"ns0"},
+				BalloonDefs:            []*BalloonDef{},
 			},
 			expectedValue: false,
 		},

--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy_test.go
@@ -1,0 +1,112 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package balloons
+
+import (
+	"testing"
+)
+
+func TestChangesBalloons(t *testing.T) {
+	tcases := []struct {
+		name          string
+		opts1         *BalloonsOptions
+		opts2         *BalloonsOptions
+		expectedValue bool
+	}{
+		{
+			name:          "both options are nil",
+			expectedValue: false,
+		},
+		{
+			name:          "one option is nil",
+			opts2:         &BalloonsOptions{},
+			expectedValue: true,
+		},
+		{
+			name: "reserved pool namespaces differ by len",
+			opts1: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc0",
+					ReservedPoolNamespaces: []string{"ns0"},
+				},
+			},
+			opts2: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc0",
+					ReservedPoolNamespaces: []string{},
+				},
+			},
+			expectedValue: true,
+		},
+		{
+			name: "reserved pool namespaces differ by content",
+			opts1: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc0",
+					ReservedPoolNamespaces: []string{"ns0"},
+				},
+			},
+			opts2: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc0",
+					ReservedPoolNamespaces: []string{"ns1"},
+				},
+			},
+			expectedValue: true,
+		},
+		{
+			name: "idle cpu classes differ",
+			opts1: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc0",
+					ReservedPoolNamespaces: []string{"ns0"},
+				},
+			},
+			opts2: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc1",
+					ReservedPoolNamespaces: []string{"ns0"},
+				},
+			},
+			expectedValue: false,
+		},
+		{
+			name: "balloon defs differ",
+			opts1: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc0",
+					ReservedPoolNamespaces: []string{"ns0"},
+					BalloonDefs:            []*BalloonDef{},
+				},
+			},
+			opts2: &BalloonsOptions{
+				BalloonsOptionsReal{
+					IdleCpuClass:           "icc1",
+					ReservedPoolNamespaces: []string{"ns0"},
+					BalloonDefs:            []*BalloonDef{},
+				},
+			},
+			expectedValue: false,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := changesBalloons(tc.opts1, tc.opts2)
+			if value != tc.expectedValue {
+				t.Errorf("Expected return value %v but got %v", tc.expectedValue, value)
+			}
+		})
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
@@ -28,9 +28,9 @@ type BalloonsOptions balloonsOptionsWrapped
 // BalloonsOptions contains configuration options specific to this policy.
 type balloonsOptionsWrapped struct {
 	// PinCPU controls pinning containers to CPUs.
-	PinCPU bool `json:"PinCPU,omitempty"`
+	PinCPU *bool `json:"PinCPU,omitempty"`
 	// PinMemory controls pinning containers to memory nodes.
-	PinMemory bool `json:"PinMemory,omitempty"`
+	PinMemory *bool `json:"PinMemory,omitempty"`
 	// IdleCpuClass controls how unusded CPUs outside any a
 	// balloons are (re)configured.
 	IdleCpuClass string `json:"IdleCPUClass",omitempty"`
@@ -82,6 +82,9 @@ type BalloonDef struct {
 	PreferNewBalloons bool
 }
 
+var defaultPinCPU bool = true
+var defaultPinMemory bool = true
+
 // DeepCopy creates a deep copy of a BalloonsOptions
 func (bo *BalloonsOptions) DeepCopy() *BalloonsOptions {
 	outBo := *bo
@@ -111,8 +114,8 @@ func (bdef *BalloonDef) DeepCopy() *BalloonDef {
 func defaultBalloonsOptions() interface{} {
 	return &BalloonsOptions{
 		ReservedPoolNamespaces: []string{metav1.NamespaceSystem},
-		PinCPU:                 true,
-		PinMemory:              true,
+		PinCPU:                 &defaultPinCPU,
+		PinMemory:              &defaultPinMemory,
 	}
 }
 


### PR DESCRIPTION
- Recreate balloons and reassign workloads only if necessary.
- CPU class of balloon types can be switched without reassigning
  workloads.