### PR TITLE
release-0.6: cache: don't crash if pod has no status data.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -107,7 +107,11 @@ func createFakePod(cch Cache, fp *fakePod) (Pod, error) {
 	fp.podCfg = req.Config
 
 	cch.(*cache).Debug("*** => creating Pod: %+v\n", *req)
-	p := cch.InsertPod(fp.id, req, nil)
+	p, err := cch.InsertPod(fp.id, req, nil)
+	if err != nil {
+		cch.(*cache).Debug("*** <= created Pod FAILED: %+v\n", err)
+		return nil, err
+	}
 	cch.(*cache).Debug("*** <= created Pod: %+v\n", *p.(*pod))
 	return p, nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -656,7 +656,7 @@ type mockCache struct {
 	returnValue2ForLookupContainer bool
 }
 
-func (m *mockCache) InsertPod(string, interface{}, *cache.PodStatus) cache.Pod {
+func (m *mockCache) InsertPod(string, interface{}, *cache.PodStatus) (cache.Pod, error) {
 	panic("unimplemented")
 }
 func (m *mockCache) DeletePod(string) cache.Pod {

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -234,7 +234,11 @@ func (m *resmgr) RunPod(ctx context.Context, method string, request interface{},
 	m.Lock()
 	defer m.Unlock()
 
-	pod := m.cache.InsertPod(podID, request, nil)
+	pod, err := m.cache.InsertPod(podID, request, nil)
+	if err != nil {
+		m.Error("%s: failed to insert new pod to cache: %v", method, err)
+		return nil, resmgrError("%s: failed to insert new pod to cache: %v", method, err)
+	}
 	m.updateIntrospection()
 
 	// search for any lingering old version and clean up if found


### PR DESCRIPTION
Don't crash during runtime state synchronization if the runtime fails to provide any useful pod status data (cgroup parent dir).
This same fix should protect against potentiallymalicious clients sending RunPodSandbox requests with nil Config or Config.Metadata.