### PR TITLE
e2e: disable numa_balancing in dynamic page demotion test

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/code.var.sh
@@ -5,6 +5,8 @@
 #   must not be migrated to PMEM.
 # - Migration speed is as configured.
 
+vm-command "echo 0 > /proc/sys/kernel/numa_balancing || true"
+
 # Relaunch cri-resmgr with dynamic page demotion configuration.
 cri_resmgr_cfg=$TEST_DIR/cri-resmgr-dynamic-page-demotion.cfg
 terminate cri-resmgr


### PR DESCRIPTION
Linux kernel autonuma may cause flakiness in page demotion test.