### PR TITLE
test/e2e: don't use invalid '0' CPU reservation.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/cri-resmgr.cfg.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/cri-resmgr.cfg.in
@@ -1,9 +1,11 @@
 policy:
   Active: topology-aware
   ReservedResources:
-    cpu: 0
+    CPU: 750m
   topology-aware:
     ColocatePods: $(echo ${COLOCATE_PODS:-false})
     ColocateNamespaces: $(echo ${COLOCATE_NAMESPACES:-false})
 logger:
   Debug: cri-resmgr,resource-manager,cache,policy
+  Klog:
+    skip_headers: true


### PR DESCRIPTION
Don't use invalid 'cpu: 0' CPU reservation. Don't even use a test-specific configuration file.
Instead, parameterize the top-level one correctly for the test case.