### PR TITLE
Replace tabs with spaces in broken balloons-policy.cfg example

### DIFF
--- a/sample-configs/balloons-policy.cfg
+++ b/sample-configs/balloons-policy.cfg
@@ -51,12 +51,12 @@ policy:
         # putting them in the same balloon.
         # The default is: false.
         PreferNewBalloons: true
-	# PreferPerNamespaceBalloon: if true, containers in the same
-	# namespace are preferrably placed in the same balloon, and
-	# containers in different namespaces to different
-	# balloons. The default is false: namespaces have no effect on
-	# placement.
-	PreferPerNamespaceBalloon: false
+        # PreferPerNamespaceBalloon: if true, containers in the same
+        # namespace are preferrably placed in the same balloon, and
+        # containers in different namespaces to different
+        # balloons. The default is false: namespaces have no effect on
+        # placement.
+        PreferPerNamespaceBalloon: false
         # PreferSpreadingPods: if true, containers of single pod can
         # be assigned in different balloons, based on which balloons
         # have most free CPU resources.


### PR DESCRIPTION
Without this fix, running example fails with following error:

Steps to reproduce:

```
go run ./cmd/cri-resmgr --force-config sample-configs/balloons-policy.cfg
```

```
F0926 11:34:21.853955  214282 main.go:85] failed to create resource manager instance: resource-manager: failed to load forced configuration sample-configs/balloons-policy.cfg: config error: failed to apply configuration from file: config error: failed to load configuration from file "sample-configs/balloons-policy.cfg": error converting YAML to JSON: yaml: line 54: found a tab character that violates indentation
exit status 1
```