### PR TITLE
balloons: topology aware balloon creation/inflation/deflation

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
@@ -56,12 +56,14 @@ const (
 
 // balloons contains configuration and runtime attributes of the balloons policy
 type balloons struct {
-	options   *policyapi.BackendOptions // configuration common to all policies
-	bpoptions BalloonsOptions           // balloons-specific configuration
-	cch       cache.Cache               // cri-resmgr cache
-	allowed   cpuset.CPUSet             // bounding set of CPUs we're allowed to use
-	reserved  cpuset.CPUSet             // system-/kube-reserved CPUs
-	freeCpus  cpuset.CPUSet             // CPUs to be included in growing or new ballons
+	options          *policyapi.BackendOptions // configuration common to all policies
+	bpoptions        BalloonsOptions           // balloons-specific configuration
+	cch              cache.Cache               // cri-resmgr cache
+	allowed          cpuset.CPUSet             // bounding set of CPUs we're allowed to use
+	reserved         cpuset.CPUSet             // system-/kube-reserved CPUs
+	freeCpus         cpuset.CPUSet             // CPUs to be included in growing or new ballons
+	cpuTree          *cpuTreeNode              // system CPU topology
+	cpuTreeAllocator *cpuTreeAllocator         // CPU allocator from system CPU topology
 
 	reservedBalloonDef *BalloonDef // built-in definition of the reserved balloon
 	defaultBalloonDef  *BalloonDef // built-in definition of the default balloon
@@ -133,12 +135,17 @@ func (bln Balloon) MaxAvailMilliCpus(freeCpus cpuset.CPUSet) int {
 
 // CreateBalloonsPolicy creates a new policy instance.
 func CreateBalloonsPolicy(policyOptions *policy.BackendOptions) policy.Backend {
+	var err error
 	p := &balloons{
 		options:      policyOptions,
 		cch:          policyOptions.Cache,
 		cpuAllocator: cpuallocator.NewCPUAllocator(policyOptions.System),
 	}
 	log.Info("creating %s policy...", PolicyName)
+	if p.cpuTree, err = NewCpuTreeFromSystem(); err != nil {
+		log.Errorf("creating CPU topology tree failed: %s", err)
+	}
+	log.Debug("CPU topology: %s", p.cpuTree)
 	// Handle common policy options: AvailableResources and ReservedResources.
 	// p.allowed: CPUs available for the policy
 	if allowed, ok := policyOptions.Available[policyapi.DomainCPU]; ok {
@@ -540,10 +547,15 @@ func (p *balloons) newBalloon(blnDef *BalloonDef, confCpus bool) (*Balloon, erro
 		// So does the default balloon unless its CPU counts are tweaked.
 		cpus = p.reserved
 	} else {
-		cpus, err = p.cpuAllocator.AllocateCpus(&p.freeCpus, blnDef.MinCpus, blnDef.AllocatorPriority)
+		addFromCpus, _, err := p.cpuTreeAllocator.ResizeCpus(cpuset.NewCPUSet(), p.freeCpus, blnDef.MinCpus)
+		if err != nil {
+			return nil, balloonsError("failed to choose a cpuset for allocating first %d CPUs from %#s", blnDef.MinCpus, p.freeCpus)
+		}
+		cpus, err = p.cpuAllocator.AllocateCpus(&addFromCpus, blnDef.MinCpus, blnDef.AllocatorPriority)
 		if err != nil {
 			return nil, balloonsError("could not allocate %d MinCpus for balloon %s[%d]: %w", blnDef.MinCpus, blnDef.Name, freeInstance, err)
 		}
+		p.freeCpus = p.freeCpus.Difference(cpus)
 	}
 	bln := &Balloon{
 		Def:      blnDef,
@@ -981,6 +993,9 @@ func (p *balloons) setConfig(bpoptions *BalloonsOptions) error {
 	p.balloons = []*Balloon{}
 	p.freeCpus = p.allowed.Clone()
 	p.freeCpus = p.freeCpus.Difference(p.reserved)
+	p.cpuTreeAllocator = p.cpuTree.NewAllocator(cpuTreeAllocatorOptions{
+		topologyBalancing: bpoptions.AllocatorTopologyBalancing,
+	})
 	// Instantiate built-in reserved and default balloons.
 	reservedBalloon, err := p.newBalloon(p.reservedBalloonDef, false)
 	if err != nil {
@@ -1074,42 +1089,57 @@ func (p *balloons) resizeBalloon(bln *Balloon, newMilliCpus int) error {
 	if bln.Def.MinCpus > 0 && newCpuCount < bln.Def.MinCpus {
 		newCpuCount = bln.Def.MinCpus
 	}
-	log.Debugf("resize %s to capacity %d: CPUs from %d to %d. freecpus: %#s", bln, newMilliCpus, oldCpuCount, newCpuCount, p.freeCpus)
+	log.Debugf("resize %s to fit %d mCPU", bln, newMilliCpus)
+	log.Debugf("- change full CPUs from %d to %d", oldCpuCount, newCpuCount)
+	log.Debugf("- freecpus: %#s", p.freeCpus)
 	if oldCpuCount == newCpuCount {
 		return nil
 	}
+	cpuCountDelta := newCpuCount - oldCpuCount
 	p.forgetCpuClass(bln)
 	defer p.useCpuClass(bln)
-	if newCpuCount > oldCpuCount {
-		oldCpus := bln.Cpus.Clone()
-		keptCpus, err := p.cpuAllocator.ReleaseCpus(&oldCpus, oldCpuCount, bln.Def.AllocatorPriority)
-		if err != nil || keptCpus.Size() != 0 {
-			return balloonsError("resize/inflate: releasing %d CPUs from %s failed: %w (kept: %s)", oldCpuCount, bln, err, keptCpus)
-		}
-		p.freeCpus = p.freeCpus.Union(bln.Cpus)
-		newCpus, err := p.cpuAllocator.AllocateCpus(&p.freeCpus, newCpuCount, bln.Def.AllocatorPriority)
+	if cpuCountDelta > 0 {
+		// Inflate the balloon.
+		addFromCpus, _, err := p.cpuTreeAllocator.ResizeCpus(bln.Cpus, p.freeCpus, cpuCountDelta)
 		if err != nil {
-			return balloonsError("resize/inflate: allocating %d CPUs for %s failed: %w", newCpuCount, bln, err)
+			return balloonsError("resize/inflate: failed to choose a cpuset for allocating additional %d CPUs: %w", cpuCountDelta, err)
 		}
-		bln.Cpus = newCpus
+		log.Debugf("- allocate CPUs %d from %#s", cpuCountDelta, addFromCpus)
+		newCpus, err := p.cpuAllocator.AllocateCpus(&addFromCpus, newCpuCount-oldCpuCount, bln.Def.AllocatorPriority)
+		if err != nil {
+			return balloonsError("resize/inflate: allocating %d CPUs for %s failed: %w", cpuCountDelta, bln, err)
+		}
+		p.freeCpus = p.freeCpus.Difference(newCpus)
+		bln.Cpus = bln.Cpus.Union(newCpus)
 	} else {
-		keptCpus, err := p.cpuAllocator.ReleaseCpus(&bln.Cpus, oldCpuCount-newCpuCount, bln.Def.AllocatorPriority)
-		if err != nil || keptCpus.Size() != newCpuCount {
-			return balloonsError("resize/deflate: releasing %d CPUs from %s failed: %w (kept: %s)", oldCpuCount-newCpuCount, bln, err, keptCpus)
+		// Deflate the balloon.
+		_, removeFromCpus, err := p.cpuTreeAllocator.ResizeCpus(bln.Cpus, p.freeCpus, cpuCountDelta)
+		if err != nil {
+			return balloonsError("resize/deflate: failed to choose a cpuset for releasing %d CPUs: %w", -cpuCountDelta, err)
 		}
-		log.Debugf("freeCpus: %s, bln.Cpus: %s, keptCpus: %s", p.freeCpus, bln.Cpus, keptCpus)
-		p.freeCpus = p.freeCpus.Union(bln.Cpus)
-		bln.Cpus = keptCpus
-		log.Debugf("new freeCpus: %s, new bln.Cpus: %s", p.freeCpus, bln.Cpus)
-	}
-	log.Debugf("resize successful: %s, freecpus: %#s", bln, p.freeCpus)
-	bln.Mems = p.closestMems(bln.Cpus)
-	for _, cID := range bln.ContainerIDs() {
-		if c, ok := p.cch.LookupContainer(cID); ok {
-			p.pinCpuMem(c, bln.Cpus, bln.Mems)
+		log.Debugf("- releasing %d CPUs from cpuset %#s", -cpuCountDelta, removeFromCpus)
+		_, err = p.cpuAllocator.ReleaseCpus(&removeFromCpus, -cpuCountDelta, bln.Def.AllocatorPriority)
+		if err != nil {
+			return balloonsError("resize/deflate: releasing %d CPUs from %s failed: %w", -cpuCountDelta, bln, err)
 		}
+		log.Debugf("- old freeCpus: %#s, old bln.Cpus: %#s, releasing: %#s", p.freeCpus, bln.Cpus, removeFromCpus)
+		p.freeCpus = p.freeCpus.Union(removeFromCpus)
+		bln.Cpus = bln.Cpus.Difference(removeFromCpus)
 	}
+	log.Debugf("- resize successful: %s, freecpus: %#s", bln, p.freeCpus)
+	p.updatePinning(bln)
 	return nil
+}
+
+func (p *balloons) updatePinning(blns ...*Balloon) {
+	for _, bln := range blns {
+		bln.Mems = p.closestMems(bln.Cpus)
+		for _, cID := range bln.ContainerIDs() {
+			if c, ok := p.cch.LookupContainer(cID); ok {
+				p.pinCpuMem(c, bln.Cpus, bln.Mems)
+			}
+		}
+	}
 }
 
 // assignContainer adds a container to a balloon
@@ -1119,7 +1149,7 @@ func (p *balloons) assignContainer(c cache.Container, bln *Balloon) {
 	// if necessary
 	podID := c.GetPodID()
 	bln.PodIDs[podID] = append(bln.PodIDs[podID], c.GetCacheID())
-	p.pinCpuMem(c, bln.Cpus, bln.Mems)
+	p.updatePinning(bln)
 }
 
 // dismissContainer removes a container from a balloon

--- a/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
@@ -37,6 +37,12 @@ type balloonsOptionsWrapped struct {
 	// ReservedPoolNamespaces is a list of namespace globs that
 	// will be allocated to reserved CPUs.
 	ReservedPoolNamespaces []string `json:"ReservedPoolNamespaces,omitempty"`
+	// If AllocatorTopologyBalancing is true, balloons are
+	// allocated and resized so that all topology elements
+	// (packages, dies, numa nodes, cores) have roughly same
+	// amount of allocations. The default is false: balloons are
+	// packed tightly to optimize power efficiency.
+	AllocatorTopologyBalancing bool
 	// BallonDefs contains balloon type definitions.
 	BalloonDefs []*BalloonDef `json:"BalloonTypes,omitempty"`
 }


### PR DESCRIPTION
- Add AllocatorTopologyBalancing configuration option.
- Use cputree functions to restrict the number of CPUs from which the
  CPU allocator selects which CPUs to allocate or release.

This PR depends on and includes commits from PR #941. 

This PR is part of the series that replaces PR #931. 