### PR TITLE
pkg/avx: don't crash if regexp produces no matches.

### DIFF
--- a/pkg/avx/collector.go
+++ b/pkg/avx/collector.go
@@ -306,12 +306,16 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			re := regexp.MustCompile(`[a-z0-9]{64}`)
+			matches := re.FindStringSubmatch(filepath.Base(path))
+			if len(matches) == 0 {
+				return
+			}
 
 			ch <- prometheus.MustNewConstMetric(
 				descriptors[avxSwitchCountDesc],
 				prometheus.GaugeValue,
 				float64(counter_),
-				re.FindStringSubmatch(filepath.Base(path))[0])
+				matches[0])
 
 			if err := c.ebpf.Maps["all_context_switch_count_hash"].Lookup(uint64(cgroupid_), &allCount); err != nil {
 				log.Error("unable to find 'all' context switch count: %+v", err)


### PR DESCRIPTION
Don't blindly assume regexp match will produce a non-empty slice of results. If it does not, trying to index the empty slice with `0` panics. 