### PR TITLE
balloons: add topology aware idle CPU sharing to balloons

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
@@ -97,6 +97,12 @@ type BalloonDef struct {
 	// prefer using filling free capacity and possibly inflating
 	// existing balloons before creating new ones.
 	PreferNewBalloons bool
+	// ShareIdleCpusInSame <topology-level>: if there are idle
+	// CPUs, that is CPUs not in any balloon, in the same
+	// <topology-level> as any CPU in the balloon, then allow
+	// workloads to run on those (shared) CPUs in addition to the
+	// (dedicated) CPUs of the balloon.
+	ShareIdleCpusInSame CPUTopologyLevel `json:"ShareIdleCPUsInSame,omitempty"`
 }
 
 var defaultPinCPU bool = true


### PR DESCRIPTION
- Add ShareIdleCpusInSame: <topo-level> option to balloon types.
- Fix FillNewBalloon* fill methods to verify that new balloon can be
  inflated to fit new container.

This PR depends on and includes commits from PR #945 and PR #942.

This PR is part of the series that replaces PR #931.