### PR TITLE
balloons: require MaxCPUs in all balloon types, allow setting it to "unlimited"

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
@@ -52,7 +52,7 @@ type BalloonDef struct {
 	// MaxCpus specifies the maximum number of CPUs exclusively
 	// usable by containers in a balloon. Balloon size will not be
 	// inflated larger than MaxCpus.
-	MaxCpus int `json:"MaxCPUs"`
+	MaxCpus Limit `json:"MaxCPUs"`
 	// MinCpus specifies the minimum number of CPUs exclusively
 	// usable by containers in a balloon. When new balloon is created,
 	// this will be the number of CPUs reserved for it even if a container
@@ -74,7 +74,7 @@ type BalloonDef struct {
 	// MaxBalloons is the maximum number of balloon instances that
 	// is allowed to co-exist. If reached, new balloons cannot be
 	// created anymore.
-	MaxBalloons int `json:"MaxBalloons"`
+	MaxBalloons Limit `json:"MaxBalloons"`
 	// PreferSpreadingPods: containers of the same pod may be
 	// placed on separate balloons. The default is false: prefer
 	// placing containers of a pod to the same balloon(s).

--- a/pkg/cri/resource-manager/policy/builtin/balloons/limit.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/limit.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package balloons
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// Limit is an integer where negative numbers have special meanings.
+type Limit int
+
+const (
+	Unlimited            Limit = -1
+	greatestInvalidLimit       = -2
+)
+
+var limitToString = map[Limit]string{
+	Unlimited: "unlimited",
+}
+
+// String stringifies a Limit
+func (lm Limit) String() string {
+	if lmStr, ok := limitToString[lm]; ok {
+		return lmStr
+	}
+	return fmt.Sprintf("%d", int(lm))
+}
+
+// MarshalJSON marshals a Limit as a quoted json string
+func (lm Limit) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString("\"" + lm.String() + "\"")
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmarshals a JSON string to Limit
+func (lm *Limit) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return balloonsError("invalid limit (empty string)")
+	}
+	if b[0] >= '0' && b[0] <= '9' {
+		lmInt, err := strconv.Atoi(string(b))
+		*lm = Limit(lmInt)
+		return err
+	}
+	bStr := string(b[1 : len(b)-1])
+	for lmConst, lmString := range limitToString {
+		if lmString == bStr {
+			*lm = lmConst
+			return nil
+		}
+	}
+	return balloonsError("invalid limit %q", string(b))
+}

--- a/pkg/cri/resource-manager/policy/builtin/balloons/metrics.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/metrics.go
@@ -83,7 +83,7 @@ func (p *balloons) PollMetrics() policy.Metrics {
 		bm.DefName = bln.Def.Name
 		bm.CpuClass = bln.Def.CpuClass
 		bm.MinCpus = bln.Def.MinCpus
-		bm.MaxCpus = bln.Def.MaxCpus
+		bm.MaxCpus = int(bln.Def.MaxCpus)
 		bm.PrettyName = bln.PrettyName()
 		bm.Cpus = bln.Cpus
 		bm.Mems = bln.Mems.String()

--- a/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
@@ -35,6 +35,7 @@ data:
           Namespaces:
             - ${BTYPE1_NAMESPACE0:-btype1ns0}
           MinCPUs: ${BTYPE1_MINCPUS:-1}
+          MaxCPUs: ${BTYPE1_MAXCPUS:-1}
           AllocatorPriority: ${BTYPE1_ALLOCATIONPRIORITY:-1}
           CPUClass: ${BTYPE1_CPUCLASS:-classB}
           PreferNewBalloons: ${BTYPE1_PREFERNEWBALLOONS:-false}

--- a/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
@@ -25,6 +25,7 @@ policy:
         Namespaces:
           - "three"
         MinCPUs: 3
+        MaxCPUs: unlimited
         AllocatorPriority: 1
         CPUClass: class3
         PreferSpreadingPods: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
@@ -27,7 +27,7 @@ launch cri-resmgr-agent
 kubectl create namespace $testns
 kubectl create namespace btype1ns0
 
-AVAILABLE_CPU="cpuset:0,4-15" BTYPE2_NAMESPACE0='"*"' apply-configmap
+AVAILABLE_CPU="cpuset:0,4-15" BTYPE2_NAMESPACE0='"*"' BTYPE1_MAXCPUS='unlimited' apply-configmap
 sleep 3
 
 # pod0 in btype0, annotation


### PR DESCRIPTION
Ignore before #865 is merged.

This draft build on top of PR #865. Add explicit "unlimited" to both MaxCPUs and MaxBalloons.

Needs testing "unlimited" CPU balloon inflation and MaxBalloons behavior.