### PR TITLE
github: update release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -22,7 +22,7 @@ future releases.
     - [ ] Run `git commit -m 'go.mod,go.sum: update dependencies.' go.{mod,sum}`, if necessary.
   - [ ] Run `git tag -a -m "CRI Resource Manager release $VERSION" $VERSION`.
   - [ ] Create source+dependencies tarball with `make vendored-dist`.
-  - [ ] Create binary tarball with `make binary-dist`.
+  - [ ] Create binary tarball with `make cross-tar`.
   - [ ] Build RPM packages with `make cross-rpm`.
   - [ ] Build DEB packages with `make cross-deb`.
   - [ ] Build container images with `make images`.


### PR DESCRIPTION
Instruct to use 'cross-tar' make target for building the "distroless" binary tarball. This builds inside a container (like cross targets) which means that we have more reproducible builds, e.g. using the golang version specified in the Makefile instead of using whatever happens to be installed on the host system (if any).