### PR TITLE
podpools: fix synchronizing all running containers at start

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
@@ -178,7 +178,7 @@ func (p *podpools) Description() string {
 // Start prepares this policy for accepting allocation/release requests.
 func (p *podpools) Start(add []cache.Container, del []cache.Container) error {
 	log.Info("%s policy started", PolicyName)
-	return p.Sync(add, del)
+	return p.Sync(p.cch.GetContainers(), del)
 }
 
 // Sync synchronizes the active policy state.

--- a/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/code.var.sh
@@ -97,6 +97,8 @@ CPUREQ="" CPULIM=""
 namespace=kube-system CONTCOUNT=3 create podpools-busybox
 report allowed
 vm-command "curl --silent $metrics_url | grep -v ^cgroup_"
-verify-log-vs-metrics pod5:pod5c1 0 20
+# There should be kube-apiserver, etcd etc. running on reserved CPUs as well,
+# therefore allow a lot of CPU usage yet pod5 is not doing anything.
+verify-log-vs-metrics pod5:pod5c1 0 100
 
 cleanup


### PR DESCRIPTION
This change makes podpools start similar to the balloons policy start: find all running containers in the system.