### PR TITLE
test/e2e: produce more readable policy test suite logs.

### DIFF
--- a/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
@@ -45,6 +45,8 @@ policy:
 
 logger:
   Debug: policy
+  Klog:
+    skip_headers: true
 
 cpu:
   classes:

--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/balloons-metrics.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/balloons-metrics.cfg
@@ -23,3 +23,5 @@ instrumentation:
   PrometheusExport: true
 logger:
   Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/balloons-reserved.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/balloons-reserved.cfg
@@ -21,3 +21,5 @@ policy:
         MinBalloons: 2
 logger:
   Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/podpools/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/podpools/cri-resmgr.cfg
@@ -31,3 +31,5 @@ policy:
         FillOrder: Packed
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/podpools-metrics.cfg
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/podpools-metrics.cfg
@@ -14,3 +14,5 @@ instrumentation:
   PrometheusExport: true
 logger:
   Debug: resource-manager,cache,policy,memory
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/podpools-custom-default.cfg
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/podpools-custom-default.cfg
@@ -12,3 +12,5 @@ policy:
         MaxPods: 1
 logger:
   Debug: resource-manager,cache,policy,memory
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/static-pools/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/static-pools/cri-resmgr.cfg
@@ -13,3 +13,5 @@ policy:
         exclusive: false
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy,stp
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/static-pools/n4c16/cri-resmgr-static-pools.cfg
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/cri-resmgr-static-pools.cfg
@@ -8,3 +8,5 @@ policy:
     TaintNode: true
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy,stp
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion-deprecated-syntax/cri-resmgr-dynamic-page-demotion.cfg
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion-deprecated-syntax/cri-resmgr-dynamic-page-demotion.cfg
@@ -10,3 +10,5 @@ resource-manager:
       MaxPageMoveCount: 100
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/cri-resmgr-dynamic-page-demotion.cfg
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/cri-resmgr-dynamic-page-demotion.cfg
@@ -10,3 +10,5 @@ resource-manager:
       MaxPageMoveCount: 100
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/topology-aware/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/topology-aware/cri-resmgr.cfg
@@ -4,3 +4,5 @@ policy:
     CPU: 750m
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy
+  Klog:
+    skip_headers: true


### PR DESCRIPTION
Omit klog headers from the generated policy test suite log files.