### PR TITLE
Don't track static binaries in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage.txt
 *.tar
 *.tar.*
 *.spec
+.static.*
 /debian
 /packages
 


### PR DESCRIPTION
Intentionally ignore CRI-RM static binaries from git.
Those binaries could appear on the local repository
for example after `make build-static`.


