### PR TITLE
Makefile: add cross-tar to cross-packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,7 @@ e2e-tests: build-static
 	    exit 1; \
 	fi
 
-packaging-tests: cross-deb cross-rpm
+packaging-tests: cross-packages
 	$(Q)for dir in test/e2e/packages.test-suite/*; do \
 	    cleanup=1 omit_agent=1 $(E2E_RUN) $$dir; \
 	    echo "--------------------------------------"; \
@@ -480,7 +480,7 @@ else
     packages: cross-$(DISTRO_PACKAGE).$(DISTRO_ID)
 endif
 
-cross-packages: cross-rpm cross-deb
+cross-packages: cross-rpm cross-deb cross-tar
 
 cross-rpm: $(foreach d,$(SUPPORTED_RPM_DISTROS),cross-rpm.$(d))
 


### PR DESCRIPTION
Also build the "distroless" binary tarball with the corss-packages
target similar to the deb and rpm packages.

Also, change packaging-tests target to depend on cross-packages so that
it also tests the binary tarball. Even if it currently only tests the
buildability of the tarball as there is no actual e2e test to install
and verify it. Adding a packaging e2e-test for the binary tarball is
left as a future exercise.