### PR TITLE
e2e: run Qemu with -nographic instead of -vga qxl

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -17,6 +17,7 @@ vms:
       - KVM_CPU_OPTS=${VM_QEMU_CPUMEM:=-machine pc -smp cpus=4 -m 8G}
       - EXTRA_QEMU_OPTS=-monitor unix:/data/monitor,server,nowait ${VM_QEMU_EXTRA}
       - USE_NET_BRIDGES=${USE_NET_BRIDGES:-0}
+      - DISABLE_VGA=1
     user-data: |
       #!/bin/bash
       set -e


### PR DESCRIPTION
Ubuntu 22.04 has known issues when trying to use -vga qxl with kvm. We do not need VGA for anything, so let's stop using qxl.