### PR TITLE
Add -check-config option to validate config.

### DIFF
--- a/cmd/cri-resmgr/main.go
+++ b/cmd/cri-resmgr/main.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/intel/goresctrl/pkg/rdt"
 
-	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager"
+	resmgr "github.com/intel/cri-resource-manager/pkg/cri/resource-manager"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/instrumentation"
 
@@ -43,9 +43,21 @@ func main() {
 
 	printConfig := flag.Bool("print-config", false, "Print configuration and exit.")
 	listPolicies := flag.Bool("list-policies", false, "List available policies.")
+	checkConfig := flag.String("check-config", "", "Check configuration and exit.")
 	flag.Parse()
 
 	switch {
+	case *checkConfig != "":
+		if err := config.SetConfigFromFile(*checkConfig); err != nil {
+			fmt.Printf("validation error: %s\n", err)
+			os.Exit(1)
+		}
+		if *printConfig {
+			config.Print(nil)
+		}
+		fmt.Println("config ok")
+		os.Exit(0)
+
 	case *printConfig:
 		config.Print(nil)
 		os.Exit(0)


### PR DESCRIPTION
Exists with proper exit code to (0-ok) and prints error message.

Can be used as a check before applying new configuration.

Just an idea - probably in our extension we will programatically API of config module - more about it here: https://github.com/intel/gardener-extension-cri-resmgr/issues/56

BTW: I found undocumented config-help/help arguments to are usefull - are they undocumented on purpose or just missed? 


Output looks like:
```
# go run ./cmd/cri-resmgr/ -check-config sample-configs/balloons-policy.cfg
...
config ok
# echo $?
0
```

or
```
# go run ./cmd/cri-resmgr/ -check-config broken.cfg
validation error:  config error: module logger: given unknown configuration data Debuug
# echo $?
1
```
with broken.cfg:
```
logger:
    Debuug: "foo"
```

Marking it as draft because I don't how usefull it would be - probably it just checks syntax (proper keys and types) but not sematics e.g. ? (cpuset is parsed for example, but I can set **policy.Active to non-existents and still returns ok!!!**)

e.g. non-existing-policy.cfg
```
#cat non-existing-policy.cfg
policy:
    Active: "ThereIsNoSuchPolicy"

# go run ./cmd/cri-resmgr/ -check-config non-existing-policy.cfg
config ok
```

