### PR TITLE
resource-manager: remove 'null' pseudo-policy.

### DIFF
--- a/pkg/cri/resource-manager/events.go
+++ b/pkg/cri/resource-manager/events.go
@@ -45,10 +45,6 @@ func (m *resmgr) setupEventProcessing() error {
 
 // startEventProcessing starts event and metrics processing.
 func (m *resmgr) startEventProcessing() error {
-	if m.policy.Bypassed() {
-		return nil
-	}
-
 	if err := m.metrics.Start(); err != nil {
 		return resmgrError("failed to start metrics (pre)processor: %v", err)
 	}

--- a/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/none/none-policy.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// PolicyName is the name used to activate this policy implementation.
-	PolicyName = "none"
+	PolicyName = policy.NonePolicy
 	// PolicyDescription is a short description of this policy.
 	PolicyDescription = "A no-op policy, doing pretty much nothing."
 )

--- a/pkg/cri/resource-manager/policy/flags.go
+++ b/pkg/cri/resource-manager/policy/flags.go
@@ -32,10 +32,10 @@ import (
 )
 
 const (
-	// NullPolicy is the reserved name for disabling policy altogether.
-	NullPolicy = "null"
-	// NullPolicyDescription is the description for the null policy.
-	NullPolicyDescription = "A policy to bypass local policy processing."
+	// NonePolicy is the name of our no-op policy.
+	NonePolicy = "none"
+	// DefaultPolicy is the name of our default policy.
+	DefaultPolicy = NonePolicy
 	// ConfigPath is the configuration module path for the generic policy layer.
 	ConfigPath = "policy"
 )
@@ -224,10 +224,6 @@ func AvailablePolicies() []*AvailablePolicy {
 			Description: be.description,
 		})
 	}
-	policies = append(policies, &AvailablePolicy{
-		Name:        NullPolicy,
-		Description: NullPolicyDescription,
-	})
 	sort.Slice(policies, func(i, j int) bool { return policies[i].Name < policies[j].Name })
 
 	return policies
@@ -236,7 +232,7 @@ func AvailablePolicies() []*AvailablePolicy {
 // defaultOptions returns a new options instance, all initialized to defaults.
 func defaultOptions() interface{} {
 	return &options{
-		Policy:    NullPolicy,
+		Policy:    DefaultPolicy,
 		Available: ConstraintSet{},
 		Reserved:  ConstraintSet{},
 	}

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -104,7 +104,6 @@ const (
 //
 // A backends operates in a set of policy domains. Currently each policy domain
 // corresponds to some particular hardware resource (CPU, memory, cache, etc).
-//
 type Backend interface {
 	// Name gets the well-known name of this policy.
 	Name() string
@@ -159,8 +158,6 @@ type Policy interface {
 	ExportResourceData(cache.Container)
 	// Introspect provides data for external introspection.
 	Introspect() *introspect.State
-	// Bypassed checks if local policy processing is effectively disabled/bypassed.
-	Bypassed() bool
 	// DescribeMetrics generates policy-specific prometheus metrics data descriptors.
 	DescribeMetrics() []*prometheus.Desc
 	// PollMetrics provides policy metrics for monitoring.
@@ -215,59 +212,46 @@ func NewPolicy(cache cache.Cache, o *Options) (Policy, error) {
 		options: *o,
 	}
 
-	if opt.Policy == NullPolicy {
-		log.Info("activating '%s' policy (no active backend)", opt.Policy)
-	} else {
-		active, ok := backends[opt.Policy]
-		if !ok {
-			return nil, policyError("unknown policy '%s' requested", opt.Policy)
-		}
-
-		log.Info("activating '%s' policy...", active.name)
-
-		if len(opt.Available) != 0 {
-			log.Info("  with available resources:")
-			for n, r := range opt.Available {
-				log.Info("    - %s=%s", n, ConstraintToString(r))
-			}
-		}
-		if len(opt.Reserved) != 0 {
-			log.Info("  with reserved resources:")
-			for n, r := range opt.Reserved {
-				log.Info("    - %s=%s", n, ConstraintToString(r))
-			}
-		}
-
-		if log.DebugEnabled() {
-			logger.Get(opt.Policy).EnableDebug(true)
-		}
-
-		backendOpts.Cache = p.cache
-		backendOpts.System = p.system
-		backendOpts.Available = opt.Available
-		backendOpts.Reserved = opt.Reserved
-		backendOpts.AgentCli = o.AgentCli
-		backendOpts.SendEvent = o.SendEvent
-
-		p.active = active.create(backendOpts)
+	active, ok := backends[opt.Policy]
+	if !ok {
+		return nil, policyError("unknown policy '%s' requested", opt.Policy)
 	}
+
+	log.Info("activating '%s' policy...", active.name)
+
+	if len(opt.Available) != 0 {
+		log.Info("  with available resources:")
+		for n, r := range opt.Available {
+			log.Info("    - %s=%s", n, ConstraintToString(r))
+		}
+	}
+	if len(opt.Reserved) != 0 {
+		log.Info("  with reserved resources:")
+		for n, r := range opt.Reserved {
+			log.Info("    - %s=%s", n, ConstraintToString(r))
+		}
+	}
+
+	if log.DebugEnabled() {
+		logger.Get(opt.Policy).EnableDebug(true)
+	}
+
+	backendOpts.Cache = p.cache
+	backendOpts.System = p.system
+	backendOpts.Available = opt.Available
+	backendOpts.Reserved = opt.Reserved
+	backendOpts.AgentCli = o.AgentCli
+	backendOpts.SendEvent = o.SendEvent
+
+	p.active = active.create(backendOpts)
 
 	return p, nil
 }
 
 // Start starts up policy, preparing it for resving requests.
 func (p *policy) Start(add []cache.Container, del []cache.Container) error {
-	if p.Bypassed() {
-		log.Info("policy '%s' active, nothing to start...", opt.Policy)
-		return nil
-	}
-
 	log.Info("starting policy '%s'...", p.active.Name())
 	return p.active.Start(add, del)
-}
-
-func (p *policy) Bypassed() bool {
-	return p.active == nil
 }
 
 // Sync synchronizes the active policy state.
@@ -297,10 +281,7 @@ func (p *policy) Rebalance() (bool, error) {
 
 // HandleEvent passes on the given event to the active policy.
 func (p *policy) HandleEvent(e *events.Policy) (bool, error) {
-	if !p.Bypassed() {
-		return p.active.HandleEvent(e)
-	}
-	return false, nil
+	return p.active.HandleEvent(e)
 }
 
 // ExportResourceData exports/updates resource data for the container.
@@ -409,35 +390,24 @@ func (p *policy) Introspect() *introspect.State {
 	p.inspsys.Policy = opt.Policy
 
 	state.System = p.inspsys
-	if !p.Bypassed() {
-		p.active.Introspect(state)
-	}
+	p.active.Introspect(state)
 
 	return state
 }
 
 // PollMetrics provides policy metrics for monitoring.
 func (p *policy) PollMetrics() Metrics {
-	if !p.Bypassed() {
-		return p.active.PollMetrics()
-	}
-	return nil
+	return p.active.PollMetrics()
 }
 
 // DescribeMetrics generates policy-specific prometheus metrics data descriptors.
 func (p *policy) DescribeMetrics() []*prometheus.Desc {
-	if !p.Bypassed() {
-		return p.active.DescribeMetrics()
-	}
-	return nil
+	return p.active.DescribeMetrics()
 }
 
 // CollectMetrics generates prometheus metrics from cached/polled policy-specific metrics data.
 func (p *policy) CollectMetrics(m Metrics) ([]prometheus.Metric, error) {
-	if !p.Bypassed() {
-		return p.active.CollectMetrics(m)
-	}
-	return nil, nil
+	return p.active.CollectMetrics(m)
 }
 
 // Register registers a policy backend.

--- a/sample-configs/cri-full-message-dump.cfg
+++ b/sample-configs/cri-full-message-dump.cfg
@@ -1,6 +1,6 @@
-# run without activating even the agnostic policy module
+# run with no-op policy
 policy:
-  Active: null
+  Active: none
 # enable full dumps of all messages
 dump:
   Config: full:.*

--- a/sample-configs/cri-kubelet-message-dump.cfg
+++ b/sample-configs/cri-kubelet-message-dump.cfg
@@ -1,6 +1,0 @@
-# run without activating even the agnostic policy module
-policy:
-  Active: null
-# enable dumping of interesting messages
-dump:
-  Config: off:.*,((Create)|(Run)|(Start)|(Update)|(Stop)|(Remove)).*


### PR DESCRIPTION
Remove the 'null' pseudo-policy and the related bypass code-paths which leave part of the normal CRI relaying and intercepting infra uninitialized. Use the no-op `none` policy as the default. This setup should be a much more reasonable default. It should also allow us to change the handling of configuration updates to enable/handle the switch from the default `none` policy to any other one.