### PR TITLE
resmgr: make sysfs/other hostfs pseudoroot directory configurable on the command line.

### DIFF
--- a/pkg/cri/resource-manager/flags.go
+++ b/pkg/cri/resource-manager/flags.go
@@ -25,6 +25,7 @@ import (
 
 // Options captures our command line parameters.
 type options struct {
+	HostRoot              string
 	ImageSocket           string
 	RuntimeSocket         string
 	RelaySocket           string
@@ -54,6 +55,9 @@ const (
 
 // Register us for command line option processing.
 func init() {
+	flag.StringVar(&opt.HostRoot, "host-root", "",
+		"Directory prefix under which the host's sysfs, etc. are mounted.")
+
 	flag.StringVar(&opt.RuntimeSocket, "runtime-socket", sockets.Containerd,
 		"Unix domain socket path where CRI runtime service requests should be relayed to.")
 	flag.StringVar(&opt.ImageSocket, "image-socket", relay.DefaultImageSocket,

--- a/pkg/cri/resource-manager/resource-manager.go
+++ b/pkg/cri/resource-manager/resource-manager.go
@@ -38,6 +38,8 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/instrumentation"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/pidfile"
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/topology"
 
 	policyCollector "github.com/intel/cri-resource-manager/pkg/policycollector"
 	"github.com/intel/cri-resource-manager/pkg/utils"
@@ -85,6 +87,9 @@ func NewResourceManager() (ResourceManager, error) {
 	if err := m.setupCache(); err != nil {
 		return nil, err
 	}
+
+	sysfs.SetSysRoot(opt.HostRoot)
+	topology.SetSysRoot(opt.HostRoot)
 
 	switch {
 	case opt.ResetPolicy && opt.ResetConfig:

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -30,9 +30,12 @@ import (
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 
+var (
+	// Parent directory under which host sysfs, etc. is mounted (if non-standard location).
+	sysRoot = ""
+)
+
 const (
-	// SysfsRootPath is the mount path of sysfs.
-	SysfsRootPath = "/sys"
 	// sysfs devices/cpu subdirectory path
 	sysfsCPUPath = "devices/system/cpu"
 	// sysfs device/node subdirectory path
@@ -236,9 +239,14 @@ type Cache struct {
 	cpus  idset.IDSet // CPUs sharing this cache
 }
 
+// SetSysRoot sets the sys root directory.
+func SetSysRoot(path string) {
+	sysRoot = path
+}
+
 // DiscoverSystem performs discovery of the running systems details.
 func DiscoverSystem(args ...DiscoveryFlag) (System, error) {
-	return DiscoverSystemAt(SysfsRootPath, args...)
+	return DiscoverSystemAt(filepath.Join("/", sysRoot, "sys"))
 }
 
 // DiscoverSystemAt performs discovery of the running systems details from sysfs mounted at path.
@@ -1051,9 +1059,12 @@ func (p *cpuPackage) SstInfo() *sst.SstPackageInfo {
 }
 
 // Discover cache associated with the given CPU.
+//
 // Notes:
-//     I'm not sure how to interpret the cache information under sysfs. This code is now effectively
-//     disabled by forcing the associated discovery bit off in the discovery flags.
+//
+//	I'm not sure how to interpret the cache information under sysfs.
+//	This code is now effectively disabled by forcing the associated
+//	discovery bit off in the discovery flags.
 func (sys *system) discoverCache(path string) error {
 	var id idset.ID
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -28,7 +28,7 @@ import (
 
 // to mock in tests
 var (
-	mockRoot = ""
+	sysRoot = ""
 )
 
 const (
@@ -48,6 +48,11 @@ type Hint struct {
 // Hints represents set of hints collected from multiple providers
 type Hints map[string]Hint
 
+// SetSysRoot sets the sysfs root directory to use.
+func SetSysRoot(root string) {
+	sysRoot = root
+}
+
 func getDevicesFromVirtual(realDevPath string) (devs []string, err error) {
 	if !filepath.HasPrefix(realDevPath, "/sys/devices/virtual") {
 		return nil, fmt.Errorf("%s is not a virtual device", realDevPath)
@@ -58,7 +63,7 @@ func getDevicesFromVirtual(realDevPath string) (devs []string, err error) {
 	dir, file := filepath.Split(relPath)
 	switch dir {
 	case "vfio/":
-		iommuGroup := filepath.Join(mockRoot, "/sys/kernel/iommu_groups", file, "devices")
+		iommuGroup := filepath.Join(sysRoot, "/sys/kernel/iommu_groups", file, "devices")
 		files, err := ioutil.ReadDir(iommuGroup)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read IOMMU group %s", iommuGroup)
@@ -128,7 +133,7 @@ func NewTopologyHints(devPath string) (hints Hints, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed get realpath for %s", devPath)
 	}
-	for p := realDevPath; strings.HasPrefix(p, mockRoot+"/sys/devices/"); p = filepath.Dir(p) {
+	for p := realDevPath; strings.HasPrefix(p, sysRoot+"/sys/devices/"); p = filepath.Dir(p) {
 		hint, err := getTopologyHint(p)
 		if err != nil {
 			return nil, err

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -31,9 +31,9 @@ func setupTestEnv(t *testing.T) func() {
 	if path, err := filepath.EvalSymlinks(pwd); err == nil {
 		pwd = path
 	}
-	mockRoot = pwd + "/testdata"
+	SetSysRoot(pwd + "/testdata")
 	teardown := func() {
-		mockRoot = ""
+		SetSysRoot("")
 	}
 	return teardown
 }
@@ -163,7 +163,7 @@ func TestGetDevicesFromVirtual(t *testing.T) {
 		{
 			name:        "vfio",
 			input:       "/sys/devices/virtual/vfio/42",
-			output:      []string{mockRoot + "/sys/devices/pci0000:00/0000:00:02.0"},
+			output:      []string{sysRoot + "/sys/devices/pci0000:00/0000:00:02.0"},
 			expectedErr: false,
 		},
 		{
@@ -281,10 +281,10 @@ func TestNewTopologyHints(t *testing.T) {
 		},
 		{
 			name:  "pci card1",
-			input: mockRoot + "/sys/devices/pci0000:00/0000:00:02.0/drm/card1",
+			input: sysRoot + "/sys/devices/pci0000:00/0000:00:02.0/drm/card1",
 			output: Hints{
-				mockRoot + "/sys/devices/pci0000:00/0000:00:02.0": Hint{
-					Provider: mockRoot + "/sys/devices/pci0000:00/0000:00:02.0",
+				sysRoot + "/sys/devices/pci0000:00/0000:00:02.0": Hint{
+					Provider: sysRoot + "/sys/devices/pci0000:00/0000:00:02.0",
 					CPUs:     "0-7",
 					NUMAs:    "",
 					Sockets:  ""},


### PR DESCRIPTION
Allow overriding the default `sysfs` mount point using the newly introduced `--sysfs-root $dir` command line option. When used, the real host sysfs should be available/mounted as `$dir/sys`.

Target usage for this is to allow an NRI-enabled `cri-resmgr` to run as  a `DaemonSet` inside a container, yet be able to do proper HW-discovery using the full `sysfs` of the host.