### PR TITLE
resmgr: allow disabling the agent ingress and egress interfaces.

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/static-pools/node.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-pools/node.go
@@ -48,7 +48,7 @@ func newNodeUpdater(agent agent.Interface) *nodeUpdater {
 func (u *nodeUpdater) start() error {
 	u.Info("starting node updater")
 
-	if u.agent == nil {
+	if u.agent == nil || u.agent.IsDisabled() {
 		return stpError("cri-resmgr-agent connection required")
 	}
 


### PR DESCRIPTION
This patch set allows one to disable the incoming and outgoing config/agent interfaces by explicitly setting the corresponding command line options to `"disabled"` or `""`.