### PR TITLE
Bump builds to use Golang v1.19.6

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Install golangci-lint
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
 
     - name: Gofmt
       run: make format

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO_FMT      := gofmt
 GO_CYCLO    := gocyclo
 GO_LINT     := golint
 GO_CILINT   := golangci-lint
-GO_VERSION  ?= 1.18.9
+GO_VERSION  ?= 1.19.6
 GOLICENSES_VERSION  ?= v1.5.0
 
 # TEST_TAGS is the set of extra build tags passed for tests.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_TEST   := $(GO_CMD) test $(GO_PARALLEL) -tags $(TEST_TAGS)
 GO_VET    := $(GO_CMD) vet -tags $(TEST_TAGS)
 
 # Disable some golangci_lint checkers for now until we have an more acceptable baseline...
-GO_CILINT_CHECKERS := -D unused,staticcheck,errcheck,deadcode,structcheck,gosimple -E golint,gofmt
+GO_CILINT_CHECKERS := -D unused,staticcheck,errcheck,deadcode,structcheck,gosimple -E revive,gofmt
 GO_CILINT_RUNFLAGS := --build-tags $(TEST_TAGS)
 
 # Protoc compiler and protobuf definitions we might need to recompile.

--- a/cmd/cri-resmgr-agent/Dockerfile
+++ b/cmd/cri-resmgr-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.19
 
 FROM golang:${GO_VERSION}-bullseye as builder
 

--- a/cmd/cri-resmgr-webhook/Dockerfile
+++ b/cmd/cri-resmgr-webhook/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.19
 
 FROM golang:${GO_VERSION}-bullseye as builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/intel/cri-resource-manager
 
-go 1.18
+go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/pkg/apis/resmgr/generated/clientset/versioned/fake/register.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/fake/register.go
@@ -35,14 +35,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/apis/resmgr/generated/clientset/versioned/scheme/register.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/scheme/register.go
@@ -35,14 +35,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/avx/collector.go
+++ b/pkg/avx/collector.go
@@ -200,7 +200,7 @@ func NewCollector() (prometheus.Collector, error) {
 	progVer := spec.Programs["tracepoint__x86_fpu_regs_deactivated"].KernelVersion
 
 	if hostVer < progVer {
-		return nil, errors.Wrapf(err, "The host kernel version (v%s) is too old to run the AVX512 collector program. Minimum version is v%s.", kernelVersionStr(hostVer), kernelVersionStr(progVer))
+		return nil, errors.Wrapf(err, "The host kernel version (v%s) is too old to run the AVX512 collector program. Minimum version is v%s", kernelVersionStr(hostVer), kernelVersionStr(progVer))
 	}
 
 	collection, err := bpf.NewCollection(spec)

--- a/pkg/blockio/blockio_test.go
+++ b/pkg/blockio/blockio_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/testutils"
 )
 
-var knownIOSchedulers map[string]bool = map[string]bool{
+var knownIOSchedulers = map[string]bool{
 	"bfq":         true,
 	"cfq":         true,
 	"deadline":    true,

--- a/pkg/cgroups/cgroupblkio.go
+++ b/pkg/cgroups/cgroupblkio.go
@@ -47,9 +47,10 @@ var blkioThrottleWriteIOPSFiles = []string{"blkio.throttle.write_iops_device"}
 // Effects of Weight and Rate values in SetBlkioParameters():
 // Value  |  Effect
 // -------+-------------------------------------------------------------------
-//    -1  |  Do not write to cgroups, value is missing
-//     0  |  Write to cgroups, will remove the setting as specified in cgroups blkio interface
-//  other |  Write to cgroups, sets the value
+//
+//	  -1  |  Do not write to cgroups, value is missing
+//	   0  |  Write to cgroups, will remove the setting as specified in cgroups blkio interface
+//	other |  Write to cgroups, sets the value
 type OciBlockIOParameters struct {
 	Weight                  int64
 	WeightDevice            OciDeviceWeights

--- a/pkg/cpuallocator/allocator.go
+++ b/pkg/cpuallocator/allocator.go
@@ -633,9 +633,10 @@ func (p CPUPriority) String() string {
 }
 
 // cmpCPUSet compares two cpusets in terms of preferred cpu priority. Returns:
-//   > 0 if cpuset A is preferred
-//   < 0 if cpuset B is preferred
-//   0 if cpusets A and B are equal in terms of cpu priority
+//
+//	> 0 if cpuset A is preferred
+//	< 0 if cpuset B is preferred
+//	0 if cpusets A and B are equal in terms of cpu priority
 func (c *cpuPriorities) cmpCPUSet(csetA, csetB cpuset.CPUSet, prefer CPUPriority, cpuCnt int) int {
 	if prefer == PriorityNone {
 		return 0

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -707,16 +707,14 @@ func (ca *cachedAllocations) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-//
 // Functions for calculating CFS cpu.shares and cpu.cfs_quota_us.
 //
-//   Notes: These functions are almost verbatim taken from the kubelet
-//   code (from k8s.io/kubernetes/pkg/kubelet/cm/helpers_linux.go).
-//   Since these are exported there, we could try to import them, set the
-//   related feature gates (kubefeatures.CPUCFSQuotaPeriod) for ourselves
-//   into the desired positions (disabled most probably for now) and use
-//   the imported code.
-//
+//	Notes: These functions are almost verbatim taken from the kubelet
+//	code (from k8s.io/kubernetes/pkg/kubelet/cm/helpers_linux.go).
+//	Since these are exported there, we could try to import them, set the
+//	related feature gates (kubefeatures.CPUCFSQuotaPeriod) for ourselves
+//	into the desired positions (disabled most probably for now) and use
+//	the imported code.
 const (
 	MinShares     = 2
 	SharesPerCPU  = 1024

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -193,17 +193,17 @@ func (l Level) String() string {
 // setLevel sets the logging severity level.
 func (log *logging) setLevel(level Level) error {
 	log.level = level
-	kThreshold := ""
+	threshold := ""
 	switch level {
 	case LevelDebug, LevelInfo:
-		kThreshold = "INFO"
+		threshold = "INFO"
 	case LevelWarn:
-		kThreshold = "WARNING"
+		threshold = "WARNING"
 	case LevelError, LevelPanic, LevelFatal:
-		kThreshold = "ERROR"
+		threshold = "ERROR"
 	}
-	if err := klogctl.Set("stderrthreshold", kThreshold); err != nil {
-		return loggerError("failed to set log level/threshold to %s: %v", kThreshold, err)
+	if err := klogctl.Set("stderrthreshold", threshold); err != nil {
+		return loggerError("failed to set log level/threshold to %s: %v", threshold, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Bump from v1.18 to the latest patch release of v1.19. v1.18 has been archived so it's better not to use it anymore.