### PR TITLE
e2e: fix isolcpus test on Fedora

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -529,6 +529,10 @@ fedora-install-containerd-pre() {
     fedora-install-containernetworking-plugins
 }
 
+fedora-install-containerd-post() {
+    vm-command "systemctl enable containerd"
+}
+
 fedora-install-k8s() {
     local repo="/etc/yum.repos.d/kubernetes.repo"
     local base="https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch"

--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -605,6 +605,17 @@ fi
 EOF
 }
 
+fedora-set-kernel-cmdline() {
+    local e2e_defaults="$*"
+    vm-command "mkdir -p /etc/default; touch /etc/default/grub; sed -i '/e2e:fedora-set-kernel-cmdline/d' /etc/default/grub"
+    vm-command "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"\${GRUB_CMDLINE_LINUX_DEFAULT} ${e2e_defaults}\" # by e2e:fedora-set-kernel-cmdline' >> /etc/default/grub" || {
+        command-error "writing new command line parameters failed"
+    }
+    vm-command "grub2-mkconfig -o /boot/grub2/grub.cfg" || {
+        command-error "updating grub failed"
+    }
+}
+
 fedora-33-install-crio-pre() {
     fedora-install-crio-version 1.20
 }


### PR DESCRIPTION
- Fixes topology-aware/n4c16/test08-isolcpus test on Fedora.