### PR TITLE
docs: use ADD in the dockerfile to fetch go tarball

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,8 +3,11 @@ FROM sphinxdoc/sphinx:5.3.0
 RUN apt-get update && apt-get install -y wget git
 
 # Note: Any golang version that can 'go list -m -f {{.Variable}}' is fine...
-RUN wget https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
+ADD https://go.dev/dl/go1.18.3.linux-amd64.tar.gz /
+
+RUN tar -C /usr/local -xzf /go1.18.3.linux-amd64.tar.gz && \
+    rm /go1.18.3.linux-amd64.tar.gz
+
 ENV PATH=$PATH:/usr/local/go/bin
 
 COPY requirements.txt .


### PR DESCRIPTION
Speeds up subsequent builds as the tarball will be cached.