### PR TITLE
cri-resmgr-agent: print version info on startup.

### DIFF
--- a/cmd/cri-resmgr-agent/main.go
+++ b/cmd/cri-resmgr-agent/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/intel/cri-resource-manager/pkg/agent"
 	"github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/version"
 )
 
 func main() {
@@ -35,6 +36,8 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to create resource manager agent instance: %v", err)
 	}
+
+	log.Info("cri-resmgr agent (version %s, build %s) starting...", version.Version, version.Build)
 
 	if err := a.Run(); err != nil {
 		log.Fatal("%v", err)


### PR DESCRIPTION
As requested by Pawel [here](https://github.com/intel/cri-resource-manager/pull/903#issuecomment-1302567997)...