### PR TITLE
Makefile: fix cross-tar target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -638,7 +638,7 @@ cross-bin.%: docker/cross-build/% dist
 	    $$distro-build /bin/bash -c '$(DOCKER_BIN_BUILD)' && \
 	rm -fr $$builddir
 
-cross-tar cross-tarball: dist docker/cross-build/centos-7
+cross-tar cross-tarball: dist docker/cross-build/fedora
 	$(Q)distro=tarball; \
 	builddir=$(BUILD_DIR)/docker/$$distro; \
 	outdir=$(PACKAGES_DIR)/$$distro; \
@@ -650,7 +650,7 @@ cross-tar cross-tarball: dist docker/cross-build/centos-7
 	    --env USER_NAME="$(USER_NAME)" --env USER_EMAIL=$(USER_EMAIL) \
 	    -v $$(pwd)/$$builddir:/build \
 	    -v $$(pwd)/$$outdir:/output \
-	    centos-7-build /bin/bash -c '$(DOCKER_TAR_BUILD)' && \
+	    fedora-build /bin/bash -c '$(DOCKER_TAR_BUILD)' && \
 	rm -fr $$builddir
 
 # Build a docker image (for distro cross-building).

--- a/dockerfiles/cross-build/Dockerfile.fedora.in
+++ b/dockerfiles/cross-build/Dockerfile.fedora.in
@@ -8,7 +8,7 @@ ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
 RUN dnf install -y rpm-build systemd-rpm-macros \
-    kernel-devel gcc clang \
+    kernel-devel gcc clang glibc-static \
     git-core make wget
 
 RUN arch="$(rpm --eval %{_arch})"; \


### PR DESCRIPTION
Install glibc-static in the builder image that we use for building "binary-dist" tarball. Also changes the builder image of the "distroless" binary tarball to Fedora instead of the ancient CentOS that were used previously.