### PR TITLE
e2e: relax idle CPU load max from 20 to 30 %

### DIFF
--- a/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/code.var.sh
@@ -57,7 +57,7 @@ out "### Idle single-container pod"
 CPUREQ="400m" MEMREQ="" CPULIM="400m" MEMLIM=""
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: 400mCPU" CONTCOUNT=1 create podpools-busybox
 report allowed
-verify-log-vs-metrics pod0:pod0c0 0 20
+verify-log-vs-metrics pod0:pod0c0 0 30
 
 # pod0: single container, reserve 400m CPU and use it.
 # "yes" should show up in top with 40 % CPU consumption.
@@ -74,7 +74,7 @@ CPUREQ="100m" CPULIM="100m"
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: 400mCPU" CONTCOUNT=4 create podpools-busybox
 report allowed
 verify-metrics-has-line 'pool_cpu_usage{CPUs="[0-9]-[0-9]",container_name="pod2:pod2c0,pod2:pod2c1,pod2:pod2c2,pod2:pod2c3",def_name="400mCPU",memory="1",pod_name="pod2",policy="podpools",pool_size="2000",pretty_name="400mCPU\[[0-9]\]"}'
-verify-log-vs-metrics pod2:pod2c3 0 20
+verify-log-vs-metrics pod2:pod2c3 0 30
 
 out ""
 out "### Busy four-container pod"
@@ -89,7 +89,7 @@ CPUREQ="" CPULIM=""
 CONTCOUNT=2 create podpools-busybox
 report allowed
 vm-command "curl --silent $metrics_url | grep -v ^cgroup_"
-verify-log-vs-metrics pod4:pod4c1 0 20
+verify-log-vs-metrics pod4:pod4c1 0 30
 
 out ""
 out "### Multicontainer pod in kube-system namespace. Runs on reserved CPUs."
@@ -97,6 +97,6 @@ CPUREQ="" CPULIM=""
 namespace=kube-system CONTCOUNT=3 create podpools-busybox
 report allowed
 vm-command "curl --silent $metrics_url | grep -v ^cgroup_"
-verify-log-vs-metrics pod5:pod5c1 0 20
+verify-log-vs-metrics pod5:pod5c1 0 30
 
 cleanup


### PR DESCRIPTION
After debugging with "perf sched" it turned out that kube-apiserver and etcd where constantly scheduled on certain CPU core in e2e test vms. They generated high enough load to fail the test that checks reporting CPU load of podpools where containers were expected to do nothing but sleep.