### PR TITLE
images: build statically linked binaries

### DIFF
--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Build webhook, fully statically linked binary
 COPY . .
 
-RUN CGO_ENABLED=0 make BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
+RUN CGO_ENABLED=0 make build-static BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
 
 FROM scratch as final
 

--- a/cmd/cri-resmgr-webhook/Dockerfile
+++ b/cmd/cri-resmgr-webhook/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Build webhook, fully statically linked binary
 COPY . .
 
-RUN CGO_ENABLED=0 make BUILD_DIRS=cri-resmgr-webhook
+RUN CGO_ENABLED=0 make build-static BUILD_DIRS=cri-resmgr-webhook
 
 FROM scratch as final
 


### PR DESCRIPTION
We use scratch as the base image now so now dynamically loaded libs are
available.