### PR TITLE
resmgr,relay: make image socket default to runtime one.

### DIFF
--- a/pkg/cri/relay/relay.go
+++ b/pkg/cri/relay/relay.go
@@ -27,6 +27,8 @@ import (
 const (
 	// DisableService is used to mark a socket/service to not be connected.
 	DisableService = client.DontConnect
+	// DefaultImageSocket uses the runtime socket for the image servie, too.
+	DefaultImageSocket = "default"
 )
 
 // Options contains the configurable options of our CRI relay.
@@ -73,8 +75,13 @@ func NewRelay(options Options) (Relay, error) {
 		options: options,
 	}
 
+	imageSocket := r.options.ImageSocket
+	if imageSocket == DefaultImageSocket {
+		imageSocket = r.options.RuntimeSocket
+	}
+
 	cltopts := client.Options{
-		ImageSocket:   r.options.ImageSocket,
+		ImageSocket:   imageSocket,
 		RuntimeSocket: r.options.RuntimeSocket,
 		DialNotify:    r.dialNotify,
 	}

--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/intel/cri-resource-manager/pkg/cri/relay"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/sockets"
 	"github.com/intel/cri-resource-manager/pkg/pidfile"
 )
@@ -53,10 +54,10 @@ const (
 
 // Register us for command line option processing.
 func init() {
-	flag.StringVar(&opt.ImageSocket, "image-socket", sockets.Containerd,
-		"Unix domain socket path where CRI image service requests should be relayed to.")
 	flag.StringVar(&opt.RuntimeSocket, "runtime-socket", sockets.Containerd,
 		"Unix domain socket path where CRI runtime service requests should be relayed to.")
+	flag.StringVar(&opt.ImageSocket, "image-socket", relay.DefaultImageSocket,
+		"CRI image service socket, defaults to the value used for --runtime-socket.")
 	flag.StringVar(&opt.RelaySocket, "relay-socket", sockets.ResourceManagerRelay,
 		"Unix domain socket path where the resource manager should serve requests on.")
 	flag.StringVar(&opt.RelayDir, "relay-dir", "/var/lib/cri-resmgr",


### PR DESCRIPTION
Make the image socket default to the current value of the runtime socket instead of the default value of the runtime socket. With this in place, changing only the value of the runtime socket changes the value of the image socket as well. In particular, this avoids `cri-resmgr --runtime-socket /var/run/crio/crio.sock` being a synonym for the insane `cri-resmgr --runtime-socket /var/run/crio/crio.sock --image-socket /var/run/containerd/containerd.sock` setup.