### PR TITLE
e2e: balloons: Cleanup pods in the tests

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
@@ -1,5 +1,12 @@
 # This test verifies prometheus metrics from the balloons policy.
 
+cleanup() {
+    vm-command "kubectl delete pods --all --now"
+    return 0
+}
+
+cleanup
+
 # Launch cri-resmgr with wanted metrics update interval and a
 # configuration that opens the instrumentation http server.
 terminate cri-resmgr
@@ -74,3 +81,5 @@ verify-metrics-has-line 'balloon="fast-dualcore\[0\]".*pod5c0.* 4'
 # # Re-launch cri-resmgr with test suite default parameters
 # terminate cri-resmgr
 # launch cri-resmgr
+
+cleanup

--- a/test/e2e/policies.test-suite/balloons/n4c16/test07-maxballoons/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test07-maxballoons/code.var.sh
@@ -1,3 +1,10 @@
+cleanup() {
+    vm-command "kubectl delete pods --all --now"
+    return 0
+}
+
+cleanup
+
 terminate cri-resmgr
 cri_resmgr_cfg=${TEST_DIR}/balloons-maxballoons.cfg launch cri-resmgr
 
@@ -53,6 +60,8 @@ if ! grep -q 'no suitable balloon instance available' <<< "$COMMAND_OUTPUT"; the
     error "could not find 'no suitable balloon instance available' in pod6 description"
 fi
 vm-command "kubectl delete pod pod5 --now"
+
+cleanup
 
 # Try starting cri-resmgr with a configuration where MinBalloons and
 # MaxBalloons of the same balloon type contradict.


### PR DESCRIPTION
Make sure all pods are cleared when test starts and ends in order not to affect or get affected from other tests.