### PR TITLE
packaging: store licenses

### DIFF
--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -2,20 +2,27 @@ ARG GO_VERSION=1.18
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG GOLICENSES_VERSION
+
 WORKDIR /go/build
 
 # Fetch go dependencies in a separate layer for caching
+RUN go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 COPY go.mod go.sum ./
 COPY pkg/topology/ pkg/topology/
-RUN go mod download
+RUN go mod download -x
 
-# Build webhook, fully statically linked binary
+# Build agent and agent-probe, fully statically linked binary
 COPY . .
 
-RUN CGO_ENABLED=0 make build-static BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe"
+RUN CGO_ENABLED=0 make build-static BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe" && \
+    install -D /go/build/bin/* -t /install_root/bin
+
+# Save licenses
+RUN make install-licenses BUILD_DIRS="cri-resmgr-agent cri-resmgr-agent-probe" DESTDIR=/install_root
 
 FROM scratch as final
 
-COPY --from=builder /go/build/bin/* /bin/
+COPY --from=builder /install_root /
 
 ENTRYPOINT ["/bin/cri-resmgr-agent"]

--- a/cmd/cri-resmgr-webhook/Dockerfile
+++ b/cmd/cri-resmgr-webhook/Dockerfile
@@ -2,23 +2,30 @@ ARG GO_VERSION=1.18
 
 FROM golang:${GO_VERSION}-bullseye as builder
 
+ARG GOLICENSES_VERSION
+
 WORKDIR /go/build
 
 # Fetch go dependencies in a separate layer for caching
+RUN go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 COPY go.mod go.sum ./
 COPY pkg/topology/ pkg/topology/
-RUN go mod download
+RUN go mod download -x
 
 # Build webhook, fully statically linked binary
 COPY . .
 
-RUN CGO_ENABLED=0 make build-static BUILD_DIRS=cri-resmgr-webhook
+RUN CGO_ENABLED=0 make build-static BUILD_DIRS=cri-resmgr-webhook && \
+    install -D /go/build/bin/* -t /install_root/bin
+
+# Save licenses
+RUN make install-licenses BUILD_DIRS=cri-resmgr-webhook DESTDIR=/install_root
 
 FROM scratch as final
 
 USER 65534:65534
 
-COPY --from=builder /go/build/bin/cri-resmgr-webhook /bin/cri-resmgr-webhook
+COPY --from=builder /install_root /
 
 ENTRYPOINT ["/bin/cri-resmgr-webhook"]
 

--- a/dockerfiles/cross-build/Dockerfile.centos-7
+++ b/dockerfiles/cross-build/Dockerfile.centos-7
@@ -2,6 +2,7 @@
 FROM centos:7 as centos-7-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG GIT_VERSION=2.27.0
 ARG GIT_URLDIR=https://github.com/git/git/archive
@@ -37,6 +38,8 @@ RUN mkdir /git && cd /git && wget $GIT_URLDIR/v$GIT_VERSION.tar.gz && \
     make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr all && \
     yum remove -y git && \
     make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr install
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.centos-8
+++ b/dockerfiles/cross-build/Dockerfile.centos-8
@@ -2,6 +2,7 @@
 FROM centos:8 as centos-8-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
@@ -29,6 +30,8 @@ RUN arch="$(rpm --eval %{_arch})"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.debian-10
+++ b/dockerfiles/cross-build/Dockerfile.debian-10
@@ -2,6 +2,7 @@
 FROM debian:buster as debian-10-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -29,6 +30,8 @@ RUN arch="$(dpkg --print-architecture)"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.debian-sid
+++ b/dockerfiles/cross-build/Dockerfile.debian-sid
@@ -2,6 +2,7 @@
 FROM debian:sid as debian-sid-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -29,6 +30,8 @@ RUN arch="$(dpkg --print-architecture)"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -2,6 +2,7 @@
 FROM fedora:latest as fedora-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
@@ -26,6 +27,8 @@ RUN arch="$(rpm --eval %{_arch})"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.suse-15.4
+++ b/dockerfiles/cross-build/Dockerfile.suse-15.4
@@ -2,6 +2,7 @@
 FROM opensuse/leap:15.4 as suse-15.4-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
@@ -27,6 +28,8 @@ RUN arch="$(rpm --eval %{_arch})"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
@@ -2,6 +2,7 @@
 FROM ubuntu:18.04 as ubuntu-18.04-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -29,6 +30,8 @@ RUN arch="$(dpkg --print-architecture)"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
@@ -2,6 +2,7 @@
 FROM ubuntu:20.04 as ubuntu-20.04-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -30,6 +31,8 @@ RUN arch="$(dpkg --print-architecture)"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-22.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-22.04
@@ -2,6 +2,7 @@
 FROM ubuntu:22.04 as ubuntu-22.04-build
 
 ARG GO_VERSION=x.yz
+ARG GOLICENSES_VERSION
 ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
@@ -30,6 +31,8 @@ RUN arch="$(dpkg --print-architecture)"; \
     export PATH="/usr/local/go/bin:$PATH" && \
     echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
     go version
+
+RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 
 RUN [ -n "$CREATE_USER" -a "$CREATE_USER" != "root" ] && \
     useradd -m -s /bin/bash $CREATE_USER $USER_OPTIONS

--- a/packaging/deb.in/rules
+++ b/packaging/deb.in/rules
@@ -16,8 +16,8 @@ override_dh_auto_build:
 override_dh_auto_install:
 	export PATH="$$PATH:$$(go env GOPATH)/bin"; \
 	make BUILD_DIRS="__BUILD_DIRS__" install DESTDIR=debian/__PACKAGE__
-	mkdir -p debian/__PACKAGE__/usr/share/doc/__PACKAGE__
-	cp LICENSE README.md docs/*.md cmd/*/*.sample \
+	make BUILD_DIRS="__BUILD_DIRS__" install-licenses DESTDIR=debian/__PACKAGE__/usr/share/doc/__PACKAGE__
+	cp README.md docs/*.md cmd/*/*.sample \
 	    debian/__PACKAGE__/usr/share/doc/__PACKAGE__
 
 override_dh_gencontrol:

--- a/packaging/rpm/cri-resource-manager.spec.in
+++ b/packaging/rpm/cri-resource-manager.spec.in
@@ -19,6 +19,7 @@ placement policies.
 
 %build
 make build BUILD_DIRS=cri-resmgr
+make install-licenses BUILD_DIRS=cri-resmgr DESTDIR=.
 
 %install
 %make_install UNITDIR=%{_unitdir} SYSCONFDIR=%{_sysconfdir} BUILD_DIRS=cri-resmgr
@@ -32,6 +33,6 @@ install -m 0700 -d %{?buildroot}%{_sharedstatedir}/cri-resmgr
 %dir %attr(0700,root,root) %{_sharedstatedir}/cri-resmgr
 %dir %attr(0700,root,root) %{_sysconfdir}/cri-resmgr
 %config(noreplace) %{_sysconfdir}/cri-resmgr/*
-%doc LICENSE
+%license licenses/cri-resmgr/*
 %doc README.md docs/*.md
 %doc cmd/*/*.sample

--- a/scripts/build/docker-build-image
+++ b/scripts/build/docker-build-image
@@ -2,7 +2,6 @@
 
 VOLUMES=(-v /sys:/sys -v /home:/mnt/host/home)
 IMAGE=$1
-GO_VERSION=$2
 DOCKERFILE=dockerfiles/cross-build/Dockerfile.${IMAGE%-build}
 shift 2
 
@@ -37,7 +36,6 @@ echo "  - options   : " "${PASSTHROUGH[@]}"
 
 docker build . \
        -f "$DOCKERFILE" -t "$IMAGE" \
-       --build-arg GO_VERSION=$GO_VERSION \
        --build-arg "CREATE_USER=$USER" \
        --build-arg USER_OPTIONS="-u $(id -u)" \
        "${PASSTHROUGH[@]}" || exit 1


### PR DESCRIPTION
Use the go-licenses tool to save all used licenses (plus MPL-licensed
code) inside all distributed binary "archives". That is deb and rpm
packages, the "distroless" binary tarball and the container images of
cri-resmgr-agent and cri-resmgr-webhook.

For agent and webhook dockerfiles this patch also adds the -x flag to go
mod download to print progress information.