### PR TITLE
Makefile: use statically linked binaries in e2e-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ endif
 
 release-tests: e2e-tests
 
-e2e-tests: build
+e2e-tests: build-static
 	$(Q)tests="$(if $(E2E_TESTS),$(E2E_TESTS),test/e2e/policies.test-suite)"; \
 	$(E2E_RUN) $$tests; \
 	if [ "$$?" != "0" ]; then \


### PR DESCRIPTION
Otherwise tests might fail because of library version incompatibilities
wrt build host vs the container image that we're running the binaries.