### PR TITLE
control/memory: check top tier memory control on startup.

### DIFF
--- a/pkg/cri/resource-manager/control/memory/memory.go
+++ b/pkg/cri/resource-manager/control/memory/memory.go
@@ -59,9 +59,9 @@ func getMemoryController() *memctl {
 // Start initializes the controller for enforcing decisions.
 func (ctl *memctl) Start(cache cache.Cache, client client.Client) error {
 	// Let's keep this off for now so we can exercise this without a patched kernel...
-	/*if !ctl.checkToptierLimitSupport() {
+	if !ctl.checkToptierLimitSupport() {
 		return memctlError("cgroup top tier memory limit control not available")
-	}*/
+	}
 	ctl.cache = cache
 	return nil
 }


### PR DESCRIPTION
Check and return an error if the kernels lack the top tier memory control knob. This should cause the control setup code to disable the top tier memory controller and prevent reoccuring warning/error messages whenever we put policy decision in practice.