### PR TITLE
packaging/: drop agent and webhook from deb packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -619,8 +619,7 @@ debian/%: packaging/deb.in/%
 	          -e "s/__VERSION__/$(DEB_VERSION)/g"       \
 	          -e "s/__AUTHOR__/$(USER_NAME)/g"          \
 	          -e "s/__EMAIL__/$(USER_EMAIL)/g"          \
-	          -e "s/__DATE__/$(BUILD_DATE)/g"           \
-	          -e "s/__BUILD_DIRS__/$(BUILD_DIRS)/g" $@
+	          -e "s/__DATE__/$(BUILD_DATE)/g" $@
 
 clean-deb:
 	$(Q)rm -fr debian

--- a/packaging/deb.in/rules
+++ b/packaging/deb.in/rules
@@ -15,8 +15,8 @@ override_dh_auto_test:
 override_dh_auto_build:
 override_dh_auto_install:
 	export PATH="$$PATH:$$(go env GOPATH)/bin"; \
-	make BUILD_DIRS="__BUILD_DIRS__" install DESTDIR=debian/__PACKAGE__
-	make BUILD_DIRS="__BUILD_DIRS__" install-licenses DESTDIR=debian/__PACKAGE__/usr/share/doc/__PACKAGE__
+	make BUILD_DIRS=cri-resmgr install DESTDIR=debian/__PACKAGE__
+	make BUILD_DIRS=cri-resmgr install-licenses DESTDIR=debian/__PACKAGE__/usr/share/doc/__PACKAGE__
 	cp README.md docs/*.md cmd/*/*.sample \
 	    debian/__PACKAGE__/usr/share/doc/__PACKAGE__
 


### PR DESCRIPTION
Align with other packages i.e. rpm and the binary tarball.