### PR TITLE
e2e: check if cri-resmgr is expected to run with different policy

### DIFF
--- a/test/e2e/policies.test-suite/check-correct-policy.source.sh
+++ b/test/e2e/policies.test-suite/check-correct-policy.source.sh
@@ -1,0 +1,13 @@
+# This script does a policy check before the real test code is started.
+
+cache_policy="$(vm-command-q "cat /var/lib/cri-resmgr/cache" | jq -r .PolicyName)"
+
+cfg_policy=$(awk '/Active:/{print $2}' < "$cri_resmgr_cfg")
+
+if [ -n "$cache_policy" ] && [ -n "$cfg_policy" ] && [ "$cache_policy" != "$cfg_policy" ]; then
+    echo "cri-resmgr is been started with policy \"$cache_policy\", switching to \"$cfg_policy\""
+    terminate cri-resmgr
+    echo "destroying cri-resmgr cache with previous policy"
+    vm-command "rm -rf /var/lib/cri-resmgr"
+    launch cri-resmgr
+fi


### PR DESCRIPTION
E2E tests generally avoid restarting cri-resmgr for faster execution. This causes false FAILs when the same vm runs one test from policy A followed by another test from policy B without forced cri-resmgr restarting. This patch adds a script that run_tests.sh imports automatically when running any test from the policies test suite. The script checks if vm is running cri-resmgr with different policy than what next test expects, and if so, restarts cri-resmgr with cache cleared when needed.