### PR TITLE
topology-aware: refuse empty reserved CPU set.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -546,6 +546,10 @@ func (p *policy) checkConstraints() error {
 		p.reserved = cset
 	}
 
+	if p.reserved.IsEmpty() {
+		return policyError("cannot start without CPU reservation")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The policy can't run without reserved CPUs, so make sure we always end up with a non-empty set.