### PR TITLE
Makefile: dynamically linked binary-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,7 @@ binary-dist:
 	echo "Creating binary dist tarball $$tarball..."; \
 	tardir=binary-dist; \
 	rm -fr $$tarball* $$tardir && \
-	$(MAKE) STATIC=1 DESTDIR=$$tardir \
+	$(MAKE) DESTDIR=$$tardir \
 	        BUILD_DIRS=cri-resmgr \
 	        PREFIX=/opt/intel \
 	        DEFAULTDIR=/etc/default \
@@ -664,7 +664,7 @@ cross-tar cross-tarball: dist docker/cross-build/fedora
 	    -v $$(pwd)/$$builddir:/build \
 	    -v $$(pwd)/$$outdir:/output \
 	    -v "`go env GOMODCACHE`:/home/$$USER/go/pkg/mod" \
-	    fedora-build /bin/bash -c '$(DOCKER_TAR_BUILD)' && \
+	    centos-7-build /bin/bash -c '$(DOCKER_TAR_BUILD)' && \
 	rm -fr $$builddir
 
 # Build a docker image (for distro cross-building).

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -8,7 +8,7 @@ ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
 RUN dnf install -y rpm-build systemd-rpm-macros \
-    kernel-devel gcc clang glibc-static \
+    kernel-devel gcc clang \
     git-core make wget
 
 RUN arch="$(rpm --eval %{_arch})"; \


### PR DESCRIPTION
Build a dynamically linked cri-resmgr binary with the binary-dist target. Change the builder image from fedora to centos-7 in order to link against as-old-as possible glibc version to mitigate risk of users hitting glibc symbol version skew.

Also clean up fedora builder dockerfile to remove support for static linking.