### PR TITLE
images: take go version from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,10 @@ clean-gen:
 
 image-%:
 	$(Q)bin=$(patsubst image-%,%,$@); \
-		$(DOCKER) build . -f "cmd/$$bin/Dockerfile" -t $(IMAGE_REPO)$$bin:$(IMAGE_VERSION)
+	    go_version=`$(GO_CMD) list -m -f '{{.GoVersion}}'`; \
+	    $(DOCKER) build . -f "cmd/$$bin/Dockerfile" \
+	    --build-arg GO_VERSION=$${go_version} \
+	    -t $(IMAGE_REPO)$$bin:$(IMAGE_VERSION)
 
 image-push-%: image-%
 	$(Q)bin=$(patsubst image-push-%,%,$@); \

--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -1,6 +1,6 @@
-ARG BUILDER_BASE=golang:1.17.8-bullseye
+ARG GO_VERSION=1.18
 
-FROM ${BUILDER_BASE} as builder
+FROM golang:${GO_VERSION}-bullseye as builder
 
 WORKDIR /go/build
 

--- a/cmd/cri-resmgr-webhook/Dockerfile
+++ b/cmd/cri-resmgr-webhook/Dockerfile
@@ -1,6 +1,6 @@
-ARG BUILDER_BASE=golang:1.17.8-bullseye
+ARG GO_VERSION=1.18
 
-FROM ${BUILDER_BASE} as builder
+FROM golang:${GO_VERSION}-bullseye as builder
 
 WORKDIR /go/build
 


### PR DESCRIPTION
Parse the golang version to be used in the builder image from go.mod.
Keeps it always in sync.

(cherry picked from commit 3772f63d7aab2ba1076f459cb18fb22737a1a9f3)