### PR TITLE
sysfs: add SysRoot() getter for SetSysRoot()

### DIFF
--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -244,6 +244,11 @@ func SetSysRoot(path string) {
 	sysRoot = path
 }
 
+// SysRoot returns the sys root directory.
+func SysRoot() string {
+	return sysRoot
+}
+
 // DiscoverSystem performs discovery of the running systems details.
 func DiscoverSystem(args ...DiscoveryFlag) (System, error) {
 	return DiscoverSystemAt(filepath.Join("/", sysRoot, "sys"))


### PR DESCRIPTION
This change enables policies to read and use cri-resmgr --host-root value, that will help validation and running in custom environments.