### PR TITLE
Enable fixing balloon instances to hardcoded CPUs and memories for benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,15 @@ RANDOM_ID := "$(shell head -c20 /dev/urandom | od -An -tx1 | tr -d ' \n')"
 
 ifdef STATIC
     STATIC_LDFLAGS:=-extldflags=-static
-    BUILD_TAGS:=-tags osusergo,netgo
+    BUILD_TAGS := $(BUILD_TAGS),osusergo,netgo
+endif
+
+ifdef BENCHMARKING
+    BUILD_TAGS := $(BUILD_TAGS),benchmarking
+endif
+
+ifdef BUILD_TAGS
+    BUILD_TAGS:=-tags $(BUILD_TAGS)
 endif
 
 LDFLAGS    = \

--- a/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/flags.go
@@ -43,8 +43,27 @@ type balloonsOptionsWrapped struct {
 	// amount of allocations. The default is false: balloons are
 	// packed tightly to optimize power efficiency.
 	AllocatorTopologyBalancing bool
-	// BallonDefs contains balloon type definitions.
+	// BalloonDefs contains balloon type definitions.
 	BalloonDefs []*BalloonDef `json:"BalloonTypes,omitempty"`
+	// BalloonInstances define balloon instance-specific options.
+	BalloonInsts []*BalloonInst `json:"BalloonInstances,omitempty"`
+}
+
+// BalloonInst contains additional constraints and overrides on
+// balloon instantiation.
+type BalloonInst struct {
+	// Type of the balloon, that is, the name of a balloon Def.
+	Type string `json:"Type"`
+	// Balloon instances on which following constraints apply.
+	Instances []int
+	// Allow CPU allocation only from listed CPU packages.
+	AllowedCpuPackages []int
+	// Allow CPU allocation only from listed NUMAs.
+	AllowedCpuNumas []int
+	// Allow CPU allocation only from listed CPUs.
+	AllowedCpus []int
+	// Force memory pinning exactly on listed NUMAs.
+	ForcedMemNumas []int
 }
 
 // BalloonDef contains a balloon definition.

--- a/pkg/cri/resource-manager/policy/builtin/balloons/instances-benchmarking.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/instances-benchmarking.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build benchmarking
+// +build benchmarking
+
+package balloons
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	idset "github.com/intel/goresctrl/pkg/utils"
+)
+
+func (p *balloons) instValidateConfig(bpoptions *BalloonsOptions) error {
+	return nil
+}
+
+func (p *balloons) instAllowedCpus(blnDef *BalloonDef, instance int, availCpus cpuset.CPUSet) cpuset.CPUSet {
+	mask := p.instAllowedCpuMask(blnDef, instance)
+	if mask != nil {
+		allowed := availCpus.Intersection(*mask)
+		log.Debugf("benchmarking: restricting CPU allocation for balloon %s[%d] from free %s, allowed mask %s, result: %s", blnDef.Name, instance, availCpus, *mask, allowed)
+		return allowed
+	}
+	return availCpus
+}
+
+func (p *balloons) instForcedMems(blnDef *BalloonDef, instance int) idset.IDSet {
+	for _, binst := range p.balloonInsts(blnDef, instance) {
+		if len(binst.ForcedMemNumas) > 0 {
+			forced := idset.NewIDSet(binst.ForcedMemNumas...)
+			log.Debugf("benchmarking: forcing memory of balloon %s[%d] to %v", blnDef.Name, instance, forced)
+			return forced
+		}
+	}
+	return idset.NewIDSet()
+}
+
+func (p *balloons) balloonInsts(blnDef *BalloonDef, instance int) []*BalloonInst {
+	binsts := []*BalloonInst{}
+	for _, binst := range p.bpoptions.BalloonInsts {
+		if binst.Type == blnDef.Name && containsInt(binst.Instances, instance) {
+			binsts = append(binsts, binst)
+		}
+	}
+	return binsts
+}
+
+func containsInt(haystack []int, needle int) bool {
+	for _, hay := range haystack {
+		if hay == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *balloons) instAllowedCpuMask(blnDef *BalloonDef, instance int) *cpuset.CPUSet {
+	for _, binst := range p.balloonInsts(blnDef, instance) {
+		switch {
+		case len(binst.AllowedCpuPackages) > 0:
+			cpus := p.cpuTree.CpusIn(CPUTopologyLevelPackage, binst.AllowedCpuPackages)
+			return &cpus
+		case len(binst.AllowedCpuNumas) > 0:
+			cpus := p.cpuTree.CpusIn(CPUTopologyLevelNuma, binst.AllowedCpuNumas)
+			return &cpus
+		case len(binst.AllowedCpus) > 0:
+			cpus := cpuset.NewCPUSet(binst.AllowedCpus...)
+			return &cpus
+		}
+	}
+	return nil
+}

--- a/pkg/cri/resource-manager/policy/builtin/balloons/instances-production.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/instances-production.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !benchmarking
+// +build !benchmarking
+
+package balloons
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	idset "github.com/intel/goresctrl/pkg/utils"
+)
+
+func (p *balloons) instValidateConfig(bpoptions *BalloonsOptions) error {
+	for _, binst := range bpoptions.BalloonInsts {
+		if len(binst.AllowedCpuPackages) > 0 ||
+			len(binst.AllowedCpuNumas) > 0 ||
+			len(binst.AllowedCpus) > 0 ||
+			len(binst.ForcedMemNumas) > 0 {
+			return balloonsError("this balloons policy build does not support benchmarking features: allowed/forced CPU and memory pinning")
+		}
+	}
+	return nil
+}
+
+func (p *balloons) instAllowedCpus(blnDef *BalloonDef, instance int, availCpus cpuset.CPUSet) cpuset.CPUSet {
+	// Ignore forced balloon allocations in production builds.
+	return availCpus
+}
+
+func (p *balloons) instForcedMems(blnDef *BalloonDef, instance int) idset.IDSet {
+	// No forced memory nodes.
+	return idset.NewIDSet()
+}

--- a/test/e2e/policies.test-suite/balloons/n4c16/test10-instances/balloons-instances.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test10-instances/balloons-instances.cfg
@@ -1,0 +1,32 @@
+policy:
+  Active: balloons
+  ReservedResources:
+    CPU: cpuset:0
+  balloons:
+    BalloonTypes:
+      - Name: fixed
+        MinCPUs: 2
+        MaxCPUs: 2
+        MinBalloons: 2
+        Namespaces:
+          - "default"
+        PreferNewBalloons: true
+    BalloonInstances:
+      - Type: fixed
+        Instances: [0, 3]
+        AllowedCpuPackages: [0]
+      - Type: fixed
+        Instances: [1]
+        AllowedCpus: [14, 15]
+        ForcedMemNumas: [2, 3]
+      - Type: fixed
+        Instances: [2]
+        AllowedCpuNumas: [2]
+        ForcedMemNumas: [1]
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test10-instances/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test10-instances/code.var.sh
@@ -1,0 +1,34 @@
+# This test is available only when using build flag BENCHMARK
+terminate cri-resmgr
+( cri_resmgr_cfg=${TEST_DIR}/balloons-instances.cfg cri_resmgr_extra_args="-metrics-interval 4s" launch cri-resmgr ) || {
+    vm-command "grep 'this balloons policy build does not support benchmarking features' < cri-resmgr.output.txt" && {
+        echo "WARNING:"
+        echo "WARNING: Skipping $TEST_DIR."
+        echo "WARNING: cri-resmgr is built without benchmarking build tag"
+        echo "WARNING:"
+        sleep 3
+        exit 0
+    }
+    error "failed to start cri-resmgr"
+}
+
+# First two fixed instances are created at init.
+verify-metrics-has-line 'balloon="fixed\[0\].*mems="0"'
+verify-metrics-has-line 'balloon="fixed\[1\].*mems="2,3"'
+verify-metrics-has-line 'balloon="fixed\[1\].*p1d0n3'
+CPU=250m MEM=100M n=4 create guaranteed
+
+# Last two fixed instances are created on-demand when creating containers.
+verify-metrics-has-line 'balloon="fixed\[2\].*numas="p1d0n2"'
+verify-metrics-has-line 'balloon="fixed\[2\].*mems="1"'
+verify-metrics-has-line 'balloon="fixed\[3\].*packages="p0"'
+verify 'packages["pod0c0"] == {"package0"}' \
+       'mems["pod0c0"] == {"node0"}' \
+       'cpus["pod1c0"] == {"cpu14", "cpu15"}' \
+       'mems["pod1c0"] == {"node2", "node3"}' \
+       'packages["pod2c0"] == {"package1"}' \
+       'mems["pod2c0"] == {"node1"}' \
+       'packages["pod3c0"] == {"package0"}'
+
+terminate cri-resmgr
+launch cri-resmgr


### PR DESCRIPTION
These patches add support for `BalloonInstances` configuration. It enables setting constraints and overrides on individual balloon instances regarding CPU allocation and memory pinning.

This feature is useful for benchmarking well-known hardware under different loads. However, using this feature makes the balloons policy configuration totally inapplicable to heterogenous clusters and very prone to configuration errors. These issues are likely to manifest themselves by not being able to run pods that have been scheduled on a node. Therefore this feature is not available by default, but only if `cri-resmgr` is built with `benchmarking` build tag (or `make BENCHMARKING=1`).