### PR TITLE
github: refactor docs building

### DIFF
--- a/.github/workflows/common-build-docs.yaml
+++ b/.github/workflows/common-build-docs.yaml
@@ -1,0 +1,36 @@
+name: Build documentation
+on:
+  workflow_call:
+    inputs:
+      publish:
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  update-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Fetch gh-pages
+      run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages
+
+    - name: Install build dependencies
+      run: |
+        pip3 install --user -r docs/requirements.txt
+        echo "`python3 -m site --user-base`/bin" >> $GITHUB_PATH
+
+    - name: Add docs from this revision to gh-pages
+      run: |
+        git config user.name "Github"
+        git config user.email "no-reply@github.com"
+        ./scripts/build/update-gh-pages.sh
+
+    - name: Publish gh-pages
+      if: ${{ inputs.publish }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git gh-pages

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish documentation
 
 on:
   push:
@@ -13,27 +13,6 @@ concurrency:
 
 jobs:
   update-gh-pages:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Fetch gh-pages
-      run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages
-
-    - name: Install build dependencies
-      run: |
-        pip3 install --user -r docs/requirements.txt
-        echo "`python3 -m site --user-base`/bin" >> $GITHUB_PATH
-
-    - name: Add docs from this revision to gh-pages
-      run: |
-        git config user.name "Github"
-        git config user.email "no-reply@github.com"
-        ./scripts/build/update-gh-pages.sh
-
-    - name: Publish/push to gh-pages
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git gh-pages
+    uses: "./.github/workflows/common-build-docs.yaml"
+    with:
+      publish: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,13 +36,6 @@ jobs:
     - name: Codecov report
       run: bash <(curl -s https://codecov.io/bash)
 
-    - name: Install gh-pages build dependencies
-      run: |
-        pip3 install --user -r docs/requirements.txt
-        echo "`python3 -m site --user-base`/bin" >> $GITHUB_PATH
-
-    - name: Verify update of gh-pages
-      run: |
-        git config user.name "Github"
-        git config user.email "no-reply@github.com"
-        ./scripts/build/update-gh-pages.sh
+  build-docs:
+    name: Verify docs build and gh-pages update
+    uses: "./.github/workflows/common-build-docs.yaml"


### PR DESCRIPTION
Refactor the docs-build into a re-usable job called from both the verify and publish workflows.