### PR TITLE
[release-0.8] rdt: stop trying to get container cgroup dir

### DIFF
--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -194,12 +194,6 @@ func (ctl *rdtctl) assignClass(c cache.Container, class string) error {
 		return rdtError("%q: failed to get pod", c.PrettyName())
 	}
 
-	dir := c.GetCgroupDir()
-	if dir == "" {
-		return rdtError("%q: failed to determine cgroup directory",
-			c.PrettyName())
-	}
-
 	pids, err := c.GetProcesses()
 	if err != nil {
 		return rdtError("%q: failed to get process list: %v", c.PrettyName(), err)


### PR DESCRIPTION
We don't use that information for anything. In an error case we'll get the same error from container.GetProcesses() later anyway.

(cherry picked from commit 61acbd7cbf7c93eab503fc8de479b9855f432ac3)