### PR TITLE
test/e2e: try rebooting harder for/after isolcpu tests.

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
@@ -1,6 +1,6 @@
 vm-command "grep isolcpus=8,9 /proc/cmdline" || {
     vm-set-kernel-cmdline "isolcpus=8,9"
-    vm-reboot
+    vm-force-restart
     vm-command "grep isolcpus=8,9 /proc/cmdline" || {
         error "failed to set isolcpus kernel commandline parameter"
     }
@@ -97,7 +97,7 @@ verify "disjoint_sets(set.union(cpus['pod7c0'], cpus['pod7c1'], cpus['pod7c2'], 
 # Cleanup kernel commandline, otherwise isolcpus will affect CPU
 # pinning and cause false negatives from other tests on this VM.
 vm-set-kernel-cmdline ""
-vm-reboot
+vm-force-restart
 vm-command "grep isolcpus /proc/cmdline" && {
     error "failed to clean up isolcpus kernel commandline parameter"
 }


### PR DESCRIPTION
Be more insistent when rebooting a VM node for/between test cases. Use the newly introduced `vm-force-restart` instead of `vm-reboot`. In practice, if the test node is a govm-managed virtual machine, this will force the node to reboot with these steps:
1. `vm-command "shutdown -h now"`
2. `sleep 10`
3. `vm-monitor system_reset`
4. `host-wait-vm-ssh-server`

If the test node is not a govm-managed virtual machine `vm-force-restart` falls back to `vm-reboot`. 