### PR TITLE
github: drop containerized build of docs from verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,11 +36,6 @@ jobs:
     - name: Codecov report
       run: bash <(curl -s https://codecov.io/bash)
 
-    - name: Build docs
-      run: |
-        make site-build
-        make clean-html
-
     - name: Install gh-pages build dependencies
       run: |
         pip3 install --user -r docs/requirements.txt


### PR DESCRIPTION
Buildability of docs and gh-pages update are verified in the following steps anyway. Dropping the containerized build of docs speeds up CI.