### PR TITLE
balloons: fix handling of undefined (unlimited) MaxCPUs

### DIFF
--- a/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
@@ -35,6 +35,7 @@ data:
           Namespaces:
             - ${BTYPE1_NAMESPACE0:-btype1ns0}
           MinCPUs: ${BTYPE1_MINCPUS:-1}
+          MaxCPUs: ${BTYPE1_MAXCPUS:-1}
           AllocatorPriority: ${BTYPE1_ALLOCATIONPRIORITY:-1}
           CPUClass: ${BTYPE1_CPUCLASS:-classB}
           PreferNewBalloons: ${BTYPE1_PREFERNEWBALLOONS:-false}

--- a/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
@@ -27,7 +27,7 @@ launch cri-resmgr-agent
 kubectl create namespace $testns
 kubectl create namespace btype1ns0
 
-AVAILABLE_CPU="cpuset:0,4-15" BTYPE2_NAMESPACE0='"*"' apply-configmap
+AVAILABLE_CPU="cpuset:0,4-15" BTYPE2_NAMESPACE0='"*"' BTYPE1_MAXCPUS='0' apply-configmap
 sleep 3
 
 # pod0 in btype0, annotation


### PR DESCRIPTION
- When MaxCpus=NoLimit=0, maximum available CPUs of a balloon depends on the number of free CPUs in the system.
- Validate min/max values in balloons policy configurations.