### PR TITLE
Balloons: add e2e tests for topology aware allocation and idle CPU sharing

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/balloons-dynamic.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/balloons-dynamic.cfg
@@ -1,0 +1,19 @@
+policy:
+  Active: balloons
+  ReservedResources:
+    cpu: cpuset:31
+  balloons:
+    AllocatorTopologyBalancing: true
+    BalloonTypes:
+      - Name: dynamic
+        MaxCPUs: 32
+        MaxBalloons: 8
+        PreferNewBalloons: true
+        ShareIdleCpusInSame: numa
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/code.var.sh
@@ -1,0 +1,76 @@
+terminate cri-resmgr
+cri_resmgr_cfg=${TEST_DIR}/balloons-dynamic.cfg cri_resmgr_extra_args="-metrics-interval 4s" launch cri-resmgr
+
+# pod0-pod7: create 8 balloons, where each lands on a different NUMA node.
+# Each balloon (except one that lands on the NUMA node with reserved CPUs)
+# has 1 shared CPU at the most since a NUMA node has 4 CPUs and a pod is
+# requesting 1 CPU. Only one of the balloon that using NUMA node with
+#reserved CPU has 0 shared CPUs.
+CPUREQLIM="3"
+INITCPUREQLIM="100m-100m 100m-100m 100m-100m"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamic"
+n=8 create multicontainerpod
+verify-metrics-has-line 'balloon="dynamic\[0\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[1\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[2\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[3\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[4\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[5\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[6\]".*cpus_count="3"*'
+verify-metrics-has-line 'balloon="dynamic\[7\]".*cpus_count="3"*'
+verify-metrics-has-no-line 'cpus_count="4"'
+verify-metrics-has-line 'sharedidlecpus_count="1"'
+verify-metrics-has-line 'cpus_allowed_count="4"'
+verify-metrics-has-line 'sharedidlecpus_count="0"'
+verify-metrics-has-line 'cpus_allowed_count="3"'
+verify-metrics-has-no-line 'sharedidlecpus_count="2"'
+verify-metrics-has-no-line 'cpus_allowed_count="5"'
+verify 'disjoint_sets(nodes["pod0c0"], nodes["pod1c0"], nodes["pod2c0"], nodes["pod3c0"], nodes["pod4c0"], nodes["pod5c0"], nodes["pod6c0"], nodes["pod7c0"])' \
+       'len(nodes["pod0c0"]) == len(nodes["pod1c0"]) == len(nodes["pod2c0"]) == \
+        len(nodes["pod3c0"]) == len(nodes["pod4c0"]) == len(nodes["pod5c0"]) == \
+        len(nodes["pod6c0"]) == len(nodes["pod7c0"]) == 1'
+
+# pod8: Add one more pod with 2 CPUs to inflate over NUMAs nodes, which should cross
+# the NUMA node boundaries but not the die boundaries. Because two NUMA nodes can offer
+# 2 CPUs in total. 
+CPUREQLIM="2"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamic"
+create multicontainerpod
+verify-metrics-has-line 'cpus_count="5"'
+verify-metrics-has-line 'sharedidlecpus="",sharedidlecpus_count="0"'
+verify-metrics-has-line 'sharedidlecpus_count="1"'
+verify 'len(nodes["pod8c0"])==2' \
+       'len(dies["pod8c0"])==1' \
+       'len(packages["pod8c0"])==1'
+kubectl delete pod pod8 --now
+verify-metrics-has-no-line 'cpus_count="5"'
+
+# pod9: Add one more pod with 4 CPUs to inflate over dies, which should cross
+# the NUMA node boundaries as well as dies boundaries. Since 2 dies under the
+# same package can offer 4 CPUs, we should not cross the package boundaries.
+CPUREQLIM="4"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamic"
+create multicontainerpod
+verify 'len(nodes["pod9c0"])==4' \
+       'len(dies["pod9c0"])==2' \
+       'len(packages["pod9c0"])==1'
+kubectl delete pod pod9 --now
+verify 'disjoint_sets(nodes["pod0c0"], nodes["pod1c0"], nodes["pod2c0"], nodes["pod3c0"], nodes["pod4c0"], nodes["pod5c0"], nodes["pod6c0"], nodes["pod7c0"])' \
+
+# pod9: Add one more pod with 7 CPUs to inflate over packages, which should cross
+# NUMA node, dies and package boundaries. At this point, there is no free CPUs
+# left on the host, so no shared CPUs.
+CPUREQLIM="6 1"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamic"
+create multicontainerpod
+verify 'len(nodes["pod10c0"])==7' \
+       'len(dies["pod10c0"])==4' \
+       'len(packages["pod10c0"])==2'
+verify-metrics-has-line 'sharedidlecpus="",sharedidlecpus_count="0"'
+verify-metrics-has-no-line 'sharedidlecpus_count="1"'
+
+# pod0, pod9 deflate. This should free up 10 CPUs that will cause having
+# shared CPUs available again.
+kubectl delete pod pod10 --now
+kubectl delete pod pod0 --now
+verify-metrics-has-line 'sharedidlecpus_count="1"'

--- a/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/multicontainerpod.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/multicontainerpod.yaml.in
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  $(if [ -n "$POD_ANNOTATION" ]; then echo "
+  annotations:
+    $POD_ANNOTATION
+  "; fi)
+  labels:
+    app: ${NAME}
+spec:
+  containers:
+  $(contnum=0; for reqlim in ${CPUREQLIM}; do echo "
+  - name: ${NAME}c${contnum}
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -c
+      - ${WORK}echo ${NAME}c${contnum} \$(sleep inf)
+    $(if [ -n "${reqlim}" ]; then echo "
+    resources:
+      $(if [ -n "${reqlim/-*}" ]; then echo "
+      requests:
+        cpu: ${reqlim/-*/}
+      "; fi)
+      $(if [ -n "${reqlim/*-/}" ]; then echo "
+      limits:
+        cpu: ${reqlim/*-}
+      "; fi)
+    "; fi)
+  "; contnum=$((contnum + 1)); done )
+  $(if [ -n "$INITCPUREQLIM" ]; then echo "
+  initContainers:
+  $(contnum=0; for initreqlim in ${INITCPUREQLIM}; do echo "
+  - name: ${NAME}c${contnum}-init
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -c
+      - ${WORK}echo ${NAME}c${contnum}-init \$(sleep 1)
+    $(if [ -n "${initreqlim}" ]; then echo "
+    resources:
+      $(if [ -n "${initreqlim/-*}" ]; then echo "
+      requests:
+        cpu: ${initreqlim/-*/}
+      "; fi)
+      $(if [ -n "${initreqlim/*-/}" ]; then echo "
+      limits:
+        cpu: ${initreqlim/*-}
+      "; fi)
+    "; fi)
+  "; contnum=$((contnum + 1)); done )
+  "; fi)
+  terminationGracePeriodSeconds: 1

--- a/test/e2e/policies.test-suite/balloons/n4c32/topology.var.json
+++ b/test/e2e/policies.test-suite/balloons/n4c32/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "dies": 2, "packages": 2}
+]

--- a/test/e2e/policies.test-suite/balloons/verify.source.sh
+++ b/test/e2e/policies.test-suite/balloons/verify.source.sh
@@ -11,8 +11,7 @@ verify-metrics-has-line() {
 
 verify-metrics-has-no-line() {
     local unexpected_line="$1"
-    vm-command "echo 'checking absense of metrics line: $unexpected_line' >&2; curl --silent $verify_metrics_url | grep -E '$unexpected_line'" && {
+    vm-run-until --timeout 10 "echo 'checking absense of metrics line: $unexpected_line' >&2; ! curl --silent $verify_metrics_url | grep -Eq '$unexpected_line'" || {
         command-error "unexpected line '$1' found from the output"
     }
-    return 0
 }


### PR DESCRIPTION
This PR extends E2E to test idle CPU sharing (`ShareIdleCpusInSame` field)
and topology aware creation/inflation/deflation that is implemented in https://github.com/intel/cri-resource-manager/pull/931.