### PR TITLE
resmgr: allow optional unix://-prefix for socket path options.

### DIFF
--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -472,6 +472,11 @@ func (m *resmgr) setupRelay() error {
 		RuntimeSocket: opt.RuntimeSocket,
 		QualifyReqFn:  m.disambiguate,
 	}
+
+	options.ImageSocket = strings.TrimPrefix(options.ImageSocket, "unix://")
+	options.RuntimeSocket = strings.TrimPrefix(options.RuntimeSocket, "unix://")
+	options.RelaySocket = strings.TrimPrefix(options.RelaySocket, "unix://")
+
 	if m.relay, err = relay.NewRelay(options); err != nil {
 		return resmgrError("failed to create CRI relay: %v", err)
 	}


### PR DESCRIPTION
Allow optional unix socket qualifier for runtime, image and relay socket paths (by stripping any `unix://`-prefix). 