### PR TITLE
[backport from nri-plugins] all: switch to k8s.io/utils/cpuset.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,9 @@ require (
 	k8s.io/apimachinery v0.25.10
 	k8s.io/client-go v0.25.10
 	k8s.io/cri-api v0.25.10
-	k8s.io/klog/v2 v2.70.1
+	k8s.io/klog/v2 v2.80.1
 	k8s.io/kubernetes v1.25.10
+	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -121,7 +122,6 @@ require (
 	k8s.io/kube-scheduler v0.24.1 // indirect
 	k8s.io/kubelet v0.24.1 // indirect
 	k8s.io/mount-utils v0.24.1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -376,7 +376,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -761,8 +760,8 @@ k8s.io/csi-translation-lib v0.25.10 h1:aPA/UAGffC5+4cHgeWORZe2w1ytrpXGg96TQyxLf2
 k8s.io/csi-translation-lib v0.25.10/go.mod h1:kCLPsbj4GvdyjlYy57obi1wDjAAhuQ9wH+EqaV0qcr4=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
-k8s.io/klog/v2 v2.70.1 h1:7aaoSdahviPmR+XkS7FyxlkkXs6tHISSG03RxleQAVQ=
-k8s.io/klog/v2 v2.70.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkIFQtZShWqoha7snGixVgEA=
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1/go.mod h1:C/N6wCaBHeBHkHUesQOQy2/MZqGgMAFPqGsGQLdbZBU=
 k8s.io/kube-scheduler v0.25.10 h1:wpQZ8G2AE+7tC5ue3FVQox/UgpKSVDeUaE0EVxN0mQg=
@@ -774,8 +773,8 @@ k8s.io/kubernetes v1.25.10/go.mod h1:USGoemphFvArsdVC5SC9jPMggic3scS3nUBuXurz97w
 k8s.io/mount-utils v0.25.10 h1:ZlMrV9cs6YAyiZrYCpUcLZMv6keq5cXi+50SZMXJNTo=
 k8s.io/mount-utils v0.25.10/go.mod h1:IM9QOFh15E1a4Nb6Rcn8FJ9Z1PbBpuyAPCty/qvKSAw=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
-k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20230505201702-9f6742963106 h1:EObNQ3TW2D+WptiYXlApGNLVy0zm/JIBVY9i+M4wpAU=
+k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/cpuallocator/cpuallocator_test.go
+++ b/pkg/cpuallocator/cpuallocator_test.go
@@ -20,10 +20,9 @@ import (
 	"path"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
-
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
 	"github.com/intel/cri-resource-manager/pkg/utils"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 )
 
 func TestAllocatorHelper(t *testing.T) {
@@ -67,7 +66,7 @@ func TestAllocatorHelper(t *testing.T) {
 			from:        cpuset.MustParse("2,3,10-14,20"),
 			prefer:      PriorityNormal,
 			cnt:         9,
-			expected:    cpuset.NewCPUSet(),
+			expected:    cpuset.New(),
 		},
 		{
 			description: "request all available CPUs",
@@ -81,7 +80,7 @@ func TestAllocatorHelper(t *testing.T) {
 			from:        cpuset.MustParse("2,3,10-25"),
 			prefer:      PriorityHigh,
 			cnt:         4,
-			expected:    cpuset.NewCPUSet(2, 3, 15, 17),
+			expected:    cpuset.New(2, 3, 15, 17),
 		},
 	}
 

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -27,13 +27,13 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/apis/resmgr"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/topology"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 

--- a/pkg/cri/resource-manager/control/cpu/cpu.go
+++ b/pkg/cri/resource-manager/control/cpu/cpu.go
@@ -17,14 +17,13 @@ package cpu
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
-
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cri/client"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	"github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -155,7 +154,7 @@ func (ctl *cpuctl) enforceUncore(assignments cpuClassAssignments, affectedCPUs .
 		return nil
 	}
 
-	cpus := cpuset.NewCPUSet(affectedCPUs...)
+	cpus := cpuset.New(affectedCPUs...)
 
 	for _, cpuPkgID := range ctl.system.PackageIDs() {
 		cpuPkg := ctl.system.Package(cpuPkgID)
@@ -164,7 +163,7 @@ func (ctl *cpuctl) enforceUncore(assignments cpuClassAssignments, affectedCPUs .
 
 			// Check if this die is affected by the specified cpuset
 			if cpus.Size() == 0 || dieCPUs.Intersection(cpus).Size() > 0 {
-				min, max, minCls, maxCls := effectiveUncoreFreqs(utils.NewIDSet(dieCPUs.ToSlice()...), ctl.config.Classes, assignments)
+				min, max, minCls, maxCls := effectiveUncoreFreqs(utils.NewIDSet(dieCPUs.List()...), ctl.config.Classes, assignments)
 
 				if min == 0 && max == 0 {
 					log.Debug("no uncore frequency limits for cpu package/die %d/%d", cpuPkgID, cpuDieID)

--- a/pkg/cri/resource-manager/policy/builtin/balloons/metrics.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/metrics.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 // Prometheus Metric descriptor indices and descriptor table

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
@@ -35,6 +34,7 @@ import (
 	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/utils"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -125,7 +125,7 @@ func (dp *DynamicPool) updateRealCpuUsed(cpuInfo []float64) (float64, error) {
 		log.Debug("dynamic pool %s cpuset is 0", dp.Def.Name)
 		return 0, nil
 	}
-	cpus := dp.Cpus.ToSliceNoSort()
+	cpus := dp.Cpus.UnsortedList()
 	var sum float64
 	for i := 0; i < len(cpus); i++ {
 		sum += cpuInfo[cpus[i]]
@@ -313,7 +313,7 @@ func CreateDynamicPoolsPolicy(policyOptions *policy.BackendOptions) policy.Backe
 		p.allowed = policyOptions.System.CPUSet().Difference(policyOptions.System.Offlined())
 	}
 	// p.reserved: CPUs reserved for kube-system pods, subset of p.allowed.
-	p.reserved = cpuset.NewCPUSet()
+	p.reserved = cpuset.New()
 	if reserved, ok := p.options.Reserved[policyapi.DomainCPU]; ok {
 		switch v := reserved.(type) {
 		case cpuset.CPUSet:
@@ -582,7 +582,7 @@ func (p *dynamicPools) useCpuClass(dp *DynamicPool) error {
 	// - User-defined CPU AllocatorPriority: dp.Def.AllocatorPriority.
 	// - All existing dynamicPool instances: p.dynamicPools.
 	// - CPU configurations by user: dp.Def.CpuClass (for dp in p.dynamicPools)
-	cpucontrol.Assign(p.cch, dp.Def.CpuClass, dp.Cpus.ToSliceNoSort()...)
+	cpucontrol.Assign(p.cch, dp.Def.CpuClass, dp.Cpus.UnsortedList()...)
 	log.Debugf("useCpuClass Cpus: %s; CpuClass: %s", dp.Cpus, dp.Def.CpuClass)
 	return nil
 }

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
@@ -17,7 +17,7 @@ package dyp
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 )
 
 func TestChangesDynamicPools(t *testing.T) {
@@ -86,25 +86,25 @@ func TestIsNeedReallocate(t *testing.T) {
 				Def: &DynamicPoolDef{
 					Name: reservedDynamicPoolDefName,
 				},
-				Cpus: cpuset.NewCPUSet(1, 2),
+				Cpus: cpuset.New(1, 2),
 			},
 			{
 				Def: &DynamicPoolDef{
 					Name: sharedDynamicPoolDefName,
 				},
-				Cpus: cpuset.NewCPUSet(3, 4, 5, 6),
+				Cpus: cpuset.New(3, 4, 5, 6),
 			},
 			{
 				Def: &DynamicPoolDef{
 					Name: "poo1",
 				},
-				Cpus: cpuset.NewCPUSet(7, 8, 9, 10, 11, 12),
+				Cpus: cpuset.New(7, 8, 9, 10, 11, 12),
 			},
 			{
 				Def: &DynamicPoolDef{
 					Name: "poo2",
 				},
-				Cpus: cpuset.NewCPUSet(0),
+				Cpus: cpuset.New(0),
 			},
 		},
 	}
@@ -146,32 +146,32 @@ func TestIsNeedReallocate(t *testing.T) {
 
 func TestCalculatePoolCpuset(t *testing.T) {
 	p := &dynamicPools{
-		allowed:  cpuset.NewCPUSet(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
-		reserved: cpuset.NewCPUSet(1, 2),
+		allowed:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+		reserved: cpuset.New(1, 2),
 		dynamicPools: []*DynamicPool{
 			{
 				Def: &DynamicPoolDef{
 					Name: reservedDynamicPoolDefName,
 				},
-				Cpus: cpuset.NewCPUSet(1, 2),
+				Cpus: cpuset.New(1, 2),
 			},
 			{
 				Def: &DynamicPoolDef{
 					Name: sharedDynamicPoolDefName,
 				},
-				Cpus: cpuset.NewCPUSet(3, 4, 5, 6),
+				Cpus: cpuset.New(3, 4, 5, 6),
 			},
 			{
 				Def: &DynamicPoolDef{
 					Name: "poo1",
 				},
-				Cpus: cpuset.NewCPUSet(7, 8, 9, 10, 11, 12, 13),
+				Cpus: cpuset.New(7, 8, 9, 10, 11, 12, 13),
 			},
 			{
 				Def: &DynamicPoolDef{
 					Name: "poo2",
 				},
-				Cpus: cpuset.NewCPUSet(0),
+				Cpus: cpuset.New(0),
 			},
 		},
 	}

--- a/pkg/cri/resource-manager/policy/builtin/dynamic-pools/metrics.go
+++ b/pkg/cri/resource-manager/policy/builtin/dynamic-pools/metrics.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 // Prometheus Metric descriptor indices and descriptor table

--- a/pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	pkgcfg "github.com/intel/cri-resource-manager/pkg/config"
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
@@ -34,6 +33,7 @@ import (
 	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/utils"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -136,7 +136,7 @@ func CreatePodpoolsPolicy(policyOptions *policy.BackendOptions) policy.Backend {
 		p.allowed = policyOptions.System.CPUSet().Difference(policyOptions.System.Offlined())
 	}
 	// p.reserved: CPUs reserved for kube-system pods, subset of p.allowed.
-	p.reserved = cpuset.NewCPUSet()
+	p.reserved = cpuset.New()
 	if reserved, ok := p.options.Reserved[policyapi.DomainCPU]; ok {
 		switch v := reserved.(type) {
 		case cpuset.CPUSet:

--- a/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,6 +32,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 )
 
 const (
@@ -291,7 +291,7 @@ func (p *staticplus) setupPools(available, reserved policy.ConstraintSet) error 
 		qty := cpus.(resource.Quantity)
 		count := (int(qty.MilliValue()) + 999) / 1000
 		if count < 2 && p.available.Contains(0) {
-			p.reserved = cpuset.NewCPUSet(0)
+			p.reserved = cpuset.New(0)
 			p.available = p.available.Difference(p.reserved)
 		} else {
 			p.reserved, err = p.takeCPUs(&p.available, nil, count, cpuallocator.PriorityNormal)

--- a/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/static/static-policy.go
@@ -20,7 +20,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/config"
 	logger "github.com/intel/cri-resource-manager/pkg/log"
@@ -33,6 +32,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	"github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -335,7 +335,7 @@ func (s *static) allocateOrdinaryCPUs(numCPUs int) (cpuset.CPUSet, error) {
 	result, err := s.takeByTopology(assignable, numCPUs, cpuallocator.PriorityHigh)
 
 	if err != nil {
-		return cpuset.NewCPUSet(), err
+		return cpuset.New(), err
 	}
 
 	s.Info("allocated %d ordinary CPUs: %s", numCPUs, result.String())

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
@@ -18,9 +18,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
-
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/cache_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/cache_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 )
 
 func TestToGrant(t *testing.T) {
@@ -104,8 +104,8 @@ func TestAllocationMarshalling(t *testing.T) {
 							node: node{
 								name:    "testnode",
 								kind:    UnknownNode,
-								noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
-								freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
+								noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
+								freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(0, 0, 0), createMemoryMap(0, 0, 0)),
 							},
 						},
 					},

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
@@ -20,8 +20,8 @@ import (
 
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
 	"github.com/intel/cri-resource-manager/pkg/topology"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 // Calculate the hint score of the given hint and CPUSet.

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/hint_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/hint_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 
 	"github.com/intel/cri-resource-manager/pkg/topology"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 func TestCpuHintScore(t *testing.T) {
@@ -51,7 +51,7 @@ func TestCpuHintScore(t *testing.T) {
 			hint: topology.Hint{
 				CPUs: "1,2",
 			},
-			cpus:     cpuset.NewCPUSet(1),
+			cpus:     cpuset.New(1),
 			expected: 0.5,
 		},
 	}
@@ -198,7 +198,7 @@ func TestHintCpus(t *testing.T) {
 			hint: topology.Hint{
 				CPUs: "1",
 			},
-			expected: cpuset.NewCPUSet(1),
+			expected: cpuset.New(1),
 		},
 	}
 	for _, tc := range tcases {

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/config"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
 	"github.com/intel/cri-resource-manager/pkg/topology"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	"github.com/intel/goresctrl/pkg/sst"
 	idset "github.com/intel/goresctrl/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 type mockSystemNode struct {
@@ -63,7 +63,7 @@ func (fake *mockSystemNode) HasNormalMemory() bool {
 }
 
 func (fake *mockSystemNode) CPUSet() cpuset.CPUSet {
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 
 func (fake *mockSystemNode) Distance() []int {
@@ -85,7 +85,7 @@ func (p *mockCPUPackage) ID() idset.ID {
 }
 
 func (p *mockCPUPackage) CPUSet() cpuset.CPUSet {
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 
 func (p *mockCPUPackage) NodeIDs() []idset.ID {
@@ -97,7 +97,7 @@ func (p *mockCPUPackage) DieIDs() []idset.ID {
 }
 
 func (p *mockCPUPackage) DieCPUSet(idset.ID) cpuset.CPUSet {
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 
 func (p *mockCPUPackage) DieNodeIDs(idset.ID) []idset.ID {
@@ -138,7 +138,7 @@ func (c *mockCPU) CoreID() idset.ID {
 	return c.id
 }
 func (c *mockCPU) ThreadCPUSet() cpuset.CPUSet {
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 func (c *mockCPU) FrequencyRange() system.CPUFreq {
 	return system.CPUFreq{}
@@ -190,17 +190,17 @@ func (fake *mockSystem) Package(idset.ID) system.CPUPackage {
 	return &mockCPUPackage{}
 }
 func (fake *mockSystem) Offlined() cpuset.CPUSet {
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 func (fake *mockSystem) Isolated() cpuset.CPUSet {
 	if fake.isolatedCPU > 0 {
-		return cpuset.NewCPUSet(fake.isolatedCPU)
+		return cpuset.New(fake.isolatedCPU)
 	}
 
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 func (fake *mockSystem) CPUSet() cpuset.CPUSet {
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 func (fake *mockSystem) CPUIDs() []idset.ID {
 	return []idset.ID{}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
@@ -18,11 +18,10 @@ import (
 	"math"
 	"sort"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
-
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools_test.go
@@ -29,7 +29,7 @@ import (
 
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"
 	"github.com/intel/cri-resource-manager/pkg/utils"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 )
 
 func findNodeWithID(id int, nodes []Node) Node {
@@ -96,8 +96,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -122,8 +122,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(9999, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -148,8 +148,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 				},
 				&numanode{
@@ -157,8 +157,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      101,
 						name:    "testnode1",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(10001, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -183,8 +183,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      100,
 						name:    "testnode0",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(12000, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 				},
 				&numanode{
@@ -192,8 +192,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      101,
 						name:    "testnode1",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 0, // system node id
 				},
@@ -202,8 +202,8 @@ func TestMemoryLimitFiltering(t *testing.T) {
 						id:      102,
 						name:    "testnode2",
 						kind:    UnknownNode,
-						noderes: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
-						freeres: newSupply(&node{}, cpuset.NewCPUSet(), cpuset.NewCPUSet(), cpuset.NewCPUSet(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						noderes: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
+						freeres: newSupply(&node{}, cpuset.New(), cpuset.New(), cpuset.New(), 0, 0, createMemoryMap(6000, 0, 0), createMemoryMap(0, 0, 0)),
 					},
 					id: 1, // system node id
 				},

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
@@ -20,12 +20,11 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cpuallocator"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
-	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/kubernetes"
 	"github.com/intel/cri-resource-manager/pkg/topology"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -783,16 +782,16 @@ func (cs *supply) DumpCapacity() string {
 	cpu, mem, sep := "", cs.mem.String(), ""
 
 	if !cs.isolated.IsEmpty() {
-		cpu = fmt.Sprintf("isolated:%s", kubernetes.ShortCPUSet(cs.isolated))
+		cpu = fmt.Sprintf("isolated:%s", cpuset.ShortCPUSet(cs.isolated))
 		sep = ", "
 	}
 	if !cs.reserved.IsEmpty() {
-		cpu += sep + fmt.Sprintf("reserved:%s (%dm)", kubernetes.ShortCPUSet(cs.reserved),
+		cpu += sep + fmt.Sprintf("reserved:%s (%dm)", cpuset.ShortCPUSet(cs.reserved),
 			1000*cs.reserved.Size())
 		sep = ", "
 	}
 	if !cs.sharable.IsEmpty() {
-		cpu += sep + fmt.Sprintf("sharable:%s (%dm)", kubernetes.ShortCPUSet(cs.sharable),
+		cpu += sep + fmt.Sprintf("sharable:%s (%dm)", cpuset.ShortCPUSet(cs.sharable),
 			1000*cs.sharable.Size())
 	}
 
@@ -820,11 +819,11 @@ func (cs *supply) DumpAllocatable() string {
 	cpu, mem, sep := "", cs.mem.String(), ""
 
 	if !cs.isolated.IsEmpty() {
-		cpu = fmt.Sprintf("isolated:%s", kubernetes.ShortCPUSet(cs.isolated))
+		cpu = fmt.Sprintf("isolated:%s", cpuset.ShortCPUSet(cs.isolated))
 		sep = ", "
 	}
 	if !cs.reserved.IsEmpty() {
-		cpu += sep + fmt.Sprintf("reserved:%s (allocatable: %dm)", kubernetes.ShortCPUSet(cs.reserved), cs.AllocatableReservedCPU())
+		cpu += sep + fmt.Sprintf("reserved:%s (allocatable: %dm)", cpuset.ShortCPUSet(cs.reserved), cs.AllocatableReservedCPU())
 		sep = ", "
 		if cs.grantedReserved > 0 {
 			cpu += sep + fmt.Sprintf("grantedReserved:%dm", cs.grantedReserved)
@@ -833,7 +832,7 @@ func (cs *supply) DumpAllocatable() string {
 	local_grantedShared := cs.grantedShared
 	total_grantedShared := cs.node.GrantedSharedCPU()
 	if !cs.sharable.IsEmpty() {
-		cpu += sep + fmt.Sprintf("sharable:%s (", kubernetes.ShortCPUSet(cs.sharable))
+		cpu += sep + fmt.Sprintf("sharable:%s (", cpuset.ShortCPUSet(cs.sharable))
 		sep = ""
 		if local_grantedShared > 0 || total_grantedShared > 0 {
 			cpu += fmt.Sprintf("grantedShared:")

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
@@ -17,7 +17,6 @@ package topologyaware
 import (
 	v1 "k8s.io/api/core/v1"
 	resapi "k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,6 +26,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/cache"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 
 	policyapi "github.com/intel/cri-resource-manager/pkg/cri/resource-manager/policy"
 	system "github.com/intel/cri-resource-manager/pkg/sysfs"

--- a/pkg/cri/resource-manager/policy/flags.go
+++ b/pkg/cri/resource-manager/policy/flags.go
@@ -25,10 +25,10 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/cgroups"
 	"github.com/intel/cri-resource-manager/pkg/config"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 )
 
 const (

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/intel/cri-resource-manager/pkg/blockio"
 	"github.com/intel/cri-resource-manager/pkg/config"
@@ -31,6 +30,7 @@ import (
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/control/rdt"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/events"
 	"github.com/intel/cri-resource-manager/pkg/cri/resource-manager/introspect"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	"github.com/prometheus/client_golang/prometheus"
 
 	logger "github.com/intel/cri-resource-manager/pkg/log"

--- a/pkg/procstats/procstats.go
+++ b/pkg/procstats/procstats.go
@@ -99,7 +99,7 @@ func (t *CPUTimeStat) GetCPUTimeStat() error {
 			t.PrevTotalTime[i] = t.CurTotalTime[i]
 		}
 	}
-	for _, i := range sys.Offlined().ToSlice() {
+	for _, i := range sys.Offlined().List() {
 		t.DeltaIdleTime[i] = 0.0
 		t.DeltaTotalTime[i] = 0.0
 		t.PrevIdleTime[i] = t.CurIdleTime[i]

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -22,10 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
-
 	logger "github.com/intel/cri-resource-manager/pkg/log"
 	"github.com/intel/cri-resource-manager/pkg/utils"
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
 	"github.com/intel/goresctrl/pkg/sst"
 	idset "github.com/intel/goresctrl/pkg/utils"
 )
@@ -735,7 +734,7 @@ func readCPUsetFile(base, entry string) (cpuset.CPUSet, error) {
 
 	blob, err := ioutil.ReadFile(path)
 	if err != nil {
-		return cpuset.NewCPUSet(), sysfsError(path, "failed to read sysfs entry: %v", err)
+		return cpuset.New(), sysfsError(path, "failed to read sysfs entry: %v", err)
 	}
 
 	return cpuset.Parse(strings.Trim(string(blob), "\n"))
@@ -775,16 +774,16 @@ func (sys *system) discoverNodes() error {
 			memoryNodeIDs, err)
 	}
 
-	cpuNodesBuilder := cpuset.NewBuilder()
+	cpuNodesSlice := []int{}
 	for id, node := range sys.nodes {
 		if node.cpus.Size() > 0 {
-			cpuNodesBuilder.Add(int(id))
+			cpuNodesSlice = append(cpuNodesSlice, int(id))
 		}
 		if normalMemNodes.Contains(int(id)) {
 			node.normalMem = true
 		}
 	}
-	cpuNodes := cpuNodesBuilder.Result()
+	cpuNodes := cpuset.New(cpuNodesSlice...)
 
 	sys.Logger.Info("NUMA nodes with CPUs: %s", cpuNodes.String())
 	sys.Logger.Info("NUMA nodes with (any) memory: %s", memoryNodes.String())
@@ -1056,7 +1055,7 @@ func (p *cpuPackage) DieCPUSet(id idset.ID) cpuset.CPUSet {
 	if dieCPUs, ok := p.dieCPUs[id]; ok {
 		return CPUSetFromIDSet(dieCPUs)
 	}
-	return cpuset.NewCPUSet()
+	return cpuset.New()
 }
 
 func (p *cpuPackage) SstInfo() *sst.SstPackageInfo {

--- a/pkg/sysfs/utils.go
+++ b/pkg/sysfs/utils.go
@@ -16,13 +16,14 @@ package sysfs
 
 import (
 	"fmt"
-	idset "github.com/intel/goresctrl/pkg/utils"
 	"io/ioutil"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/intel/cri-resource-manager/pkg/utils/cpuset"
+	idset "github.com/intel/goresctrl/pkg/utils"
 )
 
 // Get the trailing enumeration part of a name.
@@ -356,14 +357,14 @@ func formatValueList(sep string, value interface{}) (string, error) {
 
 // IDSetFromCPUSet returns an id set corresponding to a cpuset.CPUSet.
 func IDSetFromCPUSet(cset cpuset.CPUSet) idset.IDSet {
-	return idset.NewIDSetFromIntSlice(cset.ToSlice()...)
+	return idset.NewIDSetFromIntSlice(cset.List()...)
 }
 
 // CPUSetFromIDSet returns a cpuset.CPUSet corresponding to an id set.
 func CPUSetFromIDSet(s idset.IDSet) cpuset.CPUSet {
-	b := cpuset.NewBuilder()
+	cpus := []int{}
 	for id := range s {
-		b.Add(int(id))
+		cpus = append(cpus, int(id))
 	}
-	return b.Result()
+	return cpuset.New(cpus...)
 }

--- a/pkg/utils/cpuset/cpuset.go
+++ b/pkg/utils/cpuset/cpuset.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Intel Corporation. All Rights Reserved.
+// Copyright The NRI Plugins Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kubernetes
+package cpuset
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"k8s.io/utils/cpuset"
 )
+
+// CPUSet is an alias for k8s.io/utils/cpuset.CPUSet.
+type CPUSet = cpuset.CPUSet
+
+var (
+	// New is an alias for cpuset.New.
+	New = cpuset.New
+	// Parse is an alias for cpuset.Parse.
+	Parse = cpuset.Parse
+)
+
+// MustParse panics if parsing the given cpuset string fails.
+func MustParse(s string) cpuset.CPUSet {
+	cset, err := cpuset.Parse(s)
+	if err != nil {
+		panic(fmt.Errorf("failed to parse CPUSet %s: %w", s, err))
+	}
+	return cset
+}
 
 // ShortCPUSet prints the cpuset as a string, trying to further shorten compared to .String().
 func ShortCPUSet(cset cpuset.CPUSet) string {

--- a/pkg/utils/cpuset/cpuset_test.go
+++ b/pkg/utils/cpuset/cpuset_test.go
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kubernetes
+package cpuset
 
 import (
 	"testing"
-
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 func TestShortCPUSet(t *testing.T) {
@@ -39,7 +37,7 @@ func TestShortCPUSet(t *testing.T) {
 		},
 	}
 	for _, tc := range tcases {
-		cset := cpuset.MustParse(tc.source)
+		cset := MustParse(tc.source)
 		native := cset.String()
 		if native != tc.native {
 			t.Errorf("incorrect native CPUSet for %q, expected %q, got %q",


### PR DESCRIPTION
Instead of importing cpuset.CPUSet directly from the kubelet, switch to using k8s.io/utils/cpuset. However, don't import it directly all over the map. Instead wrap it in a single place (pkg/utils/cpuset) and import it everywhere else from there.

Switching cpuset from the kubelet internal to the publicly exported one greatly reduces the kubernetes blast radius in the code base, making it much easier to eventually remove the few reamining bits altogether. The offending files before and after this commit are:

```
klitkey1-mobl1 switch-to-k8sio-utils-cpuset $ git grep 'k8s.io/kubernetes/' HEAD^ -- '*.go' | sed 's/HEAD^://g;s/:.*$//g' | sort -u
pkg/cpuallocator/allocator.go
pkg/cpuallocator/cpuallocator_test.go
pkg/cri/resource-manager/cache/cache.go
pkg/cri/resource-manager/cache/cache_test.go
pkg/cri/resource-manager/cache/utils.go
pkg/cri/resource-manager/control/cpu/cpu.go
pkg/cri/resource-manager/kubernetes/cpuset.go
pkg/cri/resource-manager/kubernetes/cpuset_test.go
pkg/cri/resource-manager/kubernetes/kubernetes.go
pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
pkg/cri/resource-manager/policy/builtin/balloons/cputree.go
pkg/cri/resource-manager/policy/builtin/balloons/cputree_test.go
pkg/cri/resource-manager/policy/builtin/balloons/metrics.go
pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp.go
pkg/cri/resource-manager/policy/builtin/dynamic-pools/dyp_test.go
pkg/cri/resource-manager/policy/builtin/dynamic-pools/metrics.go
pkg/cri/resource-manager/policy/builtin/podpools/metrics.go
pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy.go
pkg/cri/resource-manager/policy/builtin/podpools/podpools-policy_test.go
pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
pkg/cri/resource-manager/policy/builtin/static/static-policy.go
pkg/cri/resource-manager/policy/builtin/topology-aware/cache.go
pkg/cri/resource-manager/policy/builtin/topology-aware/cache_test.go
pkg/cri/resource-manager/policy/builtin/topology-aware/hint.go
pkg/cri/resource-manager/policy/builtin/topology-aware/hint_test.go
pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
pkg/cri/resource-manager/policy/builtin/topology-aware/node.go
pkg/cri/resource-manager/policy/builtin/topology-aware/pools.go
pkg/cri/resource-manager/policy/builtin/topology-aware/pools_test.go
pkg/cri/resource-manager/policy/builtin/topology-aware/resources.go
pkg/cri/resource-manager/policy/builtin/topology-aware/topology-aware-policy.go
pkg/cri/resource-manager/policy/flags.go
pkg/cri/resource-manager/policy/policy.go
pkg/sysfs/system.go
pkg/sysfs/utils.go
test/functional/e2e_test.go
``` 

and

```
klitkey1-mobl1 switch-to-k8sio-utils-cpuset $ git grep 'k8s.io/kubernetes/' '*.go' | sed 's/:.*$//g' | sort -u
pkg/cri/resource-manager/cache/cache_test.go
pkg/cri/resource-manager/cache/utils.go
pkg/cri/resource-manager/kubernetes/kubernetes.go
pkg/cri/resource-manager/policy/builtin/static-plus/static-plus-policy.go
test/functional/e2e_test.go
```