### PR TITLE
test/e2e: clean up after namespace colocation tests.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
@@ -85,4 +85,10 @@ verify \
     'cpus["pod7c0"] == cpus["pod5c0"]' \
     'cpus["pod7c1"] == cpus["pod5c0"]'
 
-kubectl delete pods --all --now
+kubectl delete pods -n test-ns --all --now
+kubectl delete namespace test-ns
+
+# Restore default test configuration, restart cri-resmgr.
+terminate cri-resmgr
+cri_resmgr_cfg=$(instantiate cri-resmgr.cfg)
+launch cri-resmgr


### PR DESCRIPTION
Properly clean up pods and restore default configuration after having run the namespace-colocation tests.