### PR TITLE
jenkinsfile: build *:devel images from master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,11 @@ pipeline {
         stage('Build and push images') {
             steps {
                 withDockerRegistry([credentialsId: "${env.DOCKER_REGISTRY}", url: "https://${env.IMAGE_REPO}"]) {
-                    sh "make images-push IMAGE_REPO=${env.IMAGE_REPO}"
+                    if (env.BRANCH_NAME == 'master') {
+                        sh "make images-push IMAGE_REPO=${env.IMAGE_REPO} IMAGE_VERSION=devel Q="
+                    } else {
+                        sh "make images-push IMAGE_REPO=${env.IMAGE_REPO} Q="
+                    }
                 }
             }
         }


### PR DESCRIPTION
So far we've only built container images from tags. This patch adds
special handling for the master branch so that container images built
from it are tagged with *:devel tag (instead of *:master). This naming
matches what we have in documentation, for example.