### PR TITLE
cpuallocator: fix cpu priority discovery

### DIFF
--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -428,6 +428,7 @@ func (c *topologyCache) discoverCPUPriorities(sys sysfs.System) {
 			prio[p] = prio[p].Union(cset)
 		}
 	}
+	c.cpuPriorities = prio
 }
 
 func (c *topologyCache) discoverSstCPUPriority(sys sysfs.System, pkgID idset.ID) ([NumCPUPriorities][]idset.ID, bool) {


### PR DESCRIPTION
The CPU priorities were discovered correctly but not stored in the cpuallocator so they were effectively discarded.