### PR TITLE
topology-aware: don't restore config on startup

### DIFF
--- a/pkg/cri/client/v1/client.go
+++ b/pkg/cri/client/v1/client.go
@@ -273,24 +273,45 @@ func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...gr
 	return c.rsc.Status(ctx, in)
 }
 
+func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	return c.rsc.CheckpointContainer(ctx, in)
+}
+
+func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	eventsClient, err := c.rsc.GetContainerEvents(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return eventsClient, err
+}
+
 //
 // These are being introduced but they are not defined yet for the
 // CRI API version we are compiling against.
 /*
-func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1 RuntimeService")
-}
-
-func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetContainerEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1 RuntimeService")
-}
-
 func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, opts ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1 RuntimeService")
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	return c.rsc.ListMetricDescriptors(ctx, in)
 }
 
 func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1 RuntimeService")
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	return c.rsc.ListPodSandboxMetrics(ctx, in)
 }
 */
 

--- a/pkg/cri/client/v1alpha2/client.go
+++ b/pkg/cri/client/v1alpha2/client.go
@@ -706,24 +706,35 @@ func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...gr
 	return v1resp, nil
 }
 
+func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
+	c.Errorf("internal error: GetContainerEvents() called for v1alpha2 client")
+	return &criv1.CheckpointContainerResponse{},
+		fmt.Errorf("internal error: CheckpointContainer() called for v1alpha2 client")
+}
+
+func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
+	c.Errorf("internal error: GetContainerEvents() called for v1alpha2 client")
+	return nil, fmt.Errorf("internal error: GetContainerEvents() called for v1alpha2 client")
+}
+
 //
 // These are being introduced but they are not defined yet for the
 // CRI API version we are compiling against.
 /*
-func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
-}
-
-func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetContainerEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
-}
-
 func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, opts ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	return c.rsc.ListMetricDescriptors(ctx, in)
 }
 
 func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
-	return nil, fmt.Errorf("unimplemented by CRI v1alpha2 RuntimeService")
+	if err := c.checkRuntimeService(); err != nil {
+		return nil, err
+	}
+
+	return c.rsc.ListPodSandboxMetrics(ctx, in)
 }
 */
 

--- a/pkg/cri/relay/runtime-service.go
+++ b/pkg/cri/relay/runtime-service.go
@@ -17,6 +17,8 @@ package relay
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/intel/cri-resource-manager/pkg/dump"
@@ -179,4 +181,13 @@ func (r *relay) Status(ctx context.Context,
 	req *criv1.StatusRequest) (*criv1.StatusResponse, error) {
 	r.dump("Status", req)
 	return r.client.Status(ctx, req)
+}
+
+func (r *relay) CheckpointContainer(ctx context.Context, req *criv1.CheckpointContainerRequest) (*criv1.CheckpointContainerResponse, error) {
+	r.dump("CheckpointContainer", req)
+	return r.client.CheckpointContainer(ctx, req)
+}
+
+func (r *relay) GetContainerEvents(req *criv1.GetEventsRequest, src criv1.RuntimeService_GetContainerEventsServer) error {
+	return status.Errorf(codes.Unimplemented, "method GetContainerEvents not implemented")
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
@@ -94,23 +94,6 @@ func (p *policy) reinstateGrants(grants map[string]Grant) error {
 	return nil
 }
 
-func (p *policy) saveConfig() error {
-	cached := cachedOptions{Options: *opt}
-	p.cache.SetPolicyEntry(keyConfig, cache.Cachable(&cached))
-	p.cache.Save()
-	return nil
-}
-
-func (p *policy) restoreConfig() bool {
-	cached := cachedOptions{}
-	if !p.cache.GetPolicyEntry(keyConfig, &cached) {
-		return false
-	}
-
-	*opt = cached.Options
-	return true
-}
-
 type cachedGrant struct {
 	Exclusive   string
 	Part        int
@@ -245,22 +228,5 @@ func (a *allocations) Set(value interface{}) {
 func (a *allocations) Dump(logfn func(format string, args ...interface{}), prefix string) {
 	for _, cg := range a.grants {
 		logfn(prefix+"%s", cg)
-	}
-}
-
-type cachedOptions struct {
-	Options options
-}
-
-func (o *cachedOptions) Get() interface{} {
-	return o
-}
-
-func (o *cachedOptions) Set(value interface{}) {
-	switch value.(type) {
-	case options:
-		o.Options = value.(cachedOptions).Options
-	case *options:
-		o.Options = value.(*cachedOptions).Options
 	}
 }

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -476,8 +476,6 @@ func (p *policy) configNotify(event config.Event, source config.Source) error {
 		p.root.Dump("<post-config>")
 	}
 
-	p.saveConfig()
-
 	return nil
 }
 
@@ -554,11 +552,6 @@ func (p *policy) checkConstraints() error {
 }
 
 func (p *policy) restoreCache() error {
-	if !p.restoreConfig() {
-		log.Warn("no saved configuration found in cache...")
-		p.saveConfig()
-	}
-
 	allocations := p.newAllocations()
 	if p.cache.GetPolicyEntry(keyAllocations, &allocations) {
 		if err := p.restoreAllocations(&allocations); err != nil {

--- a/pkg/cri/server/services.go
+++ b/pkg/cri/server/services.go
@@ -19,6 +19,8 @@ import (
 
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -58,6 +60,7 @@ const (
 	listPodSandboxStats      = "ListPodSandboxStats"
 	updateRuntimeConfig      = "UpdateRuntimeConfig"
 	status                   = "Status"
+	checkpointContainer      = "CheckpointContainer"
 )
 
 func fqmn(service, method string) string {
@@ -480,4 +483,21 @@ func (s *server) Status(ctx context.Context,
 	}
 
 	return rsp.(*criv1.StatusResponse), err
+}
+
+func (s *server) CheckpointContainer(ctx context.Context, req *criv1.CheckpointContainerRequest) (*criv1.CheckpointContainerResponse, error) {
+	rsp, err := s.interceptRequest(ctx, runtimeService, checkpointContainer, req,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return (*s.runtime).CheckpointContainer(ctx, req.(*criv1.CheckpointContainerRequest))
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rsp.(*criv1.CheckpointContainerResponse), err
+}
+
+func (s *server) GetContainerEvents(req *criv1.GetEventsRequest, src criv1.RuntimeService_GetContainerEventsServer) error {
+	return grpcstatus.Errorf(grpccodes.Unimplemented, "GetContainerEvents not implemented")
 }

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -268,6 +268,15 @@ func (s *fakeCriServer) Status(ctx context.Context, req *criv1.StatusRequest) (*
 	return response.(*criv1.StatusResponse), err
 }
 
+func (s *fakeCriServer) CheckpointContainer(ctx context.Context, req *criv1.CheckpointContainerRequest) (*criv1.CheckpointContainerResponse, error) {
+	response, err := s.callHandler(ctx, req, nil)
+	return response.(*criv1.CheckpointContainerResponse), err
+}
+
+func (s *fakeCriServer) GetContainerEvents(req *criv1.GetEventsRequest, srv criv1.RuntimeService_GetContainerEventsServer) error {
+	return nil
+}
+
 // Implementation of criv1.ImageServiceServer
 
 func (s *fakeCriServer) ListImages(ctx context.Context, req *criv1.ListImagesRequest) (*criv1.ListImagesResponse, error) {


### PR DESCRIPTION
**Notes:** This PR depends/is stacked on #934. Please review / merge that one first.


Do not save and especially don't restore policy configuration as policy-specific data. It silently overwrites the effective configuration during policy startup. This cases really tricky to debug failures in some tests that use forced configuration to alter behavior but are not run first after startup.
