### PR TITLE
Policy: create dynamic-pools policy for cri-rm

### DIFF
--- a/docs/policy/dynamic-pools.md
+++ b/docs/policy/dynamic-pools.md
@@ -37,7 +37,6 @@ Dynamic-pools policy parameters:
 
 * `PinCPU` controls pinning a container to CPUs of its dynamic-pool. The default is  `true`: the container cannot use other CPUs.
 * `PinMemory` controls pinning a container to the memories that are closest to the CPUs of its dynamic-pool. The default is `true`: allow using memory only from the closest NUMA nodes. Warning: this may cause kernel to kill workloads due to out-of-memory error when closest NUMA nodes do not have enough memory. In this situation consider switching this option `false`.
-* `IdleCPUClass` specifies the CPU class of those CPUs that do not belong to any dynamic-pool.
 * `ReservedPoolNamespaces` is a list of namespaces (wildcards allowed) that are assigned to the special reserved dynamic-pool, that is, will run on reserved CPUs. This always includes the `kube-system` namespace.
 * `DynamicPoolTypes` is a list of dynamic-pool type definitions. Each type can be configured with the following parameters:
   - `Name` of the dynamic-pool type. This is used in pod annotations to assign containers to dynamic-pool of this type.

--- a/docs/policy/dynamic-pools.md
+++ b/docs/policy/dynamic-pools.md
@@ -59,14 +59,11 @@ Example configuration that runs all pods in dynamic-pools.
   cpu: |+
     classes:
       pool1-cpuclass:
-        maxFreq: 2110000
-        minFreq: 2110000
+        maxFreq: 1500000
+        minFreq: 2000000
       pool2-cpuclass:
-        maxFreq: 2500000
+        maxFreq: 2000000
         minFreq: 2500000
-      idle:
-        maxFreq: 2500000
-        minFreq: 1500000
   policy: |+
     Active: dynamic-pools
     ReservedResources:
@@ -74,7 +71,6 @@ Example configuration that runs all pods in dynamic-pools.
     dynamic-pools:
       PinCPU: true
       PinMemory: true
-      IdleCPUClass: idle
       DynamicPoolTypes:
         - Name: "pool1"
           Namespaces:

--- a/docs/policy/dynamic-pools.md
+++ b/docs/policy/dynamic-pools.md
@@ -1,0 +1,122 @@
+# Dynamic-Pools Policy
+
+## Overview
+
+The dynamic-pools policy puts the workload in the dynamic-pool that are disjoint CPU pools. The dynamic-pools can be resized, that is CPUs added and removed, which is based on the requests of the containers and the CPU utilization of the workload in the dynamic-pools.
+
+On the premise that the CPUs in each dynamic-pool can meet the requests of the pods in the dynamic-pool, the CPUs are allocated based on the CPU utilization of the workload. Dynamic-pools policy try to keep CPU utilization balanced.
+
+ CPUs in dynamic-pools can be configured, for example, by setting min and max frequencies on CPU cores and uncore.
+
+## How It Works
+
+1. The user configures the dynamic-pool types from which the policy instantiates dynamic-pools. In addition to the dynamic-pools configured by the user, there is also a built-in dynamic-pool named shared pool.
+2. A dynamic-pool has a set of CPUs and a set of containers running on the CPUs.
+3. Every container is assigned to a dynamic-pool. Allows a container to use all CPUs of its pool and no other CPUs.
+4. Each logical CPU belongs to and belongs to at most one dynamic-pool. There cannot be CPUs that do not belong to any dynamic-pool.
+5. The number of CPUs in a dynamic-pool can change. If CPUs are added to a dynamic-pool, then all containers in the dynamic-pool can use more CPUs. The opposite is true if the CPUs are removed.
+6. As CPUs are added to or removed from the dynamic-pool, the CPUs are reconfigured according to the dynamic-pool's CPU class attributes or the idle CPU class attributes.
+7. Update the number of CPUs in dynamic-pools:
+   - The dynamic-pool policy needs to update the number of CPUs in dynamic-pools when starting policy, creating pods, deleting pods, updating configurations, and at regular intervals.
+   - The number of CPUs in the dynamic-pools is determined by the requests of containers and CPU utilization in the dynamic-pools. On the premise that the CPUs in each dynamic-pool can meet the requests of the pods in the pool, the CPUs are allocated based on the utilization of the workload.
+8. When a new container is created on a Kubernetes node, the policy first decides the type of the dynamic-pool that will run the container. The decision is based on the annotation of the pod, or the namespace if annotations are not given.
+
+## Deployment
+
+### Install cri-resmgr
+
+Deploy cri-resmgr on each node as you would for any other policy. See [installation](https://intel.github.io/cri-resource-manager/stable/docs/installation.html) for more details.
+
+## Configuration
+
+The dynamic-pools policy is configured using the yaml-based configuration system of CRI-RM. See [setup and usage](https://intel.github.io/cri-resource-manager/stable/docs/setup.html#setting-up-cri-resource-manager) for more details on managing the configuration.
+
+### Parameters
+
+Dynamic-pools policy parameters:
+
+* `PinCPU` controls pinning a container to CPUs of its dynamic-pool. The default is  `true`: the container cannot use other CPUs.
+* `PinMemory` controls pinning a container to the memories that are closest to the CPUs of its dynamic-pool. The default is `true`: allow using memory only from the closest NUMA nodes. Warning: this may cause kernel to kill workloads due to out-of-memory error when closest NUMA nodes do not have enough memory. In this situation consider switching this option `false`.
+* `IdleCPUClass` specifies the CPU class of those CPUs that do not belong to any dynamic-pool.
+* `ReservedPoolNamespaces` is a list of namespaces (wildcards allowed) that are assigned to the special reserved dynamic-pool, that is, will run on reserved CPUs. This always includes the `kube-system` namespace.
+* `DynamicPoolTypes` is a list of dynamic-pool type definitions. Each type can be configured with the following parameters:
+  - `Name` of the dynamic-pool type. This is used in pod annotations to assign containers to dynamic-pool of this type.
+  - `Namespaces` is a list of namespaces (wildcards allowed) whose pods should be assigned to this dynamic-pool type, unless overridden by pod annotations.
+  - `CpuClass` specifies the name of the CPU class according to which CPUs of dynamic-pools are configured.
+  - `AllocatorPriority` (0: High, 1: Normal, 2: Low, 3: None). CPU allocator parameter, used when creating new or resizing existing dynamic-pools.
+
+Related configuration parameters:
+
+* `policy.ReservedResources.CPU` specifies the (number of) CPUs in the special `reserved` dynamic-pool. By default all containers in the `kube-system` namespace are assigned to the reserved dynamic-pool.
+* `policy.AvailableResources.CPU` specifies the CPUs that can be used by the policy, including `policy.ReservedResources.CPU`.
+* `cpu.classes` defines CPU classes and their parameters (such as `minFreq`, `maxFreq`, `uncoreMinFreq` and `uncoreMaxFreq`).
+
+### Example
+
+Example configuration that runs all pods in dynamic-pools.
+
+```yaml
+  cpu: |+
+    classes:
+      pool1-cpuclass:
+        maxFreq: 2110000
+        minFreq: 2110000
+      pool2-cpuclass:
+        maxFreq: 2500000
+        minFreq: 2500000
+      idle:
+        maxFreq: 2500000
+        minFreq: 1500000
+  policy: |+
+    Active: dynamic-pools
+    ReservedResources:
+        CPU: cpuset:0
+    dynamic-pools:
+      PinCPU: true
+      PinMemory: true
+      IdleCPUClass: idle
+      DynamicPoolTypes:
+        - Name: "pool1"
+          Namespaces:
+            - "pool1"
+          CPUClass: "pool1-cpuclass"
+        - Name: "pool2"
+          Namespaces:
+            - "pool2"
+          CPUClass: "pool2-cpuclass"
+```
+
+### Update Dynamic-Pools at Regular Intervals
+
+The dynamic-pool policy can be set at regular intervals, based on the cpu utilization of the workload in each pool, to update the cpu allocation, and use the `--rebalance-interval` option to set the interval.
+
+### Assigning a Container to a Dynamic-pool
+
+The dynamic-pool type of a container can be defined in pod annotations. In the example below, the first annotation sets the dynamic-pool type (`DPT`) of a single container (`CONTAINER_NAME`). The last two annotations set the default dynamic-pools type for all containers in the pod.
+
+```yaml
+dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/container.CONTAINER_NAME: DPT
+dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: DPT
+dynamic-pool.dynamic-pools.cri-resource-manager.intel.com: DPT
+```
+
+If a pod has no annotations, its namespace is matched to the `namespace` of dynamic-pool types. The first matching dynamic-pool type is used.
+
+If the namespace does not match, the container is assigned to the `shared` dynamic-pool.
+
+## Metrics and Debugging
+
+In order to enable more verbose logging and metrics exporting from the dynamic-pools policy, enable instrumentation and policy debugging from the CRI-RM global config:
+
+```yaml
+instrumentation:
+  # The dynamic-pools policy exports containers running in each dynamic-pool,
+  # and cpusets of dynamic-pools. Accessible in command line:
+  # curl --silent http://localhost:8891/metrics
+  HTTPEndpoint::8891
+  PrometheusExport:true
+logger:
+  Debug:policy
+```
+
+Use the `--metrics-interval` option to set the interval for updating metrics data.

--- a/docs/policy/dynamic-pools.md
+++ b/docs/policy/dynamic-pools.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The dynamic-pools policy puts the workload in the dynamic-pool that are disjoint CPU pools. The dynamic-pools can be resized, that is CPUs added and removed, which is based on the requests of the containers and the CPU utilization of the workload in the dynamic-pools.
+The dynamic-pools policy can put the workload into different dynamic-pools. Each dynamic-pool contains several CPUs and can be resized dynamically in terms of the specific algorithms.
 
-On the premise that the CPUs in each dynamic-pool can meet the requests of the pods in the dynamic-pool, the CPUs are allocated based on the CPU utilization of the workload. Dynamic-pools policy try to keep CPU utilization balanced.
+The main idea of the algorithm is: on the premise that the CPUs in each dynamic-pool can meet the requests of the pods in the dynamic-pool, the CPUs are allocated based on the CPU utilization of the workload. Dynamic-pools policy try to keep CPU utilization balanced.
 
  CPUs in dynamic-pools can be configured, for example, by setting min and max frequencies on CPU cores and uncore.
 
@@ -16,9 +16,10 @@ On the premise that the CPUs in each dynamic-pool can meet the requests of the p
 4. Each logical CPU belongs to and belongs to at most one dynamic-pool. There cannot be CPUs that do not belong to any dynamic-pool.
 5. The number of CPUs in a dynamic-pool can change. If CPUs are added to a dynamic-pool, then all containers in the dynamic-pool can use more CPUs. The opposite is true if the CPUs are removed.
 6. As CPUs are added to or removed from the dynamic-pool, the CPUs are reconfigured according to the dynamic-pool's CPU class attributes or the idle CPU class attributes.
-7. Update the number of CPUs in dynamic-pools:
+7. Updating the number of CPUs in dynamic-pools:
    - The dynamic-pool policy needs to update the number of CPUs in dynamic-pools when starting policy, creating pods, deleting pods, updating configurations, and at regular intervals.
-   - The number of CPUs in the dynamic-pools is determined by the requests of containers and CPU utilization in the dynamic-pools. On the premise that the CPUs in each dynamic-pool can meet the requests of the pods in the pool, the CPUs are allocated based on the utilization of the workload.
+   - The number of CPUs in the dynamic-pools is determined by the requests of containers and CPU utilization in the dynamic-pools. 
+   - The number of CPUs allocated in each dynamic-pool is the sum of the requests of the containers in the dynamic pool and the CPUs allocated based on the CPU utilization of the workload.
 8. When a new container is created on a Kubernetes node, the policy first decides the type of the dynamic-pool that will run the container. The decision is based on the annotation of the pod, or the namespace if annotations are not given.
 
 ## Deployment

--- a/docs/policy/index.rst
+++ b/docs/policy/index.rst
@@ -12,3 +12,4 @@ Policies
    blockio.md
    rdt.md
    cpu-allocator.md
+   dynamic-pools.md

--- a/pkg/cri/resource-manager/builtin-policies.go
+++ b/pkg/cri/resource-manager/builtin-policies.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-plus"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/static-pools"
 	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/topology-aware"
+	_ "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy/builtin/dynamic-pools"
 )
 
 // TODO: add unit tests to verify that all builtin policies are found

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/cpu.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/cpu.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/intel/cri-resource-manager/pkg/sysfs"
 )
 
 type cpuTimesStat struct {
@@ -45,7 +47,7 @@ func getCpuUtilization(interval time.Duration) ([]float64, error) {
 }
 
 func getCpuTimesStat(ctx context.Context) ([]cpuTimesStat, error) {
-	filename := pathProcStat("stat")
+	filename := filepath.Join("/", sysfs.SysRoot(), "proc", "stat")
 	lines := []string{}
 	cpuLines, err := readCpuLines(filename)
 	if err != nil || len(cpuLines) == 0 {
@@ -83,17 +85,6 @@ func calculateAllCpusUtilization(cts1, cts2 []cpuTimesStat) ([]float64, error) {
 		allCpusUtilization[i] = calculateOneCpuUtilization(cts1[i], cts2[i])
 	}
 	return allCpusUtilization, nil
-}
-
-func pathProcStat(stat string) string {
-	key := "HOST_PROC"
-	defaul := "/proc"
-
-	value := os.Getenv(key)
-	if value == "" {
-		value = defaul
-	}
-	return filepath.Join(value, stat)
 }
 
 //readCpuLines skips the first line indicating the total CPU utilization.

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/cpu.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/cpu.go
@@ -1,0 +1,222 @@
+package dyp
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type cpuTimesStat struct {
+	cpu       string  `json:"cpu"`
+	user      float64 `json:"user"`
+	system    float64 `json:"system"`
+	idle      float64 `json:"idle"`
+	nice      float64 `json:"nice"`
+	ioWait    float64 `json:"iowait"`
+	irq       float64 `json:"irq"`
+	softirq   float64 `json:"softirq"`
+	steal     float64 `json:"steal"`
+	guest     float64 `json:"guest"`
+	guestNice float64 `json:"guestNice"`
+}
+
+var clocksPerSecond = float64(100)
+
+// getCpuUtilization returns the utilization of each cpu in an interval
+func getCpuUtilization(interval time.Duration) ([]float64, error) {
+	ctx := context.Background()
+	cpuTimesStat1, err := getCpuTimesStat(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := wait(ctx, interval); err != nil {
+		return nil, err
+	}
+	cpuTimesStat2, err := getCpuTimesStat(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return calculateAllCpusUtilization(cpuTimesStat1, cpuTimesStat2)
+}
+
+func getCpuTimesStat(ctx context.Context) ([]cpuTimesStat, error) {
+	filename := pathProcStat("stat")
+	lines := []string{}
+	cpuLines, err := readCpuLines(filename)
+	if err != nil || len(cpuLines) == 0 {
+		return []cpuTimesStat{}, err
+	}
+
+	stat := make([]cpuTimesStat, 0, len(lines))
+	for _, l := range cpuLines {
+		oneStat, err := formatStatLine(l)
+		if err != nil {
+			continue
+		}
+		stat = append(stat, *oneStat)
+
+	}
+	return stat, nil
+}
+
+func wait(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func calculateAllCpusUtilization(cts1, cts2 []cpuTimesStat) ([]float64, error) {
+	if len(cts1) != len(cts2) {
+		return nil, dynamicPoolsError("received two CPU counts: %d != %d", len(cts1), len(cts2))
+	}
+	allCpusUtilization := make([]float64, len(cts1))
+	for i := 0; i < len(cts1); i++ {
+		allCpusUtilization[i] = calculateOneCpuUtilization(cts1[i], cts2[i])
+	}
+	return allCpusUtilization, nil
+}
+
+func pathProcStat(stat string) string {
+	key := "HOST_PROC"
+	defaul := "/proc"
+
+	value := os.Getenv(key)
+	if value == "" {
+		value = defaul
+	}
+	return filepath.Join(value, stat)
+}
+
+func readCpuLines(filename string) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return []string{""}, err
+	}
+	defer f.Close()
+	var statLines []string
+	reader := bufio.NewReader(f)
+	for {
+		line, _, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		statLines = append(statLines, string(line))
+	}
+
+	var cpuLines []string
+	if len(statLines) < 2 {
+		return []string{""}, nil
+	}
+	for _, line := range statLines[1:] {
+		if !strings.HasPrefix(line, "cpu") {
+			break
+		}
+		cpuLines = append(cpuLines, line)
+	}
+	return cpuLines, nil
+}
+
+func formatStatLine(cpuLine string) (*cpuTimesStat, error) {
+	values := strings.Fields(cpuLine)
+	if len(values) == 0 {
+		return nil, dynamicPoolsError("Stat does not contain cpu info.")
+	}
+	cpu := values[0]
+	if cpu == "cpu" {
+		cpu = "cpu-total"
+	}
+	user, err := strconv.ParseFloat(values[1], 64)
+	if err != nil {
+		return nil, err
+	}
+	nice, err := strconv.ParseFloat(values[2], 64)
+	if err != nil {
+		return nil, err
+	}
+	system, err := strconv.ParseFloat(values[3], 64)
+	if err != nil {
+		return nil, err
+	}
+	idle, err := strconv.ParseFloat(values[4], 64)
+	if err != nil {
+		return nil, err
+	}
+	ioWait, err := strconv.ParseFloat(values[5], 64)
+	if err != nil {
+		return nil, err
+	}
+	irq, err := strconv.ParseFloat(values[6], 64)
+	if err != nil {
+		return nil, err
+	}
+	softirq, err := strconv.ParseFloat(values[7], 64)
+	if err != nil {
+		return nil, err
+	}
+	cts := &cpuTimesStat{
+		cpu:     cpu,
+		user:    user / clocksPerSecond,
+		nice:    nice / clocksPerSecond,
+		system:  system / clocksPerSecond,
+		idle:    idle / clocksPerSecond,
+		ioWait:  ioWait / clocksPerSecond,
+		irq:     irq / clocksPerSecond,
+		softirq: softirq / clocksPerSecond,
+	}
+	if len(values) > 8 { // Linux >= 2.6.11
+		steal, err := strconv.ParseFloat(values[8], 64)
+		if err != nil {
+			return nil, err
+		}
+		cts.steal = steal / clocksPerSecond
+	}
+	if len(values) > 9 { // Linux >= 2.6.24
+		guest, err := strconv.ParseFloat(values[9], 64)
+		if err != nil {
+			return nil, err
+		}
+		cts.guest = guest / clocksPerSecond
+	}
+	if len(values) > 10 { // Linux >= 3.2.0
+		guestNice, err := strconv.ParseFloat(values[10], 64)
+		if err != nil {
+			return nil, err
+		}
+		cts.guestNice = guestNice / clocksPerSecond
+	}
+	return cts, nil
+}
+
+func calculateOneCpuUtilization(cts1, cts2 cpuTimesStat) float64 {
+	cts1Total, cts1Busy := getBusyTime(cts1)
+	cts2Total, cts2Busy := getBusyTime(cts2)
+	if cts2Busy <= cts1Busy {
+		return 0
+	}
+	if cts2Total <= cts1Total {
+		return 100
+	}
+	return math.Min(100, math.Max(0, (cts2Busy-cts1Busy)/(cts2Total-cts1Total)*100))
+}
+
+func getBusyTime(cts cpuTimesStat) (float64, float64) {
+	total := cts.user + cts.system + cts.idle + cts.nice + cts.ioWait + cts.irq +
+		cts.softirq + cts.steal + cts.guest + cts.guestNice
+	if runtime.GOOS == "linux" {
+		total -= cts.guest     // Linux 2.6.24+
+		total -= cts.guestNice // Linux 3.2.0+
+	}
+	busy := total - cts.idle - cts.ioWait
+	return total, busy
+}

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp.go
@@ -1,0 +1,938 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dyp
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	resapi "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	cpucontrol "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/cpu"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	logger "github.com/intel/cri-resource-manager/pkg/log"
+	"github.com/intel/cri-resource-manager/pkg/utils"
+	idset "github.com/intel/goresctrl/pkg/utils"
+)
+
+const (
+	// PolicyName is the name used to activate this policy.
+	PolicyName = "dynamic-pools"
+	// PolicyDescription is a short description of this policy.
+	PolicyDescription = "The cpuset of the dynamic pools can be dynamically changed based on workload."
+	// PolicyPath is the path of this policy in the configuration hierarchy.
+	PolicyPath = "policy." + PolicyName
+	// dynamicPoolKey is a pod annotation key, the value is a pod dynamicPool name.
+	dynamicPoolKey = "dynamic-pool." + PolicyName + "." + kubernetes.ResmgrKeyNamespace
+	// reservedDynamicPoolDefName is the name in the reserved dynamicPool definition.
+	reservedDynamicPoolDefName = "reserved"
+	// defaultDynamicPoolDefName is the name in the default dynamicPool definition.
+	defaultDynamicPoolDefName = "shared"
+)
+
+// dynamicPools contains configuration and runtime attributes of the dynamic-pools policy
+type dynamicPools struct {
+	options   *policyapi.BackendOptions // configuration common to all policies
+	dpoptions DynamicPoolsOptions       // dynamicPool-specific configuration
+	cch       cache.Cache               // cri-resmgr cache
+	allowed   cpuset.CPUSet             // bounding set of CPUs we're allowed to use
+	reserved  cpuset.CPUSet             // system-/kube-reserved CPUs
+	freeCpus  cpuset.CPUSet             // CPUs to be included in growing dynamicPools
+
+	reservedDynamicPoolDef *DynamicPoolDef // built-in definition of the reserved dynamicPool
+	defaultDynamicPoolDef  *DynamicPoolDef // built-in definition of the default dynamicPool
+	dynamicPools           []*DynamicPool  // dynamicPool instances: reserved, default and user-defined
+
+	cpuAllocator cpuallocator.CPUAllocator // CPU allocator used by the policy
+}
+
+// DynamicPool contains attributes of a dynamicPool
+type DynamicPool struct {
+	// Def is the definition from which this dynamicPool is created.
+	Def *DynamicPoolDef
+	// Cpus is the set of CPUs exclusive to this dynamicPool only.
+	Cpus cpuset.CPUSet
+	// Mems is the set of memory nodes with minimal access delay from CPUs.
+	Mems idset.IDSet
+	// PodIDs maps pod ID to list of container IDs.
+	// - len(PodIDs) is the number of pods in the dynamicPool.
+	// - len(PodIDs[podID]) is the number of containers of podID currently assigned to the dynamicPool.
+	PodIDs map[string][]string
+}
+
+var log logger.Logger = logger.NewLogger("policy")
+
+// String is a stringer for a dynamicPool.
+func (dp DynamicPool) String() string {
+	return fmt.Sprintf("%s{Cpus:%s, Mems:%s}", dp.PrettyName(), dp.Cpus, dp.Mems)
+}
+
+// PrettyName returns a unique name for a dynamicPool.
+func (dp DynamicPool) PrettyName() string {
+	return dp.Def.Name
+}
+
+// ContainerIDs returns IDs of containers assigned in a dynamicPool.
+// (Using cache.Container.GetCacheID()'s)
+func (dp DynamicPool) ContainerIDs() []string {
+	cIDs := []string{}
+	for _, ctrIDs := range dp.PodIDs {
+		cIDs = append(cIDs, ctrIDs...)
+	}
+	return cIDs
+}
+
+// ContainerCount returns the number of containers in a dynamicPool.
+func (dp DynamicPool) ContainerCount() int {
+	count := 0
+	for _, ctrIDs := range dp.PodIDs {
+		count += len(ctrIDs)
+	}
+	return count
+}
+
+// AvailMilliCpus returns the number of CPUs in a dynamicPool.
+func (dp DynamicPool) AvailMilliCpus() int {
+	return dp.Cpus.Size() * 1000
+}
+
+// updateRealCpuUsed returns cpu utilization of a dynamicPool.
+func (p *dynamicPools) updateRealCpuUsed(dp *DynamicPool) (int, error) {
+	if dp.Cpus.Size() == 0 {
+		log.Info("dynamic pool %s cpuset is 0", dp.Def.Name)
+		return 0, nil
+	}
+	cpuInfo, _ := getCpuUtilization(time.Duration(time.Second))
+	cpus := dp.Cpus.ToSlice()
+	var sum float64
+	for i := 0; i < len(cpus); i++ {
+		sum += cpuInfo[cpus[i]]
+	}
+	res := int(sum / float64(100))
+
+	log.Info("dynamic pool %s cpuset: %s,  cpu utilization: %d", dp.Def.Name, dp.Cpus, res)
+	return res, nil
+}
+
+// calculateAllPoolWeights returns weights of all dynamicPools and the sum of weights.
+// Use dynamicPool's cpu utilization as its weight.
+func (p *dynamicPools) calculateAllPoolWeights() (map[*DynamicPool]int, int, error) {
+	weight := make(map[*DynamicPool]int)
+	sumWeight := 0
+	for _, dp := range p.dynamicPools {
+		if dp.Def.Name == "reserved" {
+			continue
+		}
+		realCpuUsed, err := p.updateRealCpuUsed(dp)
+		if err != nil {
+			return weight, sumWeight, dynamicPoolsError("The actual cpu usage of the dynamic pool %s cannot be obtained: %w",
+				dp.PrettyName(), err)
+		}
+		weight[dp] = realCpuUsed
+		sumWeight += weight[dp]
+		log.Info("dyanmic pool: %s, realCpuUsed: %d, weight: %d", dp, realCpuUsed, weight[dp])
+	}
+	log.Info("sum weight: %d", sumWeight)
+	return weight, sumWeight, nil
+}
+
+// calculateAllPoolRequests returns the sum of the requests of containers in each dynamicPool and remaining free cpu.
+// remainFree = allowed cpu - reserved cpu - sum(requests of containers in each dynamicPool)
+func (p *dynamicPools) calculateAllPoolRequests() (map[*DynamicPool]int, int) {
+	requestCpu := make(map[*DynamicPool]int)
+	remainFree := p.allowed.Difference(p.reserved).Size()
+	for _, dp := range p.dynamicPools {
+		if dp.Def.Name == "reserved" {
+			continue
+		}
+		requestCpu[dp] = (p.requestedMinMilliCpus(dp) + 999) / 1000
+		remainFree -= requestCpu[dp]
+		log.Info("dyanmic pool %s request cpu %d", dp, requestCpu[dp])
+	}
+	log.Info("sum remain free cpu %d", remainFree)
+	return requestCpu, remainFree
+}
+
+func (p *dynamicPools) containerPinPool(dp *DynamicPool) {
+	dp.Mems = p.closestMems(dp.Cpus)
+	for _, cID := range dp.ContainerIDs() {
+		if c, ok := p.cch.LookupContainer(cID); ok {
+			p.pinCpuMem(c, dp.Cpus, dp.Mems)
+		}
+	}
+}
+
+// updatePoolCpuset updates the cpuset of the dynamicPools.
+func (p *dynamicPools) updatePoolCpuset() error {
+	requestCpu, remainFree := p.calculateAllPoolRequests()
+	weight, sumWeight, err := p.calculateAllPoolWeights()
+	if err != nil {
+		return err
+	}
+
+	if remainFree >= 1 {
+		usedCpu := 0
+		// Ensure that there is at least one cpu in the shared dynamicPool.
+		for _, dp := range p.dynamicPools {
+			if dp.Def.Name == "shared" && sumWeight != 0 {
+				addCpu := remainFree * weight[dp] / sumWeight
+				if requestCpu[dp]+addCpu < 1 {
+					requestCpu[dp] = 1
+					remainFree -= 1
+				}
+			}
+		}
+		for _, dp := range p.dynamicPools {
+			if dp.Def.Name == "reserved" {
+				continue
+			}
+			if sumWeight != 0 {
+				addCpu := remainFree * weight[dp] / sumWeight
+				requestCpu[dp] += addCpu
+				usedCpu += addCpu
+			}
+			log.Info("dyanmic pool %s new request cpu %d, remain free cpu %d", dp, requestCpu[dp], remainFree-usedCpu)
+		}
+		if usedCpu < remainFree {
+			// If there is still cpus, give the dynamicPool with the highest cpu utilization.
+			tmp := p.dynamicPools[1]
+			for _, dp := range p.dynamicPools {
+				if dp.Def.Name == "reserved" {
+					continue
+				}
+				if weight[dp] > weight[tmp] {
+					tmp = dp
+				}
+			}
+			requestCpu[tmp] += (remainFree - usedCpu)
+			log.Info("dyanmic pool %s new request cpu %d, remain free cpu %d", tmp, requestCpu[tmp], 0)
+		}
+	}
+
+	// If the number of newly allocated CPUs is the same as the number of existing CPUs in the pool,
+	// it means that there is no need to re-allocate
+	isNeedReallocate := false
+	for _, dp := range p.dynamicPools {
+		if dp.Def.Name == "reserved" {
+			continue
+		}
+		if dp.Cpus.Size() != requestCpu[dp] {
+			isNeedReallocate = true
+			break
+		}
+	}
+	if !isNeedReallocate {
+		log.Info("The number of CPUs required by the pools is the same as the number of CPUs already in the pools, so there is no need to reallocate.")
+		for _, dp := range p.dynamicPools {
+			p.containerPinPool(dp)
+		}
+		return nil
+	}
+
+	for _, dp := range p.dynamicPools {
+		if dp.Def.Name == "reserved" {
+			continue
+		}
+		if dp.Cpus.Size() == 0 {
+			continue
+		}
+		p.forgetCpuClass(dp)
+		oldCpus := dp.Cpus.Clone()
+		keptCpus, err := p.cpuAllocator.ReleaseCpus(&oldCpus, dp.Cpus.Size(), dp.Def.AllocatorPriority)
+		if err != nil || keptCpus.Size() != 0 {
+			return dynamicPoolsError("releasing %d CPUs from %s failed: %w (kept: %s)", dp.Cpus.Size(), dp, err, keptCpus)
+		}
+		p.freeCpus = p.freeCpus.Union(dp.Cpus)
+	}
+	for _, dp := range p.dynamicPools {
+		if dp.Def.Name == "reserved" {
+			continue
+		}
+		newCpus, err := p.cpuAllocator.AllocateCpus(&p.freeCpus, requestCpu[dp], dp.Def.AllocatorPriority)
+		if err != nil {
+			return dynamicPoolsError("allocating %d CPUs for %s failed: %w", requestCpu[dp], dp, err)
+		}
+		dp.Cpus = newCpus
+		log.Debugf("resize successful for container: %s, new Cpus: %#s", dp.PrettyName(), dp.Cpus)
+		p.containerPinPool(dp)
+		p.useCpuClass(dp)
+	}
+	return nil
+}
+
+// CreateDynamicPoolsPolicy creates a new policy instance.
+func CreateDynamicPoolsPolicy(policyOptions *policy.BackendOptions) policy.Backend {
+	p := &dynamicPools{
+		options:      policyOptions,
+		cch:          policyOptions.Cache,
+		cpuAllocator: cpuallocator.NewCPUAllocator(policyOptions.System),
+	}
+	log.Info("creating %s policy...", PolicyName)
+	// Handle common policy options: AvailableResources and ReservedResources.
+	// p.allowed: CPUs available for the policy
+	if allowed, ok := policyOptions.Available[policyapi.DomainCPU]; ok {
+		p.allowed = allowed.(cpuset.CPUSet)
+	} else {
+		// Available CPUs not specified, default to all on-line CPUs.
+		p.allowed = policyOptions.System.CPUSet().Difference(policyOptions.System.Offlined())
+	}
+	// p.reserved: CPUs reserved for kube-system pods, subset of p.allowed.
+	p.reserved = cpuset.NewCPUSet()
+	if reserved, ok := p.options.Reserved[policyapi.DomainCPU]; ok {
+		switch v := reserved.(type) {
+		case cpuset.CPUSet:
+			p.reserved = p.allowed.Intersection(v)
+		case resapi.Quantity:
+			reserveCnt := (int(v.MilliValue()) + 999) / 1000
+			cpus, err := p.cpuAllocator.AllocateCpus(&p.allowed, reserveCnt, cpuallocator.PriorityNone)
+			if err != nil {
+				log.Fatal("failed to allocate reserved CPUs: %s", err)
+			}
+			p.reserved = cpus
+			p.allowed = p.allowed.Union(cpus)
+		}
+	}
+	if p.reserved.IsEmpty() {
+		log.Fatal("%s cannot run without reserved CPUs that are also AvailableResources", PolicyName)
+	}
+	// Handle policy-specific options
+	log.Debug("creating %s configuration", PolicyName)
+	if err := p.setConfig(dynamicPoolsOptions); err != nil {
+		log.Fatal("failed to create %s policy: %v", PolicyName, err)
+	}
+	pkgcfg.GetModule(PolicyPath).AddNotify(p.configNotify)
+
+	return p
+}
+
+// Name returns the name of this policy.
+func (p *dynamicPools) Name() string {
+	return PolicyName
+}
+
+// Description returns the description for this policy.
+func (p *dynamicPools) Description() string {
+	return PolicyDescription
+}
+
+// Start prepares this policy for accepting allocation/release requests.
+func (p *dynamicPools) Start(add []cache.Container, del []cache.Container) error {
+	log.Info("%s policy started", PolicyName)
+	return p.Sync(p.cch.GetContainers(), nil)
+}
+
+// Sync synchronizes the active policy state.
+func (p *dynamicPools) Sync(add []cache.Container, del []cache.Container) error {
+	log.Debug("synchronizing state...")
+	for _, c := range del {
+		p.ReleaseResources(c)
+	}
+	for _, c := range add {
+		p.AllocateResources(c)
+	}
+	return nil
+}
+
+// AllocateResources is a resource allocation request for this policy.
+func (p *dynamicPools) AllocateResources(c cache.Container) error {
+	log.Debug("allocating resources for container %s...", c.PrettyName())
+	dp, err := p.allocateDynamicPool(c)
+	if err != nil {
+		return dynamicPoolsError("dynamicPool allocation for container %s failed: %w", c.PrettyName(), err)
+	}
+	if dp == nil {
+		return dynamicPoolsError("no suitable dynamicPools found for container %s", c.PrettyName())
+	}
+	log.Info("assigning container %s to dynamicPool %s", c.PrettyName(), dp)
+	podID := c.GetPodID()
+	dp.PodIDs[podID] = append(dp.PodIDs[podID], c.GetCacheID())
+	if dp.Cpus.Equals(p.reserved) {
+		p.assignContainer(c, dp)
+		log.Debugf("if dynamic pool is reserved, do not updatePoolCpuset.")
+	} else {
+		p.updatePoolCpuset()
+	}
+	if log.DebugEnabled() {
+		log.Debug(p.dumpDynamicPool(dp))
+	}
+	return nil
+}
+
+// ReleaseResources is a resource release request for this policy.
+func (p *dynamicPools) ReleaseResources(c cache.Container) error {
+	log.Debug("releasing container %s...", c.PrettyName())
+	dp := p.dynamicPoolByContainer(c)
+	if dp == nil {
+		log.Debug("ReleaseResources: dynamicPool-less container %s, nothing to release", c.PrettyName())
+		return nil
+	}
+	p.dismissContainer(c, dp)
+	if dp.Cpus.Equals(p.reserved) {
+		log.Debugf("if dynamic pool is reserved, do not updatePoolCpuset.")
+	} else {
+		p.updatePoolCpuset()
+	}
+	if log.DebugEnabled() {
+		log.Debug(p.dumpDynamicPool(dp))
+	}
+	return nil
+}
+
+// UpdateResources is a resource allocation update request for this policy.
+func (p *dynamicPools) UpdateResources(c cache.Container) error {
+	log.Debug("(not) updating container %s...", c.PrettyName())
+	return nil
+}
+
+// Rebalance tries to find an optimal allocation of resources for the current containers.
+func (p *dynamicPools) Rebalance() (bool, error) {
+	log.Debug("rebalancing containers...")
+	err := p.updatePoolCpuset()
+	return true, err
+}
+
+// HandleEvent handles policy-specific events.
+func (p *dynamicPools) HandleEvent(*events.Policy) (bool, error) {
+	log.Debug("(not) handling event...")
+	return false, nil
+}
+
+// ExportResourceData provides resource data to export for the container.
+func (p *dynamicPools) ExportResourceData(c cache.Container) map[string]string {
+	return nil
+}
+
+// Introspect provides data for external introspection.
+func (p *dynamicPools) Introspect(*introspect.State) {
+	return
+}
+
+// dynamicPoolByContainer returns a dynamicPool that contains a container.
+func (p *dynamicPools) dynamicPoolByContainer(c cache.Container) *DynamicPool {
+	podID := c.GetPodID()
+	cID := c.GetCacheID()
+	for _, dp := range p.dynamicPools {
+		for _, ctrID := range dp.PodIDs[podID] {
+			if ctrID == cID {
+				return dp
+			}
+		}
+	}
+	return nil
+}
+
+// dynamicPoolsByDef returns a dynamicPool instantiated from a dynamicPool definition.
+func (p *dynamicPools) dynamicPoolByDef(dpDef *DynamicPoolDef) *DynamicPool {
+	for _, dp := range p.dynamicPools {
+		if dp.Def == dpDef {
+			return dp
+		}
+	}
+	return nil
+}
+
+// dynamicPoolDefByName returns a dynamicPool definition with a name.
+func (p *dynamicPools) dynamicPoolDefByName(defName string) *DynamicPoolDef {
+	if defName == "reserved" {
+		return p.reservedDynamicPoolDef
+	}
+	if defName == "default" {
+		return p.defaultDynamicPoolDef
+	}
+	for _, dpDef := range p.dpoptions.DynamicPoolDefs {
+		if dpDef.Name == defName {
+			return dpDef
+		}
+	}
+	return nil
+}
+
+// chooseDynamicPoolDef returns the dynamicPoolDef selected by the container
+func (p *dynamicPools) chooseDynamicPoolDef(c cache.Container) (*DynamicPoolDef, error) {
+	var dpDef *DynamicPoolDef
+	// If the requests and limits of container are 0, they are assigned to the default dynamicPool.
+	if !namespaceMatches(c.GetNamespace(), append(p.dpoptions.ReservedPoolNamespaces, metav1.NamespaceSystem)) &&
+		p.containerRequestedMilliCpus(c.GetCacheID()) == 0 && p.containerLimitedMilliCpus(c.GetCacheID()) == 0 {
+		return p.defaultDynamicPoolDef, nil
+	}
+
+	// DynamicPoolDef is defined by annotation?
+	if dpDefName, ok := c.GetEffectiveAnnotation(dynamicPoolKey); ok {
+		dpDef = p.dynamicPoolDefByName(dpDefName)
+		if dpDef == nil {
+			return nil, dynamicPoolsError("no dynamicPool for annotation %q", dpDefName)
+		}
+		return dpDef, nil
+	}
+
+	// DynamicPoolDef is defined by a special namespace (kube-system +
+	// ReservedPoolNamespaces)?
+	if namespaceMatches(c.GetNamespace(), append(p.dpoptions.ReservedPoolNamespaces, metav1.NamespaceSystem)) {
+		return p.dynamicPools[0].Def, nil
+	}
+
+	// DynamicPoolDef is defined by the namespace?
+	for _, dpDef := range append([]*DynamicPoolDef{p.reservedDynamicPoolDef, p.defaultDynamicPoolDef},
+		p.dpoptions.DynamicPoolDefs...) {
+		if namespaceMatches(c.GetNamespace(), dpDef.Namespaces) {
+			return dpDef, nil
+		}
+	}
+	// Fallback to the default dynamicPool.
+	return p.defaultDynamicPoolDef, nil
+}
+
+func (p *dynamicPools) containerRequestedMilliCpus(contID string) int {
+	cont, ok := p.cch.LookupContainer(contID)
+	if !ok {
+		return 0
+	}
+	reqCpu, ok := cont.GetResourceRequirements().Requests[corev1.ResourceCPU]
+	if !ok {
+		return 0
+	}
+	return int(reqCpu.MilliValue())
+}
+
+func (p *dynamicPools) containerLimitedMilliCpus(contID string) int {
+	cont, ok := p.cch.LookupContainer(contID)
+	if !ok {
+		return 0
+	}
+	limitCpu, ok := cont.GetResourceRequirements().Limits[corev1.ResourceCPU]
+	if !ok {
+		return 0
+	}
+	return int(limitCpu.MilliValue())
+}
+
+// requestedMaxMilliCpus sums up and returns CPU limits of all
+// containers assigned to a dynamicPool.
+func (p *dynamicPools) requestedMaxMilliCpus(dp *DynamicPool) int {
+	cpuRequested := 0
+	for _, cID := range dp.ContainerIDs() {
+		cpuRequested += p.containerLimitedMilliCpus(cID)
+	}
+	return cpuRequested
+}
+
+// requestedMinMilliCpus sums up and returns CPU requests of all
+// containers assigned to a dynamicPool.
+func (p *dynamicPools) requestedMinMilliCpus(dp *DynamicPool) int {
+	cpuRequested := 0
+	for _, cID := range dp.ContainerIDs() {
+		cpuRequested += p.containerRequestedMilliCpus(cID)
+	}
+	return cpuRequested
+}
+
+// resetCpuClass resets CPU configurations globally. All dynamicPools can
+// be ignored, their CPU configurations will be applied later.
+func (p *dynamicPools) resetCpuClass() error {
+	// Usual inputs:
+	// - p.allowed (cpuset.CPUset): all CPUs available for this
+	//   policy.
+	// - p.IdleCpuClass (string): CPU class for allowed CPUs.
+	//
+	// Other inputs, if needed:
+	// - p.reserved (cpuset.CPUset): CPUs of ReservedResources
+	//   (typically for kube-system containers).
+	//
+	// Note: p.useCpuClass(dynamicPool) will be called before assigning
+	// containers on the dynamicPool, including the reserved dynamicPool.
+	cpucontrol.Assign(p.cch, p.dpoptions.IdleCpuClass, p.allowed.ToSliceNoSort()...)
+	log.Debugf("resetCpuClass available: %s; reserved: %s", p.allowed, p.reserved)
+	return nil
+}
+
+// useCpuClass configures CPUs of a dynamicPool.
+func (p *dynamicPools) useCpuClass(dp *DynamicPool) error {
+	// Usual inputs:
+	// - CPUs that cpuallocator has reserved for this dynamicPool:
+	//   dp.Cpus (cpuset.CPUSet).
+	// - User-defined CPU configuration for CPUs of dynamicPool of this type:
+	//   dp.Def.CpuClass (string).
+	// - Current configuration(?): feel free to add data
+	//   structure for this. For instance policy-global p.cpuConfs,
+	//   or dynamicPool-local dp.cpuConfs.
+	//
+	// Other input examples, if needed:
+	// - Requested CPU resources by all containers in the dynamicPool:
+	//   p.requestedMilliCpus(dp).
+	// - Free CPU resources in the dynamicPool: p.freeMilliCpus(dp).
+	// - Number of assigned containers: dp.ContainerCount().
+	// - Container details: access p.cch with dp.ContainerIDs().
+	// - User-defined CPU AllocatorPriority: dp.Def.AllocatorPriority.
+	// - All existing dynamicPool instances: p.dynamicPools.
+	// - CPU configurations by user: dp.Def.CpuClass (for dp in p.dynamicPools)
+	cpucontrol.Assign(p.cch, dp.Def.CpuClass, dp.Cpus.ToSliceNoSort()...)
+	log.Debugf("useCpuClass Cpus: %s; CpuClass: %s", dp.Cpus, dp.Def.CpuClass)
+	return nil
+}
+
+// forgetCpuClass is called when CPUs of a dynamicPool are released from duty.
+func (p *dynamicPools) forgetCpuClass(dp *DynamicPool) {
+	// Use p.IdleCpuClass for dp.Cpus.
+	// Usual inputs: see useCpuClass
+	// cpucontrol.Assign(p.cch, p.dpoptions.IdleCpuClass, dp.Cpus.ToSliceNoSort()...)
+	// Release CPUs to dafault dynamicPool.
+	cpucontrol.Assign(p.cch, p.dpoptions.IdleCpuClass, dp.Cpus.ToSliceNoSort()...)
+	log.Debugf("forgetCpuClass Cpus: %s; CpuClass: %s", dp.Cpus, dp.Def.CpuClass)
+}
+
+func (p *dynamicPools) newDynamicPool(dpDef *DynamicPoolDef, confCpus bool) (*DynamicPool, error) {
+	var cpus cpuset.CPUSet
+	var err error
+	if dpDef == p.reservedDynamicPoolDef {
+		cpus = p.reserved
+	} else {
+		cpus, err = p.cpuAllocator.AllocateCpus(&p.freeCpus, 0, dpDef.AllocatorPriority)
+
+		if err != nil {
+			return nil, dynamicPoolsError("could not allocate Cpus for dynamicPool %s: %w", dpDef.Name, err)
+		}
+	}
+	dp := &DynamicPool{
+		Def:    dpDef,
+		PodIDs: make(map[string][]string),
+		Cpus:   cpus,
+		Mems:   p.closestMems(cpus),
+	}
+	if confCpus {
+		if err = p.useCpuClass(dp); err != nil {
+			log.Errorf("failed to apply CPU configuration to new dynamicPool %s (cpus: %s): %w", dpDef.Name, cpus, err)
+			return nil, err
+		}
+	}
+	return dp, nil
+}
+
+func namespaceMatches(namespace string, patterns []string) bool {
+	for _, pattern := range patterns {
+		ret, err := filepath.Match(pattern, namespace)
+		if err == nil && ret {
+			return true
+		}
+	}
+	return false
+}
+
+// allocateDynamicPool returns a dynamicPool allocated for a container.
+func (p *dynamicPools) allocateDynamicPool(c cache.Container) (*DynamicPool, error) {
+	dpDef, err := p.chooseDynamicPoolDef(c)
+	if err != nil {
+		return nil, err
+	}
+	if dpDef == nil {
+		return nil, dynamicPoolsError("no applicable dynamicPool type found")
+	}
+	dynamicPool := p.dynamicPoolByDef(dpDef)
+	if dynamicPool == nil {
+		return nil, dynamicPoolsError("no suitable dynamicPool instance available")
+	}
+	return dynamicPool, err
+}
+
+// dumpDynamicPool dumps dynamicPool contents in detail.
+func (p *dynamicPools) dumpDynamicPool(dp *DynamicPool) string {
+	conts := []string{}
+	pods := []string{}
+	for podID, contIDs := range dp.PodIDs {
+		podName := podID
+		if pod, ok := p.cch.LookupPod(podID); ok {
+			podName = pod.GetName()
+		}
+		pods = append(pods, podName)
+		for _, contID := range contIDs {
+			if cont, ok := p.cch.LookupContainer(contID); ok {
+				conts = append(conts, cont.PrettyName())
+			} else {
+				conts = append(conts, podName+"."+contID)
+			}
+		}
+	}
+	s := fmt.Sprintf("DynamicPool %s{Cpus: %s; Mems: %s; mCPU requests: %d; mCPU limits: %d; capacity: %d; pods: %s; conts: %s}",
+		dp.PrettyName(),
+		dp.Cpus,
+		dp.Mems,
+		p.requestedMinMilliCpus(dp),
+		p.requestedMaxMilliCpus(dp),
+		dp.AvailMilliCpus(),
+		pods,
+		conts)
+	return s
+}
+
+// changesDynamicPools returns true if two dynamicPools policy configurations
+// may lead into different dynamicPools or workload assignment.
+func changesDynamicPools(opts0, opts1 *DynamicPoolsOptions) bool {
+	if opts0 == nil && opts1 == nil {
+		return false
+	}
+	if opts0 == nil || opts1 == nil {
+		return true
+	}
+	if len(opts0.DynamicPoolDefs) != len(opts1.DynamicPoolDefs) {
+		return true
+	}
+	o0 := opts0.DeepCopy()
+	o1 := opts1.DeepCopy()
+	// Ignore differences in CPU class names. Every other change
+	// potentially changes dynamicPools or workloads.
+	o0.IdleCpuClass = ""
+	o1.IdleCpuClass = ""
+	for i := range o0.DynamicPoolDefs {
+		o0.DynamicPoolDefs[i].CpuClass = ""
+		o1.DynamicPoolDefs[i].CpuClass = ""
+	}
+	return utils.DumpJSON(o0) != utils.DumpJSON(o1)
+}
+
+// changesCpuClasses returns true if two dynamicPools policy
+// configurations can lead to using different CPU classes on
+// corresponding dynamicPool instances. Calling changesCpuClasses(o0, o1)
+// makes sense only if changesDynamicPools(o0, o1) has returned false.
+func changesCpuClasses(opts0, opts1 *DynamicPoolsOptions) bool {
+	if opts0 == nil && opts1 == nil {
+		return false
+	}
+	if opts0 == nil || opts1 == nil {
+		return true
+	}
+	if opts0.IdleCpuClass != opts1.IdleCpuClass {
+		return true
+	}
+	if len(opts0.DynamicPoolDefs) != len(opts1.DynamicPoolDefs) {
+		return true
+	}
+	for i := range opts0.DynamicPoolDefs {
+		if opts0.DynamicPoolDefs[i].CpuClass != opts1.DynamicPoolDefs[i].CpuClass {
+			return true
+		}
+	}
+	return false
+}
+
+// configNotify applies new configuration.
+func (p *dynamicPools) configNotify(event pkgcfg.Event, source pkgcfg.Source) error {
+	log.Info("configuration %s", event)
+	defer log.Debug("effective configuration:\n%s\n", utils.DumpJSON(p.dpoptions))
+	newDynamicPoolsOptions := dynamicPoolsOptions.DeepCopy()
+	if !changesDynamicPools(&p.dpoptions, newDynamicPoolsOptions) {
+		if !changesCpuClasses(&p.dpoptions, newDynamicPoolsOptions) {
+			log.Info("no configuration changes")
+		} else {
+			log.Info("configuration changes only on CPU classes")
+			// Update new CPU classes to existing DynamicPool
+			// definitions. The same DynamicPoolDef instances
+			// must be kept in use, because each dynamicPool
+			// instance holds a direct reference to its
+			// DynamicPoolDef.
+			for i := range p.dpoptions.DynamicPoolDefs {
+				p.dpoptions.DynamicPoolDefs[i].CpuClass = newDynamicPoolsOptions.DynamicPoolDefs[i].CpuClass
+			}
+			// (Re)configures all CPUs in DynamicPools.
+			p.resetCpuClass()
+			for _, dp := range p.dynamicPools {
+				p.useCpuClass(dp)
+			}
+		}
+		return nil
+	}
+	if err := p.setConfig(newDynamicPoolsOptions); err != nil {
+		log.Error("config update failed: %v", err)
+		return err
+	}
+	log.Info("config updated successfully")
+	p.Sync(p.cch.GetContainers(), p.cch.GetContainers())
+	return nil
+}
+
+// applyDynamicPoolDef creates user-defined dynamicPools or reconfigures built-in
+// dynamicPools according to the dpDef. Does not initialize dynamicPool CPUs.
+func (p *dynamicPools) applyDynamicPoolDef(dynamicPools *[]*DynamicPool, dpDef *DynamicPoolDef) error {
+	if len(*dynamicPools) < 2 {
+		return dynamicPoolsError("internal error: reserved and default dynamicPools missing, cannot apply dynamicPool definitions")
+	}
+	reservedDynamicPool := (*dynamicPools)[0]
+	defaultDynamicPool := (*dynamicPools)[1]
+	// Every dynamicPoolDef does one of the following:
+	// 1. reconfigures the "reserved" dynamicPool (most restricted)
+	// 2. reconfigures the "default" dynamicPool (somewhat restricted)
+	// 3. defines new user-defined dynamicPool.
+	switch dpDef.Name {
+	case "":
+		// Case 0: bad name
+		return dynamicPoolsError("undefined or empty dynamicPool name")
+	case reservedDynamicPool.Def.Name:
+		// Case 1: reconfigure the "reserved" dynamicPool.
+		p.reservedDynamicPoolDef.AllocatorPriority = dpDef.AllocatorPriority
+		p.reservedDynamicPoolDef.CpuClass = dpDef.CpuClass
+		p.reservedDynamicPoolDef.Namespaces = dpDef.Namespaces
+	case defaultDynamicPool.Def.Name:
+		// Case 2: reconfigure the "default" dynamicPool.
+		p.defaultDynamicPoolDef.AllocatorPriority = dpDef.AllocatorPriority
+		p.defaultDynamicPoolDef.CpuClass = dpDef.CpuClass
+		p.defaultDynamicPoolDef.Namespaces = dpDef.Namespaces
+	default:
+		// Case 3: create each user-defined dynamicPool without CPU.
+		newdp, err := p.newDynamicPool(dpDef, false)
+		if err != nil {
+			return err
+		}
+		*dynamicPools = append(*dynamicPools, newdp)
+	}
+	return nil
+}
+
+// setConfig takes new dynamicPool configuration into use.
+func (p *dynamicPools) setConfig(dpoptions *DynamicPoolsOptions) error {
+	// Create the default reserved and default dynamicPool
+	// definitions. Some properties of these definitions may be
+	// altered by user configuration.
+	p.reservedDynamicPoolDef = &DynamicPoolDef{
+		Name:              reservedDynamicPoolDefName,
+		AllocatorPriority: 3,
+	}
+	p.defaultDynamicPoolDef = &DynamicPoolDef{
+		Name:              defaultDynamicPoolDefName,
+		AllocatorPriority: 3,
+	}
+	p.dynamicPools = []*DynamicPool{}
+	p.freeCpus = p.allowed.Clone()
+	p.freeCpus = p.freeCpus.Difference(p.reserved)
+	// Instantiate built-in reserved and default dynamicPool.
+	reservedDynamicPool, err := p.newDynamicPool(p.reservedDynamicPoolDef, false)
+	if err != nil {
+		return err
+	}
+	p.dynamicPools = append(p.dynamicPools, reservedDynamicPool)
+	defaultDynamicPool, err := p.newDynamicPool(p.defaultDynamicPoolDef, false)
+	if err != nil {
+		return err
+	}
+	p.dynamicPools = append(p.dynamicPools, defaultDynamicPool)
+	// First apply customizations to built-in dynamicPools: "reserved"
+	// and "default".
+	for _, dpDef := range dpoptions.DynamicPoolDefs {
+		if dpDef.Name != reservedDynamicPoolDefName && dpDef.Name != defaultDynamicPoolDefName {
+			continue
+		}
+		if err := p.applyDynamicPoolDef(&p.dynamicPools, dpDef); err != nil {
+			return err
+		}
+	}
+	// Apply all user dynamicPool definitions, skip already customized
+	// "reserved" and "default" dynamicPools.
+	for _, dpDef := range dpoptions.DynamicPoolDefs {
+		if dpDef.Name == reservedDynamicPoolDefName || dpDef.Name == defaultDynamicPoolDefName {
+			continue
+		}
+		if err := p.applyDynamicPoolDef(&p.dynamicPools, dpDef); err != nil {
+			return err
+		}
+	}
+	// Finish dynamicPool initialization.
+	log.Info("%s policy dynamicPools:", PolicyName)
+	for dpIdx, dp := range p.dynamicPools {
+		log.Info("- dynamicPool %d: %s", dpIdx, dp)
+	}
+	// No errors in dynamicPool creation, take new configuration into use.
+	p.dpoptions = *dpoptions
+	// (Re)configures all CPUs in dynamicPools.
+	p.resetCpuClass()
+	for _, dp := range p.dynamicPools {
+		p.useCpuClass(dp)
+	}
+	return nil
+}
+
+// closestMems returns memory node IDs good for pinning containers
+// that run on given CPUs.
+func (p *dynamicPools) closestMems(cpus cpuset.CPUSet) idset.IDSet {
+	mems := idset.NewIDSet()
+	sys := p.options.System
+	for _, nodeID := range sys.NodeIDs() {
+		if !cpus.Intersection(sys.Node(nodeID).CPUSet()).IsEmpty() {
+			mems.Add(nodeID)
+		}
+	}
+	return mems
+}
+
+// assignContainer adds a container to a dynamicPool.
+func (p *dynamicPools) assignContainer(c cache.Container, dp *DynamicPool) {
+	log.Info("assigning container %s to dynamicPool %s", c.PrettyName(), dp)
+	podID := c.GetPodID()
+	dp.PodIDs[podID] = append(dp.PodIDs[podID], c.GetCacheID())
+	p.pinCpuMem(c, dp.Cpus, dp.Mems)
+}
+
+// dismissContainer removes a container from a dynamicPool.
+func (p *dynamicPools) dismissContainer(c cache.Container, dp *DynamicPool) {
+	podID := c.GetPodID()
+	dp.PodIDs[podID] = removeString(dp.PodIDs[podID], c.GetCacheID())
+	if len(dp.PodIDs[podID]) == 0 {
+		delete(dp.PodIDs, podID)
+	}
+}
+
+// pinCpuMem pins container to CPUs and memory nodes if flagged.
+func (p *dynamicPools) pinCpuMem(c cache.Container, cpus cpuset.CPUSet, mems idset.IDSet) {
+	if p.dpoptions.PinCPU == nil || *p.dpoptions.PinCPU {
+		log.Debug("  - pinning %s to cpuset: %s", c.PrettyName(), cpus)
+		c.SetCpusetCpus(cpus.String())
+		if reqCpu, ok := c.GetResourceRequirements().Requests[corev1.ResourceCPU]; ok {
+			mCpu := int(reqCpu.MilliValue())
+			c.SetCPUShares(int64(cache.MilliCPUToShares(mCpu)))
+		}
+	}
+	if p.dpoptions.PinMemory == nil || *p.dpoptions.PinMemory {
+		log.Debug("  - pinning %s to memory %s", c.PrettyName(), mems)
+		c.SetCpusetMems(mems.String())
+	}
+}
+
+// dynamicPoolsError formats an error from this policy.
+func dynamicPoolsError(format string, args ...interface{}) error {
+	return fmt.Errorf(PolicyName+": "+format, args...)
+}
+
+// removeString returns the first occurrence of a string from string slice.
+func removeString(strings []string, element string) []string {
+	for index, s := range strings {
+		if s == element {
+			strings[index] = strings[len(strings)-1]
+			return strings[:len(strings)-1]
+		}
+	}
+	return strings
+}
+
+// Register us as a policy implementation.
+func init() {
+	policy.Register(PolicyName, PolicyDescription, CreateDynamicPoolsPolicy)
+}

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
@@ -16,6 +16,8 @@ package dyp
 
 import (
 	"testing"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 func TestChangesDynamicPools(t *testing.T) {
@@ -72,6 +74,277 @@ func TestChangesDynamicPools(t *testing.T) {
 			value := changesDynamicPools(tc.opts1, tc.opts2)
 			if value != tc.expectedValue {
 				t.Errorf("Expected return value %v but got %v", tc.expectedValue, value)
+			}
+		})
+	}
+}
+
+func TestIsNeedReallocate(t *testing.T) {
+	p := &dynamicPools{
+		dynamicPools: []*DynamicPool{
+			{
+				Def: &DynamicPoolDef{
+					Name: reservedDynamicPoolDefName,
+				},
+				Cpus: cpuset.NewCPUSet(1, 2),
+			},
+			{
+				Def: &DynamicPoolDef{
+					Name: sharedDynamicPoolDefName,
+				},
+				Cpus: cpuset.NewCPUSet(3, 4, 5, 6),
+			},
+			{
+				Def: &DynamicPoolDef{
+					Name: "poo1",
+				},
+				Cpus: cpuset.NewCPUSet(7, 8, 9, 10, 11, 12),
+			},
+			{
+				Def: &DynamicPoolDef{
+					Name: "poo2",
+				},
+				Cpus: cpuset.NewCPUSet(0),
+			},
+		},
+	}
+	tcases := []struct {
+		name          string
+		newPoolCpu    map[*DynamicPool]int
+		expectedValue bool
+	}{
+		{
+			name: "no need to reallocate",
+			newPoolCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 4,
+				p.dynamicPools[2]: 6,
+				p.dynamicPools[3]: 1,
+			},
+			expectedValue: false,
+		},
+		{
+			name: "need to reallocate",
+			newPoolCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 6,
+				p.dynamicPools[2]: 4,
+				p.dynamicPools[3]: 1,
+			},
+			expectedValue: true,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := p.isNeedReallocate(tc.newPoolCpu)
+			if value != tc.expectedValue {
+				t.Errorf("Expected return value %v but got %v", tc.expectedValue, value)
+			}
+		})
+	}
+}
+
+func TestCalculatePoolCpuset(t *testing.T) {
+	p := &dynamicPools{
+		allowed:  cpuset.NewCPUSet(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+		reserved: cpuset.NewCPUSet(1, 2),
+		dynamicPools: []*DynamicPool{
+			{
+				Def: &DynamicPoolDef{
+					Name: reservedDynamicPoolDefName,
+				},
+				Cpus: cpuset.NewCPUSet(1, 2),
+			},
+			{
+				Def: &DynamicPoolDef{
+					Name: sharedDynamicPoolDefName,
+				},
+				Cpus: cpuset.NewCPUSet(3, 4, 5, 6),
+			},
+			{
+				Def: &DynamicPoolDef{
+					Name: "poo1",
+				},
+				Cpus: cpuset.NewCPUSet(7, 8, 9, 10, 11, 12, 13),
+			},
+			{
+				Def: &DynamicPoolDef{
+					Name: "poo2",
+				},
+				Cpus: cpuset.NewCPUSet(0),
+			},
+		},
+	}
+	tcases := []struct {
+		name          string
+		requestCpu    map[*DynamicPool]int
+		remainFree    int
+		weight        map[*DynamicPool]float64
+		sumWeight     float64
+		expectedValue map[*DynamicPool]int
+	}{
+		{
+			name:       "The requests and weight of the dynamic pools are both nil",
+			requestCpu: map[*DynamicPool]int{},
+			remainFree: 12,
+			weight:     map[*DynamicPool]float64{},
+			sumWeight:  0.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 12,
+				p.dynamicPools[2]: 0,
+				p.dynamicPools[3]: 0,
+			},
+		},
+		{
+			name: "The requests of the dynamic pools is not nil, and the requests of the shared dynamic pools is 0",
+			requestCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 1,
+				p.dynamicPools[1]: 0,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+			remainFree: 8,
+			weight:     map[*DynamicPool]float64{},
+			sumWeight:  0.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 8,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+		},
+		{
+			name: "The requests of the dynamic pools is not nil, and the requests of the shared dynamic pools is not 0",
+			requestCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 1,
+				p.dynamicPools[1]: 2,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+			remainFree: 6,
+			weight:     map[*DynamicPool]float64{},
+			sumWeight:  0.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 8,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+		},
+		{
+			name:       "The weight of the dynamic pools is not nil, and the weight of the shared dynamic pools is not 0",
+			requestCpu: map[*DynamicPool]int{},
+			remainFree: 12,
+			weight: map[*DynamicPool]float64{
+				p.dynamicPools[0]: 10.0,
+				p.dynamicPools[1]: 100.0,
+				p.dynamicPools[2]: 200.0,
+				p.dynamicPools[3]: 100.0,
+			},
+			sumWeight: 400.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 3,
+				p.dynamicPools[2]: 6,
+				p.dynamicPools[3]: 3,
+			},
+		},
+		{
+			name:       "The weight of the dynamic pools is not nil, and the weight of the shared dynamic pools is 0",
+			requestCpu: map[*DynamicPool]int{},
+			remainFree: 12,
+			weight: map[*DynamicPool]float64{
+				p.dynamicPools[0]: 10.0,
+				p.dynamicPools[1]: 0.0,
+				p.dynamicPools[2]: 200.0,
+				p.dynamicPools[3]: 100.0,
+			},
+			sumWeight: 300.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 1,
+				p.dynamicPools[2]: 8,
+				p.dynamicPools[3]: 3,
+			},
+		},
+		{
+			name: "The requests and weight of the dynamic pools are not nil, and the requests of the shared dynamic pools is 0",
+			requestCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 1,
+				p.dynamicPools[1]: 0,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+			remainFree: 8,
+			weight: map[*DynamicPool]float64{
+				p.dynamicPools[0]: 10.0,
+				p.dynamicPools[1]: 100.0,
+				p.dynamicPools[2]: 200.0,
+				p.dynamicPools[3]: 100.0,
+			},
+			sumWeight: 400.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 2,
+				p.dynamicPools[2]: 6,
+				p.dynamicPools[3]: 4,
+			},
+		},
+		{
+			name: "The requests and weight of the dynamic pools are not nil, and the weight of the shared dynamic pools is 0",
+			requestCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 1,
+				p.dynamicPools[1]: 1,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+			remainFree: 7,
+			weight: map[*DynamicPool]float64{
+				p.dynamicPools[0]: 10.0,
+				p.dynamicPools[1]: 0.0,
+				p.dynamicPools[2]: 200.0,
+				p.dynamicPools[3]: 100.0,
+			},
+			sumWeight: 300.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 1,
+				p.dynamicPools[2]: 7,
+				p.dynamicPools[3]: 4,
+			},
+		},
+		{
+			name: "The requests and weight of the dynamic pools are not nil, and the requests and weight of the shared dynamic pools are both 0",
+			requestCpu: map[*DynamicPool]int{
+				p.dynamicPools[0]: 1,
+				p.dynamicPools[1]: 0,
+				p.dynamicPools[2]: 2,
+				p.dynamicPools[3]: 2,
+			},
+			remainFree: 8,
+			weight: map[*DynamicPool]float64{
+				p.dynamicPools[0]: 10.0,
+				p.dynamicPools[1]: 0.0,
+				p.dynamicPools[2]: 200.0,
+				p.dynamicPools[3]: 100.0,
+			},
+			sumWeight: 300.0,
+			expectedValue: map[*DynamicPool]int{
+				p.dynamicPools[0]: 2,
+				p.dynamicPools[1]: 1,
+				p.dynamicPools[2]: 7,
+				p.dynamicPools[3]: 4,
+			},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := p.calculatePoolCpuset(tc.requestCpu, tc.remainFree, tc.weight, tc.sumWeight)
+			for k, v := range value {
+				if v != tc.expectedValue[k] {
+					t.Errorf("dynamic pool %v Expected return value %v but got %v", k, tc.expectedValue[k], v)
+				}
 			}
 		})
 	}

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dyp
+
+import (
+	"testing"
+)
+
+func TestChangesDynamicPools(t *testing.T) {
+	tcases := []struct {
+		name          string
+		opts1         *DynamicPoolsOptions
+		opts2         *DynamicPoolsOptions
+		expectedValue bool
+	}{
+		{
+			name:          "both options are nil",
+			expectedValue: false,
+		},
+		{
+			name:          "one option is nil",
+			opts2:         &DynamicPoolsOptions{},
+			expectedValue: true,
+		},
+		{
+			name: "reserved pool namespaces differ by len",
+			opts1: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
+			},
+			opts2: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{},
+			},
+			expectedValue: true,
+		},
+		{
+			name: "reserved pool namespaces differ by content",
+			opts1: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
+			},
+			opts2: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns1"},
+			},
+			expectedValue: true,
+		},
+		{
+			name: "idle cpu classes differ",
+			opts1: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
+			},
+			opts2: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc1",
+				ReservedPoolNamespaces: []string{"ns0"},
+			},
+			expectedValue: false,
+		},
+		{
+			name: "balloon defs differ",
+			opts1: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc0",
+				ReservedPoolNamespaces: []string{"ns0"},
+				DynamicPoolDefs:        []*DynamicPoolDef{},
+			},
+			opts2: &DynamicPoolsOptions{
+				IdleCpuClass:           "icc1",
+				ReservedPoolNamespaces: []string{"ns0"},
+				DynamicPoolDefs:        []*DynamicPoolDef{},
+			},
+			expectedValue: false,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := changesDynamicPools(tc.opts1, tc.opts2)
+			if value != tc.expectedValue {
+				t.Errorf("Expected return value %v but got %v", tc.expectedValue, value)
+			}
+		})
+	}
+}

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
@@ -37,11 +37,9 @@ func TestChangesDynamicPools(t *testing.T) {
 		{
 			name: "reserved pool namespaces differ by len",
 			opts1: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc0",
 				ReservedPoolNamespaces: []string{"ns0"},
 			},
 			opts2: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc0",
 				ReservedPoolNamespaces: []string{},
 			},
 			expectedValue: true,
@@ -49,40 +47,24 @@ func TestChangesDynamicPools(t *testing.T) {
 		{
 			name: "reserved pool namespaces differ by content",
 			opts1: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc0",
 				ReservedPoolNamespaces: []string{"ns0"},
 			},
 			opts2: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc0",
 				ReservedPoolNamespaces: []string{"ns1"},
 			},
 			expectedValue: true,
 		},
 		{
-			name: "idle cpu classes differ",
+			name: "dynamic-pool defs differ",
 			opts1: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc0",
-				ReservedPoolNamespaces: []string{"ns0"},
-			},
-			opts2: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc1",
-				ReservedPoolNamespaces: []string{"ns0"},
-			},
-			expectedValue: false,
-		},
-		{
-			name: "balloon defs differ",
-			opts1: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc0",
 				ReservedPoolNamespaces: []string{"ns0"},
 				DynamicPoolDefs:        []*DynamicPoolDef{},
 			},
 			opts2: &DynamicPoolsOptions{
-				IdleCpuClass:           "icc1",
-				ReservedPoolNamespaces: []string{"ns0"},
+				ReservedPoolNamespaces: []string{"ns1"},
 				DynamicPoolDefs:        []*DynamicPoolDef{},
 			},
-			expectedValue: false,
+			expectedValue: true,
 		},
 	}
 	for _, tc := range tcases {

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/flags.go
@@ -31,9 +31,6 @@ type dynamicPoolsOptionsWrapped struct {
 	PinCPU *bool `json:"PinCPU,omitempty"`
 	// PinMemory controls pinning containers to memory nodes.
 	PinMemory *bool `json:"PinMemory,omitempty"`
-	// IdleCpuClass controls how unusded CPUs outside any a
-	// dynamicPool are (re)configured.
-	IdleCpuClass string `json:"IdleCPUClass",omitempty"`
 	// ReservedPoolNamespaces is a list of namespace globs that
 	// will be allocated to reserved CPUs.
 	ReservedPoolNamespaces []string `json:"ReservedPoolNamespaces,omitempty"`
@@ -44,7 +41,7 @@ type dynamicPoolsOptionsWrapped struct {
 // DynamicPoolDef contains a dynamicPool definition.
 type DynamicPoolDef struct {
 	// Name of the dynamicPool definition.
-	Name string `json:"Name"`
+	Name       string   `json:"Name"`
 	Namespaces []string `json:"Namespaces",omitempty`
 	CpuClass   string   `json:"CpuClass"`
 	// AllocatorPriority (0: High, 1: Normal, 2: Low, 3: None)

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/flags.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dyp
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
+)
+
+type DynamicPoolsOptions dynamicPoolsOptionsWrapped
+
+// dynamicPoolsOptions contains configuration options specific to this policy.
+type dynamicPoolsOptionsWrapped struct {
+	// PinCPU controls pinning containers to CPUs.
+	PinCPU *bool `json:"PinCPU,omitempty"`
+	// PinMemory controls pinning containers to memory nodes.
+	PinMemory *bool `json:"PinMemory,omitempty"`
+	// IdleCpuClass controls how unusded CPUs outside any a
+	// dynamicPool are (re)configured.
+	IdleCpuClass string `json:"IdleCPUClass",omitempty"`
+	// ReservedPoolNamespaces is a list of namespace globs that
+	// will be allocated to reserved CPUs.
+	ReservedPoolNamespaces []string `json:"ReservedPoolNamespaces,omitempty"`
+	// DynamicPoolDefs contains dynamicPool type definitions.
+	DynamicPoolDefs []*DynamicPoolDef `json:"DynamicPoolTypes,omitempty"`
+}
+
+// DynamicPoolDef contains a dynamicPool definition.
+type DynamicPoolDef struct {
+	// Name of the dynamicPool definition.
+	Name string `json:"Name"`
+	Namespaces []string `json:"Namespaces",omitempty`
+	CpuClass   string   `json:"CpuClass"`
+	// AllocatorPriority (0: High, 1: Normal, 2: Low, 3: None)
+	// This parameter is passed to CPU allocator when creating or
+	// resizing a dynamicPool. At init, dynamicPools with highest priority
+	// CPUs are allocated first.
+	AllocatorPriority cpuallocator.CPUPriority `json:"AllocatorPriority"`
+}
+
+var defaultPinCPU bool = true
+var defaultPinMemory bool = true
+
+// DeepCopy creates a deep copy of a DynamicPoolsOptions
+func (dpo *DynamicPoolsOptions) DeepCopy() *DynamicPoolsOptions {
+	outDpo := *dpo
+	outDpo.ReservedPoolNamespaces = make([]string, len(dpo.ReservedPoolNamespaces))
+	copy(outDpo.ReservedPoolNamespaces, dpo.ReservedPoolNamespaces)
+	outDpo.DynamicPoolDefs = make([]*DynamicPoolDef, len(dpo.DynamicPoolDefs))
+	for i := range dpo.DynamicPoolDefs {
+		outDpo.DynamicPoolDefs[i] = dpo.DynamicPoolDefs[i].DeepCopy()
+	}
+	return &outDpo
+}
+
+// String stringifies a DynamicPoolsDef
+func (dpDef DynamicPoolDef) String() string {
+	return dpDef.Name
+}
+
+// DeepCopy creates a deep copy of a DynamicPoolDef
+func (bdef *DynamicPoolDef) DeepCopy() *DynamicPoolDef {
+	outBdef := *bdef
+	outBdef.Namespaces = make([]string, len(bdef.Namespaces))
+	copy(outBdef.Namespaces, bdef.Namespaces)
+	return &outBdef
+}
+
+// defaultDynamicPoolsOptions returns a new DynamicPoolsOptions instance, all initialized to defaults.
+func defaultDynamicPoolsOptions() interface{} {
+	return &DynamicPoolsOptions{
+		ReservedPoolNamespaces: []string{metav1.NamespaceSystem},
+		PinCPU:                 &defaultPinCPU,
+		PinMemory:              &defaultPinMemory,
+	}
+}
+
+// Our runtime configuration.
+var dynamicPoolsOptions = defaultDynamicPoolsOptions().(*DynamicPoolsOptions)
+
+// UnmarshalJSON makes sure all options from previous unmarshals get
+// cleared before unmarshaling new data to the same address.
+func (bo *DynamicPoolsOptions) UnmarshalJSON(data []byte) error {
+	bow := dynamicPoolsOptionsWrapped{}
+	if err := json.Unmarshal(data, &bow); err != nil {
+		return err
+	}
+	*bo = DynamicPoolsOptions(bow)
+	return nil
+}
+
+// Register us for configuration handling.
+func init() {
+	pkgcfg.Register(PolicyPath, PolicyDescription, dynamicPoolsOptions, defaultDynamicPoolsOptions)
+}

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/metrics.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/metrics.go
@@ -1,0 +1,127 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dyp
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+// Prometheus Metric descriptor indices and descriptor table
+const (
+	dynamicPoolsDesc = iota
+)
+
+var descriptors = []*prometheus.Desc{
+	dynamicPoolsDesc: prometheus.NewDesc(
+		"DynamicPools",
+		"CPUs",
+		[]string{
+			"dynamicPool_type",
+			"cpu_class",
+			"dynamicPool",
+			"cpus",
+			"mems",
+			"containers",
+			"tot_req_millicpu",
+			"tot_limit_millicpu",
+		}, nil,
+	),
+}
+
+// Metrics defines the dynamicPools-specific metrics from policy level.
+type Metrics struct {
+	DynamicPools []*DynamicPoolMetrics
+}
+
+// DynamicPoolMetrics define metrics of a dynamicPool instance.
+type DynamicPoolMetrics struct {
+	// dynamicPool type metrics
+	DefName  string
+	CpuClass string
+	// DynamicPool instance metrics
+	PrettyName              string
+	Cpus                    cpuset.CPUSet
+	Mems                    string
+	ContainerNames          string
+	ContainerReqMilliCpus   int
+	ContainerLimitMilliCpus int
+}
+
+// DescribeMetrics generates policy-specific prometheus metrics data
+// descriptors.
+func (p *dynamicPools) DescribeMetrics() []*prometheus.Desc {
+	return descriptors
+}
+
+// PollMetrics provides policy metrics for monitoring.
+func (p *dynamicPools) PollMetrics() policy.Metrics {
+	policyMetrics := &Metrics{}
+	policyMetrics.DynamicPools = make([]*DynamicPoolMetrics, len(p.dynamicPools))
+	for index, dp := range p.dynamicPools {
+		dm := &DynamicPoolMetrics{}
+		policyMetrics.DynamicPools[index] = dm
+		dm.DefName = dp.Def.Name
+		dm.CpuClass = dp.Def.CpuClass
+		dm.PrettyName = dp.PrettyName()
+		dm.Cpus = dp.Cpus
+		dm.Mems = dp.Mems.String()
+		cNames := []string{}
+		// Get container names, total requested milliCPUs and total limit milliCPUs.
+		for _, containerIDs := range dp.PodIDs {
+			for _, containerID := range containerIDs {
+				if c, ok := p.cch.LookupContainer(containerID); ok {
+					cNames = append(cNames, c.PrettyName())
+					dm.ContainerReqMilliCpus += p.containerRequestedMilliCpus(containerID)
+					dm.ContainerLimitMilliCpus += p.containerLimitedMilliCpus(containerID)
+				}
+			}
+		}
+		sort.Strings(cNames)
+		dm.ContainerNames = strings.Join(cNames, ",")
+	}
+
+	return policyMetrics
+}
+
+// CollectMetrics generates prometheus metrics from cached/polled
+// policy-specific metrics data.
+func (p *dynamicPools) CollectMetrics(m policy.Metrics) ([]prometheus.Metric, error) {
+	metrics, ok := m.(*Metrics)
+	if !ok {
+		return nil, dynamicPoolsError("type mismatch in dynamicPools metrics")
+	}
+	promMetrics := make([]prometheus.Metric, len(metrics.DynamicPools))
+	for index, dm := range metrics.DynamicPools {
+		promMetrics[index] = prometheus.MustNewConstMetric(
+			descriptors[dynamicPoolsDesc],
+			prometheus.GaugeValue,
+			float64(dm.Cpus.Size()),
+			dm.DefName,
+			dm.CpuClass,
+			dm.PrettyName,
+			dm.Cpus.String(),
+			dm.Mems,
+			dm.ContainerNames,
+			strconv.Itoa(dm.ContainerReqMilliCpus),
+			strconv.Itoa(dm.ContainerLimitMilliCpus))
+	}
+	return promMetrics, nil
+}

--- a/test/e2e/policies.test-suite/dynamic-pools/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/dynamic-pools/cri-resmgr.cfg
@@ -1,0 +1,39 @@
+policy:
+  Active: dynamic-pools
+  # Use only 15 CPUs in total, leave cpu0 for other than Kubernetes
+  # processes.
+  AvailableResources:
+    CPU: cpuset:1-15
+  # Reserve one of our CPUs for kube-system tasks.
+  ReservedResources:
+    CPU: 1
+  dynamic-pools:
+    PinCPU: true
+    PinMemory: true
+    DynamicPoolTypes:
+      - Name: "pool1"
+        Namespaces:
+          - "pool1"
+        CPUClass: "pool1-cpuclass"
+      - Name: "pool2"
+        Namespaces:
+          - "pool2"
+        CPUClass: "pool2-cpuclass"
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true
+cpu:
+  classes:
+    default:
+      minFreq: 800
+      maxFreq: 2800
+    pool1-cpuclass:
+      minFreq: 900
+      maxFreq: 2900
+    pool2-cpuclass:
+      minFreq: 1000
+      maxFreq: 3000

--- a/test/e2e/policies.test-suite/dynamic-pools/dyp-busybox.yaml.in
+++ b/test/e2e/policies.test-suite/dynamic-pools/dyp-busybox.yaml.in
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${NAME}
+  $(if [ -n "$POD_ANNOTATION" ]; then echo "
+  annotations:
+    $POD_ANNOTATION
+  "; fi)
+  labels:
+    app: ${NAME}
+spec:
+  containers:
+  $(for contnum in $(seq 1 ${CONTCOUNT}); do echo "
+  - name: ${NAME}c$(( contnum - 1 ))
+    image: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -c
+      - ${WORK}echo ${NAME}c$(( contnum - 1 )) \$(sleep inf)
+    $(if [ -n "${CPUREQ}" ]; then echo "
+    resources:
+      requests:
+        cpu: ${CPUREQ}
+        $(if [ -n "${MEMREQ}" ]; then echo "
+        memory: '${MEMREQ}'
+        "; fi)
+      $(if [ -n "${CPULIM}" ]; then echo "
+      limits:
+        cpu: ${CPULIM}
+        $(if [ -n "$MEMLIM" ]; then echo "
+        memory: '${MEMLIM}'
+        "; fi)
+    "; fi)
+    "; fi)
+  "; done )
+  terminationGracePeriodSeconds: 1

--- a/test/e2e/policies.test-suite/dynamic-pools/dyp-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/dynamic-pools/dyp-configmap.yaml.in
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cri-resmgr-config.default
+  namespace: kube-system
+data:
+  policy: |+
+    Active: dynamic-pools
+    AvailableResources:
+      CPU: ${AVAILABLE_CPU:-cpuset:0-15}
+    ReservedResources:
+      CPU: ${RESERVED_CPU:-1}
+
+    dynamic-pools:
+      PinCPU: ${PINCPU:-true}
+      PinMemory: ${PINMEMORY:-true}
+      DynamicPoolTypes:
+
+        $([ -n "$DYPTYPE0_SKIP" ] || echo "
+        - Name: dyptype0
+          AllocationPriority: ${DYPTYPE0_ALLOCATIONPRIORITY:-0}
+          CPUClass: ${DYPTYPE0_CPUCLASS:-classA}
+        ")
+
+        $([ -n "$DYPTYPE1_SKIP" ] || echo "
+        - Name: dyptype1
+          Namespaces:
+            - ${DYPTYPE1_NAMESPACE0:-dyptype1ns0}
+          AllocatorPriority: ${DYPTYPE1_ALLOCATIONPRIORITY:-1}
+          CPUClass: ${DYPTYPE1_CPUCLASS:-classB}
+        ")
+
+        $([ -n "$DYPTYPE2_SKIP" ] || echo "
+        - Name: dyptype2
+          Namespaces:
+            - ${DYPTYPE2_NAMESPACE0:-dyptype2ns0}
+            - ${DYPTYPE2_NAMESPACE1:-dyptype2ns1}
+          AllocatorPriority: ${DYPTYPE2_ALLOCATORPRIORITY:-2}
+          CPUClass: ${DYPTYPE2_CPUCLASS:-classC}
+        ")
+
+  instrumentation: |+
+    HTTPEndpoint: :8891
+    PrometheusExport: true
+
+  logger: |+
+    Debug: policy
+
+  cpu: |+
+    classes:
+      default:
+        minFreq: ${CPU_DEFAULT_MIN:-800}
+        maxFreq: ${CPU_DEFAULT_MAX:-2800}
+      classA:
+        minFreq: ${CPU_CLASSA_MIN:-900}
+        maxFreq: ${CPU_CLASSA_MAX:-2900}
+      classB:
+        minFreq: ${CPU_CLASSB_MIN:-1000}
+        maxFreq: ${CPU_CLASSB_MAX:-3000}
+      classC:
+        minFreq: ${CPU_CLASSC_MIN:-1100}
+        maxFreq: ${CPU_CLASSC_MAX:-3100}
+        energyPerformancePreference: ${CPU_CLASSC_EPP:-1}

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test01-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test01-basic-placement/code.var.sh
@@ -1,0 +1,69 @@
+# Test placing containers with and without annotations to correct dynamic pools
+# reserved and shared CPUs.
+
+cleanup() {
+    vm-command "kubectl delete pods pod0 -n kube-system; kubectl delete pods -n pool1 --all --now; kubectl delete pods --all --now; kubectl delete namespace pool1"
+    return 0
+}
+
+cleanup
+
+terminate cri-resmgr
+
+launch cri-resmgr
+
+# pod0: run on reserved CPUs.
+namespace=kube-system CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'len(cpus["pod0c0"]) == 1'
+
+# pod1: run in shared dynamic pool.
+# We do not add annotations to this pod, and we do not set any
+# namespace, so this pod is expected to be created to the shared pool.
+create dyp-busybox
+report allowed
+verify 'len(cpus["pod1c0"]) == 14'
+
+# The size of each dynamic pool is obtained by adding the requests of the containers in this pool and the CPUs allocated based on cpu utilization,
+# so the size of each dynamic pool is greater than or equal to the sum of the requests of the containers in the pool.
+
+# pod2: run in the pool1.
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: pool1" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod2c0"]) >= 1' \
+      'len(cpus["pod1c0"]) + len(cpus["pod2c0"]) == 14' \
+      'disjoint_sets(cpus["pod2c0"], cpus["pod1c0"])'
+
+# pod3: run in the pool1.
+CPUREQ="1500m" MEMREQ="100M" CPULIM="1500m" MEMLIM="100M"
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: pool1" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'cpus["pod2c0"] == cpus["pod3c0"]' \
+      'len(cpus["pod3c0"]) >= 2' \
+      'len(cpus["pod1c0"]) + len(cpus["pod3c0"]) == 14' \
+      'disjoint_sets(cpus["pod1c0"], cpus["pod3c0"])'
+
+# pod4: run in the pool2.
+CPUREQ="1500m" MEMREQ="100M" CPULIM="1500m" MEMLIM="100M"
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: pool2" CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod4c0"] == cpus["pod4c1"]' \
+      'len(cpus["pod4c0"]) >= 3' \
+      'len(cpus["pod3c0"]) >= 2' \
+      'len(cpus["pod1c0"]) + len(cpus["pod3c0"]) + len(cpus["pod4c0"]) == 14' \
+      'disjoint_sets(cpus["pod4c0"], cpus["pod3c0"], cpus["pod1c0"])' 
+
+# pod5: run in the pool1.
+CPUREQ="1500m" MEMREQ="100M" CPULIM="1500m" MEMLIM="100M"
+kubectl create namespace "pool1"
+namespace="pool1" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'cpus["pod5c0"] == cpus["pod2c0"]'\
+      'len(cpus["pod5c0"]) >= 4' \
+      'len(cpus["pod4c0"]) >= 3' \
+      'len(cpus["pod1c0"]) + len(cpus["pod3c0"]) + len(cpus["pod4c0"]) == 14' 
+
+cleanup
+

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test02-prometheus-metrics/code.var.sh
@@ -1,0 +1,72 @@
+# This test verifies prometheus metrics from the dynamic-pools policy.
+
+cleanup() {
+    vm-command "kubectl delete pods --all --now"
+    terminate cri-resmgr
+    terminate cri-resmgr-agent
+    vm-command "cri-resmgr -reset-policy; cri-resmgr -reset-config"
+    return 0
+}
+
+cleanup
+
+# Launch cri-resmgr with wanted metrics update interval and a
+# configuration that opens the instrumentation http server.
+cri_resmgr_cfg=${TEST_DIR}/dyp-metrics.cfg  cri_resmgr_extra_args="-metrics-interval 1s" launch cri-resmgr
+sleep 10
+verify-metrics-has-line 'dynamicPool="shared"'
+verify-metrics-has-line 'dynamicPool="reserved"'
+verify-metrics-has-line 'dynamicPool="full-core"'
+verify-metrics-has-line 'dynamicPool="flex"'
+verify-metrics-has-line 'dynamicPool="fast-dualcore"'
+
+# pod0: run in shared dynamic pool.
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+CONTCOUNT=2 create dyp-busybox
+report allowed
+verify-metrics-has-line 'dynamicPool="reserved"'
+verify-metrics-has-line 'dynamicPool="full-core"'
+verify-metrics-has-line 'dynamicPool="flex"'
+verify-metrics-has-line 'dynamicPool="fast-dualcore"'
+verify-metrics-has-line 'DynamicPools{containers="pod0:pod0c0,pod0:pod0c1",cpu_class="",cpus=".*",dynamicPool="shared",dynamicPool_type="shared",mems=".*",tot_limit_millicpu="200",tot_req_millicpu="200"} 15'
+
+# pod1: run in fast-dualcore dynamic pool.
+CPUREQ="200m" MEMREQ="" CPULIM="200m" MEMLIM=""
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: fast-dualcore" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify-metrics-has-line 'containers="pod1:pod1c0".*dynamicPool="fast-dualcore",dynamicPool_type="fast-dualcore".*tot_req_millicpu="(199|200)"'
+verify 'len(cpus["pod1c0"]) >= 1'
+
+# pod2: run in flex dynamic pool.
+CPUREQ="3500m" MEMREQ="" CPULIM="3500m" MEMLIM=""
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: flex" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify-metrics-has-line 'containers="pod2:pod2c0".*dynamicPool="flex",dynamicPool_type="flex"'
+verify 'len(cpus["pod2c0"]) >= 4'
+
+# pod3: run in flex dynamic pool.
+CPUREQ="1200m" MEMREQ="" CPULIM="1200m" MEMLIM=""
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: flex" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify-metrics-has-line 'containers="pod2:pod2c0,pod3:pod3c0".*dynamicPool="flex",dynamicPool_type="flex"'
+verify 'len(cpus["pod2c0"]) >= 5'
+
+# Resize flex dynamic pool in metrics.
+kubectl delete pods --now pod3
+verify-metrics-has-line 'containers="pod2:pod2c0".*dynamicPool="flex",dynamicPool_type="flex"'
+verify 'len(cpus["pod2c0"]) >= 4'
+
+kubectl delete pods --now pod2
+sleep 5
+verify-metrics-has-line 'containers="".*dynamicPool="flex",dynamicPool_type="flex".*0'
+
+# Delete all pods in shared dynamic pool.
+kubectl delete pods --now pod0
+# pod4: run in fast-dualcore dynamic pool, all CPUs are allocated to fast-dualcore dynamic pool.
+CPUREQ="14" MEMREQ="" CPULIM="14" MEMLIM=""
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: fast-dualcore" CONTCOUNT=1 create dyp-busybox
+report allowed
+verify-metrics-has-line 'containers="pod1:pod1c0,pod4:pod4c0".*dynamicPool="fast-dualcore",dynamicPool_type="fast-dualcore".*15'
+verify 'len(cpus["pod1c0"]) == 15'
+
+cleanup

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test02-prometheus-metrics/dyp-metrics.cfg
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test02-prometheus-metrics/dyp-metrics.cfg
@@ -1,0 +1,24 @@
+policy:
+  Active: dynamic-pools
+  AvailableResources:
+    CPU: cpuset:0-15
+  # Reserve one of our CPUs for kube-system tasks.
+  ReservedResources:
+    CPU: cpuset:0
+  dynamic-pools:
+    DynamicPoolTypes:
+      - Name: full-core
+        CPUClass: normal
+
+      - Name: fast-dualcore
+        CPUClass: turbo
+
+      - Name: flex
+        CPUClass: slow
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test03-rebalancing/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test03-rebalancing/code.var.sh
@@ -1,0 +1,83 @@
+# Re-launch cri-resmgr with the rebalancing parameter in order to
+# enable rebalancing calls. (See help of the "launch" function for
+# more options.)
+
+cleanup() {
+    vm-command "kubectl delete pods --all --now"
+    return 0
+}
+
+cleanup
+terminate cri-resmgr
+cri_resmgr_extra_args="-metrics-interval 1s -rebalance-interval 2s" launch cri-resmgr
+sleep 10
+
+# Create three pods:
+# - pod0 to "shared"
+# - pod1 to "pool1"
+# - pod2 to "pool2"
+create dyp-busybox
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: pool1"
+create dyp-busybox
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: pool2"
+create dyp-busybox
+# Print initial CPU pinning. 
+report allowed
+# Wait at least one rebalancing round.
+sleep 3
+verify 'len(cpus["pod0c0"]) >= 1'
+verify 'len(cpus["pod1c0"]) >= 1'
+verify 'len(cpus["pod2c0"]) >= 1'
+verify-metrics-has-line 'containers="pod0:pod0c0".*dynamicPool="shared",dynamicPool_type="shared"'
+verify-metrics-has-line 'containers="pod1:pod1c0".*dynamicPool="pool1",dynamicPool_type="pool1"'
+verify-metrics-has-line 'containers="pod2:pod2c0".*dynamicPool="pool2",dynamicPool_type="pool2"'
+
+# Increase CPU usage of pod1 to 200%
+vm-command "nohup kubectl exec pod1 -- /bin/sh -c 'gzip </dev/zero >/dev/null' </dev/null >&/dev/null &"
+vm-command "nohup kubectl exec pod1 -- /bin/sh -c 'gzip </dev/zero >/dev/null' </dev/null >&/dev/null &"
+# Wait at least one rebalancing round and print CPU pinning.
+sleep 3
+report allowed
+# Now "pool1" has 200% CPU load, "shared" and "pool2" have 0%.
+# Verify that pod in pool1 is allowed to use 12 out of 14 available CPUs.
+verify 'len(cpus["pod0c0"]) == 1'
+verify 'len(cpus["pod1c0"]) == 12'
+verify 'len(cpus["pod2c0"]) == 1'
+verify-metrics-has-line 'containers="pod0:pod0c0".*dynamicPool="shared",dynamicPool_type="shared".*1'
+verify-metrics-has-line 'containers="pod1:pod1c0".*dynamicPool="pool1",dynamicPool_type="pool1".*12'
+verify-metrics-has-line 'containers="pod2:pod2c0".*dynamicPool="pool2",dynamicPool_type="pool2".*1'
+
+# Remove CPU load from pool1 and put 100% CPU load to pool2.
+vm-command "pkill gzip"
+vm-command "nohup kubectl exec pod2 -- /bin/sh -c 'gzip </dev/zero >/dev/null' </dev/null >&/dev/null &"
+# Wait at least one rebalancing round and print CPU pinning.
+sleep 3
+report allowed
+# Verify that the pod in pool2 is allowed to use 12 out of 14 available CPUs.
+verify 'len(cpus["pod0c0"]) == 1'
+verify 'len(cpus["pod1c0"]) == 1'
+verify 'len(cpus["pod2c0"]) == 12'
+verify-metrics-has-line 'containers="pod0:pod0c0".*dynamicPool="shared",dynamicPool_type="shared".*1'
+verify-metrics-has-line 'containers="pod1:pod1c0".*dynamicPool="pool1",dynamicPool_type="pool1".*1'
+verify-metrics-has-line 'containers="pod2:pod2c0".*dynamicPool="pool2",dynamicPool_type="pool2".*12'
+
+# Remove CPU load from pool1 and put 100% CPU load to pool2 and pool1.
+vm-command "pkill gzip"
+vm-command "nohup kubectl exec pod1 -- /bin/sh -c 'gzip </dev/zero >/dev/null' </dev/null >&/dev/null &"
+vm-command "nohup kubectl exec pod2 -- /bin/sh -c 'gzip </dev/zero >/dev/null' </dev/null >&/dev/null &"
+# Takes time to reach a state of balance
+sleep 10
+report allowed
+# Verify that the pod in pool1 is allowed to use 7 out of 14 available CPUs and 
+# the pod in pool2 is allowed to use 6 out of 14 available CPUs.
+verify 'len(cpus["pod0c0"]) == 1'
+verify 'len(cpus["pod1c0"]) == 7'
+verify 'len(cpus["pod2c0"]) == 6'
+verify-metrics-has-line 'containers="pod0:pod0c0".*dynamicPool="shared",dynamicPool_type="shared".*1'
+verify-metrics-has-line 'containers="pod1:pod1c0".*dynamicPool="pool1",dynamicPool_type="pool1".*7'
+verify-metrics-has-line 'containers="pod2:pod2c0".*dynamicPool="pool2",dynamicPool_type="pool2".*6'
+
+# Remove CPU load from pool1 and pool2
+vm-command "pkill gzip"
+
+cleanup

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test04-reserved/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test04-reserved/code.var.sh
@@ -1,0 +1,85 @@
+terminate cri-resmgr
+cri_resmgr_cfg=${TEST_DIR}/dyp-reserved.cfg launch cri-resmgr
+
+cleanup() {
+    vm-command \
+        "kubectl delete pod -n kube-system --now pod0
+         kubectl delete pod -n monitor-mypods --now pod1
+         kubectl delete pod -n system-logs --now pod2
+         kubectl delete pod -n kube-system --now pod3
+         kubectl delete pods --now pod4 pod5 pod6
+         kubectl delete pod -n kube-system --now pod7
+         kubectl delete namespace monitor-mypods
+         kubectl delete namespace system-logs
+         kubectl delete namespace my-exact-name"
+    return 0
+}
+
+cleanup
+
+kubectl create namespace monitor-mypods
+kubectl create namespace system-logs
+kubectl create namespace my-exact-name
+
+# pod0: kube-system
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+namespace=kube-system create dyp-busybox
+report allowed
+verify 'cpus["pod0c0"] == {"cpu00", "cpu01", "cpu02"}'
+
+# pod1: match first ReservedPoolNamespaces glob, multicontainer
+CPUREQ="1" MEMREQ="" CPULIM="1" MEMLIM=""
+namespace=monitor-mypods CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod1c0"] == cpus["pod0c0"]' \
+       'cpus["pod1c1"] == cpus["pod0c0"]'
+
+# pod2: match last ReservedPoolNamespaces glob, slightly overbook reserved CPU
+CPUREQ="1" MEMREQ="" CPULIM="1" MEMLIM=""
+namespace=system-logs create dyp-busybox
+report allowed
+verify 'cpus["pod2c0"] == cpus["pod0c0"]'
+
+# pod3: force a kube-system pod to full-core dynamic pool using an annotation
+CPUREQ="2" MEMREQ="" CPULIM="2" MEMLIM=""
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: full-core" namespace=kube-system create dyp-busybox
+report allowed
+verify 'len(cpus["pod3c0"]) >= 2' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod3c0"])'
+
+# pod4: run in shared dynamic pool
+CPUREQ="2500m" MEMREQ="" CPULIM="2500m" MEMLIM=""
+create dyp-busybox
+report allowed
+verify 'len(cpus["pod4c0"]) >= 3' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod3c0"], cpus["pod4c0"])'
+
+# pod5: annotate otherwise a default pod to the reserved CPUs,
+# severely overbook reserved CPUs
+CPUREQ="2500m" MEMREQ="" CPULIM="2500m" MEMLIM=""
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: reserved" create dyp-busybox
+report allowed
+verify 'cpus["pod5c0"] == {"cpu00", "cpu01", "cpu02"}' \
+       'disjoint_sets(cpus["pod5c0"], cpus["pod3c0"], cpus["pod4c0"])'
+
+cleanup
+
+# Now that all pods are deleted, make sure that cpus of reserved and
+# default dynamic pools are as expected.
+
+# pod6: run in shared dynamic pool
+CPUREQ="999m" MEMREQ="" CPULIM="999m" MEMLIM=""
+create dyp-busybox
+report allowed
+verify 'len(cpus["pod6c0"]) >= 1'
+
+# pod7: kube-system
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+namespace=kube-system create dyp-busybox
+report allowed
+verify 'cpus["pod7c0"] == {"cpu00", "cpu01", "cpu02"}'
+
+cleanup
+
+terminate cri-resmgr
+launch cri-resmgr

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test04-reserved/dyp-reserved.cfg
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test04-reserved/dyp-reserved.cfg
@@ -1,0 +1,22 @@
+policy:
+  Active: dynamic-pools
+  ReservedResources:
+    CPU: cpuset:0-2
+  dynamic-pools:
+    PinCPU: true
+    PinMemory: true
+    ReservedPoolNamespaces:
+      - "monitor-*"
+      - "*-log*"
+    DynamicPoolTypes:
+      - Name: reserved
+        Namespaces:
+          - my-exact-name
+        CPUClass: reserved-class
+      - Name: default
+      - Name: full-core
+        CPUClass: turbo
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test05-namespace/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test05-namespace/code.var.sh
@@ -1,0 +1,70 @@
+terminate cri-resmgr
+cri_resmgr_cfg=${TEST_DIR}/dyp-namespace.cfg launch cri-resmgr
+
+cleanup() {
+    vm-command \
+        "kubectl delete pods -n e2e-a --all --now
+         kubectl delete pods -n e2e-b --all --now
+         kubectl delete pods -n e2e-c --all --now
+         kubectl delete pods -n e2e-d --all --now
+         kubectl delete pods --all --now
+         kubectl delete namespace e2e-a
+         kubectl delete namespace e2e-b
+         kubectl delete namespace e2e-c
+         kubectl delete namespace e2e-d"
+    return 0
+}
+cleanup
+
+kubectl create namespace e2e-a
+kubectl create namespace e2e-b
+kubectl create namespace e2e-c
+kubectl create namespace e2e-d
+
+# pod0: create in the default namespace, CPUREQ is nil, both containers go to shared dynamic pool.
+CPUREQ=""
+CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'len(cpus["pod0c0"]) == 15'
+
+# pod1: create in the e2e-a namespace, CPUREQ is nil, both containers go to shared dynamic pool.
+CPUREQ=""
+namespace="e2e-a" CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod1c0"] == cpus["pod1c1"] == cpus["pod0c0"]' \
+       'len(cpus["pod1c0"]) == 15' \
+
+# pod2: create in the default namespace, CPUREQ is 2*2, both containers go to nsdyp dynamic pool.
+CPUREQ="2" MEMREQ="100M" CPULIM="2" MEMLIM="100M"
+CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod2c0"] == cpus["pod2c1"]' \
+       'len(cpus["pod2c0"]) >= 4' \
+       'disjoint_sets(cpus["pod2c0"], cpus["pod1c0"])' \
+       'disjoint_sets(cpus["pod2c0"], cpus["pod0c0"])'
+
+# pod3: create again in the default namespace, CPUREQ is 200m*2, both containers go to nsdyp dynamic pool.
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod3c0"] == cpus["pod3c1"] == cpus["pod2c0"]' \
+       'len(cpus["pod3c0"]) >= 5' 
+
+# pod4: create in the e2e-b namespace, CPUREQ is 2*2, both containers go to nsdyp dynamic pool.
+CPUREQ="2" MEMREQ="100M" CPULIM="2" MEMLIM="100M"
+namespace="e2e-b" CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod4c0"] == cpus["pod4c1"] == cpus["pod3c0"] == cpus["pod2c0"]' \
+       'len(cpus["pod4c0"]) >= 9' 
+
+# pod5: create in the e2e-c namespace, CPUREQ is 100m*2, both containers go to nsdyp dynamic pool.
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+namespace="e2e-c" CONTCOUNT=2 create dyp-busybox
+report allowed
+verify 'cpus["pod5c0"] == cpus["pod5c1"] == cpus["pod4c0"] == cpus["pod3c0"] == cpus["pod2c0"]' \
+       'len(cpus["pod5c0"]) >= 9' 
+
+cleanup
+terminate cri-resmgr
+launch cri-resmgr

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test05-namespace/dyp-namespace.cfg
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test05-namespace/dyp-namespace.cfg
@@ -1,0 +1,13 @@
+policy:
+  Active: dynamic-pools
+  ReservedResources:
+    CPU: 1
+  dynamic-pools:
+    PinCPU: true
+    PinMemory: true
+    DynamicPoolTypes:
+      - Name: nsdyp
+        Namespaces:
+          - "*"
+logger:
+  Debug: policy

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test06-update-configmap/code.var.sh
@@ -1,0 +1,78 @@
+# This test verifies that configuration updates via cri-resmgr-agent
+# are handled properly in the dynamic-pools policy.
+
+testns=e2e-dyp-test06
+
+cleanup() {
+    vm-command "kubectl delete pods --all --now; \
+        kubectl delete pods -n $testns --all --now; \
+        kubectl delete pods -n dyptype1ns0 --all --now; \
+        kubectl delete namespace $testns || :; \
+        kubectl delete namespace dyptype1ns0 || :"
+    terminate cri-resmgr
+    terminate cri-resmgr-agent
+    vm-command "cri-resmgr -reset-policy; cri-resmgr -reset-config"
+}
+
+apply-configmap() {
+    vm-put-file $(instantiate dyp-configmap.yaml) dyp-configmap.yaml
+    vm-command "cat dyp-configmap.yaml"
+    kubectl apply -f dyp-configmap.yaml
+}
+
+cleanup
+cri_resmgr_extra_args="-metrics-interval 1s" cri_resmgr_config=fallback launch cri-resmgr
+launch cri-resmgr-agent
+
+kubectl create namespace $testns
+kubectl create namespace dyptype1ns0
+
+AVAILABLE_CPU="cpuset:1,4-15" DYPTYPE2_NAMESPACE0='"*"' apply-configmap
+sleep 3
+
+# pod0 run in dyptype0, annotation
+CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
+POD_ANNOTATION="dynamic-pool.dynamic-pools.cri-resource-manager.intel.com/pod: dyptype0" create dyp-busybox
+# pod1 run in dyptype1, namespace
+CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
+namespace="dyptype1ns0" create dyp-busybox
+# pod2 run in dyptype2, wildcard namespace
+CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
+namespace="e2e-dyp-test06" create dyp-busybox
+sleep 3
+vm-command "curl -s $verify_metrics_url"
+verify-metrics-has-line 'pod0:pod0c0.*"dyptype0"'
+verify-metrics-has-line 'pod1:pod1c0.*"dyptype1"'
+verify-metrics-has-line 'pod2:pod2c0.*"dyptype2"'
+
+# Remove first two dynamic pool types, change dyptype2 to match all
+# namespaces.
+DYPTYPE0_SKIP=1 DYPTYPE1_SKIP=1 DYPTYPE2_NAMESPACE0='"*"' apply-configmap
+# Note:
+
+# pod0 was successfully assigned to and running in dyptype0 dynamic pool.
+# Now dyptype0 was completely removed from the node.
+# Currently this behavior is undefined.
+# Possible behaviors: evict pod0, continue assign chain, refuse config...
+# For now, skip pod0c0 dynamic pool validation:
+# verify-metrics-has-line '"dyptype2".*pod0:pod0c0'
+verify-metrics-has-line 'pod1:pod1c0.*"dyptype2"' 
+verify-metrics-has-line 'pod2:pod2c0.*"dyptype2"'
+
+# Bring back dyptype0 where pod0 belongs to by annotation.
+DYPTYPE1_SKIP=1 DYPTYPE2_NAMESPACE0='"*"' apply-configmap
+verify-metrics-has-line 'pod0:pod0c0.*"dyptype0"'
+verify-metrics-has-line 'pod1:pod1c0.*"dyptype2"' 
+verify-metrics-has-line 'pod2:pod2c0.*"dyptype2"'
+
+# Change only CPU classes, no reassigning.
+verify-metrics-has-line 'pod0:pod0c0.*cpu_class="classA".*"dyptype0"'
+verify-metrics-has-line 'pod1:pod1c0.*cpu_class="classC".*"dyptype2"'
+verify-metrics-has-line 'pod2:pod2c0.*cpu_class="classC".*"dyptype2"'
+DYPTYPE0_CPUCLASS="classC" DYPTYPE1_SKIP=1 DYPTYPE2_CPUCLASS="classB" DYPTYPE2_NAMESPACE0='"*"'  apply-configmap
+verify-metrics-has-line 'pod0:pod0c0.*cpu_class="classC".*"dyptype0"' 
+verify-metrics-has-line 'pod1:pod1c0.*cpu_class="classB".*"dyptype2"'
+verify-metrics-has-line 'pod2:pod2c0.*cpu_class="classB".*"dyptype2"'
+
+cleanup
+launch cri-resmgr

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test07-numa/code.var.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test07-numa/code.var.sh
@@ -1,0 +1,81 @@
+terminate cri-resmgr
+cri_resmgr_cfg=${TEST_DIR}/dyp-numa.cfg launch cri-resmgr
+
+# pod0: besteffort, go to shared dynamic pool, make sure it still gets at least 1 CPU.
+CPUREQ="" CPULIM="" MEMREQ="" MEMLIM=""
+CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) == 15'
+
+# pod1: guaranteed, go to fit-in-numa dynamic pool, make sure it gets the CPU it requested.
+CPUREQ="1" CPULIM="1" MEMREQ="50M" MEMLIM="50M"
+CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod1c0"]) >= 1' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"])'
+
+# pod2: guaranteed, go to fit-in-numa dynamic pool, make sure it gets the CPU it requested.
+CPUREQ="1" CPULIM="1" MEMREQ="50M" MEMLIM="50M"
+CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod1c0"]) >= 2' \
+       'len(cpus["pod2c0"]) >= 2' \
+       'cpus["pod1c0"] == cpus["pod2c0"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod2c0"])'
+
+# pod3: guaranteed, go to fit-in-numa dynamic pool, make sure it gets the CPU it requested.
+CPUREQ="1" CPULIM="1" MEMREQ="50M" MEMLIM="50M"
+CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod1c0"]) >= 3' \
+       'len(cpus["pod2c0"]) >= 3' \
+       'len(cpus["pod3c0"]) >= 3' \
+       'cpus["pod1c0"] == cpus["pod2c0"] == cpus["pod3c0"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod3c0"])'
+
+# pod4: guaranteed, go to fit-in-numa dynamic pool, make sure it gets the CPU it requested.
+CPUREQ="1" CPULIM="1" MEMREQ="50M" MEMLIM="50M"
+CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod1c0"]) >= 4' \
+       'len(cpus["pod2c0"]) >= 4' \
+       'len(cpus["pod3c0"]) >= 4' \
+       'len(cpus["pod4c0"]) >= 4' \
+       'cpus["pod1c0"] == cpus["pod2c0"] == cpus["pod3c0"] == cpus["pod4c0"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod4c0"])'
+
+# pod5: besteffort, no CPU request, should fit into the shared dynamic pool.
+CPUREQ="" CPULIM="" MEMREQ="" MEMLIM=""
+CONTCOUNT=1 create dyp-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod1c0"]) >= 4' \
+       'len(cpus["pod2c0"]) >= 4' \
+       'len(cpus["pod3c0"]) >= 4' \
+       'len(cpus["pod4c0"]) >= 4' \
+       'len(cpus["pod5c0"]) >= 1' \
+       'cpus["pod1c0"] == cpus["pod2c0"] == cpus["pod3c0"] == cpus["pod4c0"]' \
+       'cpus["pod0c0"] == cpus["pod5c0"]'
+
+# Leave only one guaranteed container to the fit-in-numa dynamic pool.
+kubectl delete pods pod1 pod2 pod3 --now
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod4c0"]) >= 1' \
+       'len(cpus["pod5c0"]) >= 1' \
+       'cpus["pod0c0"] == cpus["pod5c0"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod4c0"])'
+
+# Leave only bestefforts to the dynamic pool.
+kubectl delete pods pod4 --now
+report allowed
+verify 'len(cpus["pod0c0"]) >= 1' \
+       'len(cpus["pod5c0"]) >= 1' \
+       'cpus["pod0c0"] == cpus["pod5c0"]' 
+
+terminate cri-resmgr
+launch cri-resmgr

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/test07-numa/dyp-numa.cfg
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/test07-numa/dyp-numa.cfg
@@ -1,0 +1,16 @@
+policy:
+  Active: dynamic-pools
+  AvailableResources:
+    CPU: cpuset:0-15
+  # Reserve one of our CPUs (cpu15) for kube-system tasks.
+  ReservedResources:
+    CPU: 1
+  dynamic-pools:
+    PinCPU: true
+    PinMemory: true
+    DynamicPoolTypes:
+      - Name: fit-in-numa
+        # All (non-system) containers are assigned to this dynamic pool
+        # type
+        Namespaces:
+          - "*"

--- a/test/e2e/policies.test-suite/dynamic-pools/n4c16/topology.var.json
+++ b/test/e2e/policies.test-suite/dynamic-pools/n4c16/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "packages": 2}
+]

--- a/test/e2e/policies.test-suite/dynamic-pools/verify.source.sh
+++ b/test/e2e/policies.test-suite/dynamic-pools/verify.source.sh
@@ -1,0 +1,17 @@
+# Utilities to verify data from metrics
+
+verify_metrics_url="http://localhost:8891/metrics"
+
+verify-metrics-has-line() {
+    local expected_line="$1"
+    vm-run-until --timeout 10 "echo 'waiting for metrics line: $expected_line' >&2; curl --silent $verify_metrics_url | grep -E '$expected_line'" || {
+        command-error "expected line '$1' missing from the output"
+    }
+}
+
+verify-metrics-has-no-line() {
+    local unexpected_line="$1"
+    vm-run-until --timeout 10 "echo 'checking absense of metrics line: $unexpected_line' >&2; ! curl --silent $verify_metrics_url | grep -Eq '$unexpected_line'" || {
+        command-error "unexpected line '$1' found from the output"
+    }
+}


### PR DESCRIPTION
This PR creates a new policy for `cri-resource-manager` named `dynamic-pools` policy.
This policy can put the workload in different dynamic pools, and the CPUs of dynamic pools do not overlap with each other. These dynamic pools can be dynamically resized based on the requests of the containers and the CPU utilization of the workload in the dynamic pools.
Users can define and configure dynamic pools. A dynamic pool has a set of CPUs and a set of containers running on the CPUs. CPUs in dynamic pools can be configured, for example, by setting min and max frequencies on CPU cores and uncore.
The code and documentation of the `dynamic-pools` policy are included in this PR.