### PR TITLE
cross-build: fixup centos-8 repos.

### DIFF
--- a/dockerfiles/cross-build/Dockerfile.centos-8.in
+++ b/dockerfiles/cross-build/Dockerfile.centos-8.in
@@ -7,6 +7,9 @@ ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN dnf install -y rpm-build \
     kernel-devel clang gcc \
     git-core make wget


### PR DESCRIPTION
Patch centos-8 repository paths in the cross-build docker image.