### PR TITLE
master: cache: don't crash if pod has no status data.

### DIFF
--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -520,7 +520,7 @@ type Cachable interface {
 // itself upon startup.
 type Cache interface {
 	// InsertPod inserts a pod into the cache, using a runtime request or reply.
-	InsertPod(id string, msg interface{}, status *PodStatus) Pod
+	InsertPod(id string, msg interface{}, status *PodStatus) (Pod, error)
 	// DeletePod deletes a pod from the cache.
 	DeletePod(id string) Pod
 	// LookupPod looks up a pod in the cache.
@@ -855,7 +855,7 @@ func (cch *cache) createCacheID(c *container) string {
 }
 
 // Insert a pod into the cache.
-func (cch *cache) InsertPod(id string, msg interface{}, status *PodStatus) Pod {
+func (cch *cache) InsertPod(id string, msg interface{}, status *PodStatus) (Pod, error) {
 	var err error
 
 	p := &pod{cache: cch, ID: id}
@@ -871,14 +871,14 @@ func (cch *cache) InsertPod(id string, msg interface{}, status *PodStatus) Pod {
 
 	if err != nil {
 		cch.Error("failed to insert pod %s: %v", id, err)
-		return nil
+		return nil, err
 	}
 
 	cch.Pods[p.ID] = p
 
 	cch.Save()
 
-	return p
+	return p, nil
 }
 
 // Delete a pod from the cache.
@@ -1032,8 +1032,13 @@ func (cch *cache) RefreshPods(msg *cri.ListPodSandboxResponse, status map[string
 		valid[item.Id] = struct{}{}
 		if _, ok := cch.Pods[item.Id]; !ok {
 			cch.Debug("inserting discovered pod %s...", item.Id)
-			pod := cch.InsertPod(item.Id, item, status[item.Id])
-			add = append(add, pod)
+			pod, err := cch.InsertPod(item.Id, item, status[item.Id])
+			if err != nil {
+				cch.Error("failed to insert discovered pod %s to cache: %v",
+					item.Id, err)
+			} else {
+				add = append(add, pod)
+			}
 		}
 	}
 

--- a/pkg/cri/resource-manager/cache/cache_test.go
+++ b/pkg/cri/resource-manager/cache/cache_test.go
@@ -107,7 +107,11 @@ func createFakePod(cch Cache, fp *fakePod) (Pod, error) {
 	fp.podCfg = req.Config
 
 	cch.(*cache).Debug("*** => creating Pod: %+v\n", *req)
-	p := cch.InsertPod(fp.id, req, nil)
+	p, err := cch.InsertPod(fp.id, req, nil)
+	if err != nil {
+		cch.(*cache).Debug("*** <= created Pod FAILED: %+v\n", err)
+		return nil, err
+	}
 	cch.(*cache).Debug("*** <= created Pod: %+v\n", *p.(*pod))
 	return p, nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -656,7 +656,7 @@ type mockCache struct {
 	returnValue2ForLookupContainer bool
 }
 
-func (m *mockCache) InsertPod(string, interface{}, *cache.PodStatus) cache.Pod {
+func (m *mockCache) InsertPod(string, interface{}, *cache.PodStatus) (cache.Pod, error) {
 	panic("unimplemented")
 }
 func (m *mockCache) DeletePod(string) cache.Pod {

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -244,7 +244,11 @@ func (m *resmgr) RunPod(ctx context.Context, method string, request interface{},
 	m.Lock()
 	defer m.Unlock()
 
-	pod := m.cache.InsertPod(podID, request, nil)
+	pod, err := m.cache.InsertPod(podID, request, nil)
+	if err != nil {
+		m.Error("%s: failed to insert new pod to cache: %v", method, err)
+		return nil, resmgrError("%s: failed to insert new pod to cache: %v", method, err)
+	}
 	m.updateIntrospection()
 
 	// search for any lingering old version and clean up if found


### PR DESCRIPTION
Don't crash during runtime state synchronization if the runtime fails to provide any useful pod status data (cgroup parent dir).
This same fix should protect against potentiallymalicious clients sending RunPodSandbox requests with nil Config or Config.Metadata.

This PR is #886 cherry-picker to master.