### PR TITLE
[release 0.7] backport image building fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,11 +276,10 @@ libexec/%.o: elf/%.c
 	$(Q)$(CLANG) -nostdinc -D __KERNEL__ $(KERNEL_INCLUDES) -O2 -Wall -target bpf -c $< -o $@
 
 bin/%: .static.%.$(STATIC)
-	$(Q)bin=$(notdir $@); src=cmd/$$bin; \
+	$(Q)bin=$(notdir $@); src=./cmd/$$bin; \
 	echo "Building $$([ -n "$(STATIC)" ] && echo 'static ')$@ (version $(BUILD_VERSION), build $(BUILD_BUILDID))..."; \
 	mkdir -p bin && \
-	cd $$src && \
-	    $(GO_BUILD) $(BUILD_TAGS) $(LDFLAGS) $(GCFLAGS) -o ../../bin/$$bin
+	$(GO_BUILD) $(BUILD_TAGS) $(LDFLAGS) $(GCFLAGS) -o bin/ $$src
 
 .static.%.$(STATIC):
 	$(Q)if [ ! -f "$@" ]; then \

--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Build webhook, fully statically linked binary
 COPY . .
 
-RUN CGO_ENABLED=0 make BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
+RUN CGO_ENABLED=0 make build-static BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
 
 FROM scratch as final
 

--- a/cmd/cri-resmgr-webhook/Dockerfile
+++ b/cmd/cri-resmgr-webhook/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Build webhook, fully statically linked binary
 COPY . .
 
-RUN CGO_ENABLED=0 make BUILD_DIRS=cri-resmgr-webhook
+RUN CGO_ENABLED=0 make build-static BUILD_DIRS=cri-resmgr-webhook
 
 FROM scratch as final
 


### PR DESCRIPTION
- images: build statically linked binaries
  We use scratch as the base image now so now dynamically loaded libs are
  available.
- Makefile: don't change dir when running go build
  This fixes build of agent and webhook images. Otherwise they will fail
  because go-build is not able to find the vcs information. Could be
  handled with '-buildvcs=false' build flag but just removing chdir seems
  simpler. Plus, we get the vcs information in the go binary.