### PR TITLE
Makefile: specify go version in a make variable

### DIFF
--- a/dockerfiles/cross-build/Dockerfile.centos-7
+++ b/dockerfiles/cross-build/Dockerfile.centos-7
@@ -1,19 +1,20 @@
 # pull in base + a minimal set of useful packages
-FROM centos:8 as centos-8-build
+FROM centos:7 as centos-7-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
+ARG GIT_VERSION=2.27.0
+ARG GIT_URLDIR=https://github.com/git/git/archive
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-
-RUN dnf install -y rpm-build \
+RUN yum install -y --nogpgcheck rpm-build \
     kernel-devel clang gcc \
-    git-core make wget
+    curl-devel zlib-devel openssl-devel expat-devel \
+    make wget
 
+# fetch and build go from sources
 RUN arch="$(rpm --eval %{_arch})"; \
     case "${arch}" in \
         x86_64) goarch=linux-amd64;; \
@@ -23,12 +24,19 @@ RUN arch="$(rpm --eval %{_arch})"; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+# fetch and build a recent git from sources, anything below 1.9.5 is known to not work for us
+RUN mkdir /git && cd /git && wget $GIT_URLDIR/v$GIT_VERSION.tar.gz && \
+    tar -xvzf v$GIT_VERSION.tar.gz && cd git-$GIT_VERSION && \
+    make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr all && \
+    yum remove -y git && \
+    make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr install
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.centos-8
+++ b/dockerfiles/cross-build/Dockerfile.centos-8
@@ -1,20 +1,19 @@
 # pull in base + a minimal set of useful packages
-FROM centos:7 as centos-7-build
+FROM centos:8 as centos-8-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
-ARG GIT_VERSION=2.27.0
-ARG GIT_URLDIR=https://github.com/git/git/archive
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN yum install -y --nogpgcheck rpm-build \
-    kernel-devel clang gcc \
-    curl-devel zlib-devel openssl-devel expat-devel \
-    make wget
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-# fetch and build go from sources
+RUN dnf install -y rpm-build \
+    kernel-devel clang gcc \
+    git-core make wget
+
 RUN arch="$(rpm --eval %{_arch})"; \
     case "${arch}" in \
         x86_64) goarch=linux-amd64;; \
@@ -24,19 +23,12 @@ RUN arch="$(rpm --eval %{_arch})"; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
-
-# fetch and build a recent git from sources, anything below 1.9.5 is known to not work for us
-RUN mkdir /git && cd /git && wget $GIT_URLDIR/v$GIT_VERSION.tar.gz && \
-    tar -xvzf v$GIT_VERSION.tar.gz && cd git-$GIT_VERSION && \
-    make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr all && \
-    yum remove -y git && \
-    make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr install
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.debian-10
+++ b/dockerfiles/cross-build/Dockerfile.debian-10
@@ -1,27 +1,29 @@
 # pull in base + a minimal set of useful packages
-FROM opensuse/leap:15.4 as suse-15.4-build
+FROM debian:buster as debian-10-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
-ARG CREATE_USER="build"
+ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-RUN zypper install -y rpm-build \
-    kernel-devel clang gcc \
-    git make \
-    wget
+# pull in stuff for cgo
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential fakeroot devscripts \
+        bash git make sed debhelper wget ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(rpm --eval %{_arch})"; \
-    case "${arch}" in \
-        x86_64) goarch=linux-amd64;; \
+RUN arch="$(dpkg --print-architecture)"; \
+    case "${arch##*-}" in \
+        amd64) goarch=linux-amd64;; \
         i386) goarch=linux-386;; \
         armhf) goarch=linux-armv6l;; \
         ppc64el) goarch=linux-ppc64le;; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/dockerfiles/cross-build/Dockerfile.debian-sid
+++ b/dockerfiles/cross-build/Dockerfile.debian-sid
@@ -1,7 +1,7 @@
 # pull in base + a minimal set of useful packages
-FROM ubuntu:18.04 as ubuntu-18.04-build
+FROM debian:sid as debian-sid-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -23,7 +23,7 @@ RUN arch="$(dpkg --print-architecture)"; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -1,30 +1,26 @@
 # pull in base + a minimal set of useful packages
-FROM ubuntu:20.04 as ubuntu-20.04-build
+FROM fedora:latest as fedora-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
-ARG CREATE_USER="test"
+ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
-ENV DEBIAN_FRONTEND noninteractive
 
-# pull in stuff for building
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        tzdata build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y rpm-build systemd-rpm-macros \
+    kernel-devel gcc clang glibc-static \
+    git-core make wget
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
+RUN arch="$(rpm --eval %{_arch})"; \
+    case "${arch}" in \
+        x86_64) goarch=linux-amd64;; \
         i386) goarch=linux-386;; \
         armhf) goarch=linux-armv6l;; \
         ppc64el) goarch=linux-ppc64le;; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/dockerfiles/cross-build/Dockerfile.suse-15.4
+++ b/dockerfiles/cross-build/Dockerfile.suse-15.4
@@ -1,29 +1,27 @@
 # pull in base + a minimal set of useful packages
-FROM debian:buster as debian-10-build
+FROM opensuse/leap:15.4 as suse-15.4-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
-ARG CREATE_USER="test"
+ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-# pull in stuff for cgo
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+RUN zypper install -y rpm-build \
+    kernel-devel clang gcc \
+    git make \
+    wget
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
+RUN arch="$(rpm --eval %{_arch})"; \
+    case "${arch}" in \
+        x86_64) goarch=linux-amd64;; \
         i386) goarch=linux-386;; \
         armhf) goarch=linux-armv6l;; \
         ppc64el) goarch=linux-ppc64le;; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
@@ -1,7 +1,7 @@
 # pull in base + a minimal set of useful packages
-FROM debian:sid as debian-sid-build
+FROM ubuntu:18.04 as ubuntu-18.04-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -23,7 +23,7 @@ RUN arch="$(dpkg --print-architecture)"; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
@@ -1,7 +1,7 @@
 # pull in base + a minimal set of useful packages
-FROM ubuntu:22.04 as ubuntu-22.04-build
+FROM ubuntu:20.04 as ubuntu-20.04-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -24,7 +24,7 @@ RUN arch="$(dpkg --print-architecture)"; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-22.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-22.04
@@ -1,26 +1,30 @@
 # pull in base + a minimal set of useful packages
-FROM fedora:latest as fedora-build
+FROM ubuntu:22.04 as ubuntu-22.04-build
 
-ARG GOLANG_VERSION=x.yz
+ARG GO_VERSION=x.yz
 ARG GOLANG_URLDIR=https://dl.google.com/go
-ARG CREATE_USER="build"
+ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV DEBIAN_FRONTEND noninteractive
 
-RUN dnf install -y rpm-build systemd-rpm-macros \
-    kernel-devel gcc clang glibc-static \
-    git-core make wget
+# pull in stuff for building
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tzdata build-essential fakeroot devscripts \
+        bash git make sed debhelper wget ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(rpm --eval %{_arch})"; \
-    case "${arch}" in \
-        x86_64) goarch=linux-amd64;; \
+RUN arch="$(dpkg --print-architecture)"; \
+    case "${arch##*-}" in \
+        amd64) goarch=linux-amd64;; \
         i386) goarch=linux-386;; \
         armhf) goarch=linux-armv6l;; \
         ppc64el) goarch=linux-ppc64le;; \
         s390x) goarch=linux-s390x;; \
     esac; \
     \
-    wget $GOLANG_URLDIR/go$GOLANG_VERSION.$goarch.tar.gz -O go.tgz && \
+    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
     tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
     \
     export PATH="/usr/local/go/bin:$PATH" && \

--- a/scripts/build/docker-build-image
+++ b/scripts/build/docker-build-image
@@ -2,8 +2,9 @@
 
 VOLUMES=(-v /sys:/sys -v /home:/mnt/host/home)
 IMAGE=$1
+GO_VERSION=$2
 DOCKERFILE=dockerfiles/cross-build/Dockerfile.${IMAGE%-build}
-shift
+shift 2
 
 while [ -n "$1" ]; do
     case $1 in
@@ -36,6 +37,7 @@ echo "  - options   : " "${PASSTHROUGH[@]}"
 
 docker build . \
        -f "$DOCKERFILE" -t "$IMAGE" \
+       --build-arg GO_VERSION=$GO_VERSION \
        --build-arg "CREATE_USER=$USER" \
        --build-arg USER_OPTIONS="-u $(id -u)" \
        "${PASSTHROUGH[@]}" || exit 1


### PR DESCRIPTION
Automatic detection of Golang version from go.mod does not work properly as with that we don't get the latest patch release, but the dot-zero version of it. It worked correctly for webhook and agent builds as the golang:maj.min docker images (that we use for building those) always point to the latest patch release but the rpm and deb builds were flawed.

The upside of this change is that we get more reproducible builds as the golang version is fixed. The downside is that we need to manually keep updating the version.