### PR TITLE
e2e: Remove Ubuntu 21.04 support

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -119,10 +119,6 @@ ubuntu-20_04-image-url() {
     echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
 }
 
-ubuntu-21_04-image-url() {
-    echo "https://cloud-images.ubuntu.com/releases/hirsute/release/ubuntu-21.04-server-cloudimg-amd64.img"
-}
-
 ubuntu-22_04-image-url() {
     echo "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img"
 }

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -102,7 +102,7 @@ usage() {
     echo "             Supported values: centos-7, centos-8, debian-10, debian-sid"
     echo "                 fedora, fedora-33, opensuse-tumbleweed,"
     echo "                 opensuse-15.3 (same as opensuse), opensuse-15.2, sles,"
-    echo "                 ubuntu-18.04, ubuntu-20.04, ubuntu-21.04"
+    echo "                 ubuntu-18.04, ubuntu-20.04, ubuntu-22.04"
     echo "             If sles: set VM_SLES_REGCODE=<CODE> to use official packages."
     echo "    cgroups: cgroups version in the VM, v1 or v2. The default is v1."
     echo "             cgroups=v2 is supported only on distro=fedora"


### PR DESCRIPTION
Following error was seen when trying to install Ubuntu 21.04 so remove support for it.

Reading package lists...
E: The repository 'http://security.ubuntu.com/ubuntu hirsute-security Release' no longer has a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu hirsute Release' no longer has a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu hirsute-updates Release' no longer has a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu hirsute-backports Release' does not have a Release file.