### PR TITLE
cross-build: get golang binaries instead of compiling from source

### DIFF
--- a/dockerfiles/cross-build/Dockerfile.centos-7
+++ b/dockerfiles/cross-build/Dockerfile.centos-7
@@ -3,7 +3,6 @@ FROM centos:7 as centos-7-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG GIT_VERSION=2.27.0
 ARG GIT_URLDIR=https://github.com/git/git/archive
 ARG CREATE_USER="build"
@@ -11,26 +10,9 @@ ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
 RUN yum install -y --nogpgcheck rpm-build \
-    kernel-devel clang gcc \
+    kernel-devel gcc \
     curl-devel zlib-devel openssl-devel expat-devel \
     make wget
-
-# fetch and build go from sources
-RUN arch="$(rpm --eval %{_arch})"; \
-    case "${arch}" in \
-        x86_64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
 
 # fetch and build a recent git from sources, anything below 1.9.5 is known to not work for us
 RUN mkdir /git && cd /git && wget $GIT_URLDIR/v$GIT_VERSION.tar.gz && \
@@ -38,6 +20,11 @@ RUN mkdir /git && cd /git && wget $GIT_URLDIR/v$GIT_VERSION.tar.gz && \
     make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr all && \
     yum remove -y git && \
     make -j8 NO_TCLTK=1 NO_GETTEXT=1 prefix=/usr install
+
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.centos-8
+++ b/dockerfiles/cross-build/Dockerfile.centos-8
@@ -3,7 +3,6 @@ FROM centos:8 as centos-8-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -12,24 +11,13 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 RUN dnf install -y rpm-build \
-    kernel-devel clang gcc \
-    git-core make wget
+    kernel-devel gcc \
+    git-core make
 
-RUN arch="$(rpm --eval %{_arch})"; \
-    case "${arch}" in \
-        x86_64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.debian-10
+++ b/dockerfiles/cross-build/Dockerfile.debian-10
@@ -3,7 +3,6 @@ FROM debian:buster as debian-10-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -12,24 +11,13 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
+        bash git make sed debhelper ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.debian-sid
+++ b/dockerfiles/cross-build/Dockerfile.debian-sid
@@ -3,7 +3,6 @@ FROM debian:sid as debian-sid-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -12,24 +11,13 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
+        bash git make sed debhelper ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.fedora
+++ b/dockerfiles/cross-build/Dockerfile.fedora
@@ -3,30 +3,18 @@ FROM fedora:latest as fedora-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
 RUN dnf install -y rpm-build systemd-rpm-macros \
-    kernel-devel gcc clang \
-    git-core make wget
+    kernel-devel gcc \
+    git-core make
 
-RUN arch="$(rpm --eval %{_arch})"; \
-    case "${arch}" in \
-        x86_64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.opensuse-leap-15.4
+++ b/dockerfiles/cross-build/Dockerfile.opensuse-leap-15.4
@@ -3,31 +3,18 @@ FROM opensuse/leap:15.4 as suse-15.4-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="build"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
 RUN zypper install -y rpm-build \
-    kernel-devel clang gcc \
-    git make \
-    wget
+    kernel-devel gcc \
+    git make
 
-RUN arch="$(rpm --eval %{_arch})"; \
-    case "${arch}" in \
-        x86_64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-18.04
@@ -3,7 +3,6 @@ FROM ubuntu:18.04 as ubuntu-18.04-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -12,24 +11,13 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
+        bash git make sed debhelper ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-20.04
@@ -3,7 +3,6 @@ FROM ubuntu:20.04 as ubuntu-20.04-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -13,24 +12,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         tzdata build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
+        bash git make sed debhelper ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 

--- a/dockerfiles/cross-build/Dockerfile.ubuntu-22.04
+++ b/dockerfiles/cross-build/Dockerfile.ubuntu-22.04
@@ -3,7 +3,6 @@ FROM ubuntu:22.04 as ubuntu-22.04-build
 
 ARG GO_VERSION=x.yz
 ARG GOLICENSES_VERSION
-ARG GOLANG_URLDIR=https://dl.google.com/go
 ARG CREATE_USER="test"
 ARG USER_OPTIONS=""
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -13,24 +12,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         tzdata build-essential fakeroot devscripts \
-        bash git make sed debhelper wget ca-certificates && \
+        bash git make sed debhelper ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN arch="$(dpkg --print-architecture)"; \
-    case "${arch##*-}" in \
-        amd64) goarch=linux-amd64;; \
-        i386) goarch=linux-386;; \
-        armhf) goarch=linux-armv6l;; \
-        ppc64el) goarch=linux-ppc64le;; \
-        s390x) goarch=linux-s390x;; \
-    esac; \
-    \
-    wget $GOLANG_URLDIR/go$GO_VERSION.$goarch.tar.gz -O go.tgz && \
-    tar -C /usr/local -xvzf go.tgz && rm go.tgz && \
-    \
-    export PATH="/usr/local/go/bin:$PATH" && \
-    echo "PATH=/usr/local/go/bin:$PATH" > /etc/profile.d/go.sh && \
-    go version
+ADD http://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /
+
+RUN tar xf /go${GO_VERSION}.linux-amd64.tar.gz -C "/usr/local" && \
+    rm /go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN GOBIN=/go/bin go install github.com/google/go-licenses@${GOLICENSES_VERSION}
 


### PR DESCRIPTION
Speed up builds considerably by reducing the download times (the golang tarball will be cached by docker) and skipping the build of golang itself.