### PR TITLE
CODEOWNERS: update maintainers.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kad @klihub @marquiz @ipuustin @mythi @askervin @jukkar
+* @kad @klihub @marquiz @mythi @askervin @jukkar


### PR DESCRIPTION
Remove those previous owners who are nowadays mostly guilty by association.