### PR TITLE
balloons: add debug logging

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
@@ -166,7 +166,7 @@ func CreateBalloonsPolicy(policyOptions *policy.BackendOptions) policy.Backend {
 	if err := p.setConfig(balloonsOptions); err != nil {
 		log.Fatal("failed to create %s policy: %v", PolicyName, err)
 	}
-
+	log.Debug("first effective configuration:\n%s\n", utils.DumpJSON(p.bpoptions))
 	pkgcfg.GetModule(PolicyPath).AddNotify(p.configNotify)
 
 	return p
@@ -203,7 +203,10 @@ func (p *balloons) Sync(add []cache.Container, del []cache.Container) error {
 
 // AllocateResources is a resource allocation request for this policy.
 func (p *balloons) AllocateResources(c cache.Container) error {
-	log.Debug("allocating resources for container %s...", c.PrettyName())
+	log.Debug("allocating resources for container %s (request %d mCPU, limit %d mCPU)...",
+		c.PrettyName(),
+		p.containerRequestedMilliCpus(c.GetCacheID()),
+		p.containerLimitedMilliCpus(c.GetCacheID()))
 	bln, err := p.allocateBalloon(c)
 	if err != nil {
 		return balloonsError("balloon allocation for container %s failed: %w", c.PrettyName(), err)
@@ -393,6 +396,18 @@ func (p *balloons) containerRequestedMilliCpus(contID string) int {
 		return 0
 	}
 	reqCpu, ok := cont.GetResourceRequirements().Requests[corev1.ResourceCPU]
+	if !ok {
+		return 0
+	}
+	return int(reqCpu.MilliValue())
+}
+
+func (p *balloons) containerLimitedMilliCpus(contID string) int {
+	cont, ok := p.cch.LookupContainer(contID)
+	if !ok {
+		return 0
+	}
+	reqCpu, ok := cont.GetResourceRequirements().Limits[corev1.ResourceCPU]
 	if !ok {
 		return 0
 	}


### PR DESCRIPTION
- Print first effective configuration. Allows debugging which configuration is used on policy start-up that affects reassignment of running workloads.
- Print CPU requests and limits of containers whose resources are to be allocated.

This PR is part of the series that replaces PR https://github.com/intel/cri-resource-manager/pull/931.