### PR TITLE
github: take golang version from go.mod

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.20
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+      id: go
 
     - name: Install golangci-lint
       run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2


### PR DESCRIPTION
Fix the verify workflow to actually install the version of Go specified
in go.mod. Previously, because of the yaml parsing peculiarities go v1.2 was
installed.

Also changes the order of steps so that go.mod is available.

> **NOTE:** This expects that the practice from now on is to keep the Go version
> in go.mod and Makefile in sync.