### PR TITLE
docs: update sphinx to v5.3.0

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.2.1
+FROM sphinxdoc/sphinx:5.3.0
 
 RUN apt-get update && apt-get install -y wget git
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ myst_substitutions = {
     'golang_version': mod_versions['golang'],
     'goresctrl_version': mod_versions['github.com/intel/goresctrl']
 }
+myst_heading_anchors = 3
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==3.5.4
+sphinx==5.3.0
 sphinx_rtd_theme
-myst-parser==0.15.1
+myst-parser==0.18.1
 sphinx-markdown-tables
-Pygments==2.7.4
+Pygments==2.13.0


### PR DESCRIPTION
Update Sphinx and the other docs dependencies to their latest released versions.