### PR TITLE
github: split security scanning into re-usable jobs

### DIFF
--- a/.github/workflows/common-codeql.yaml
+++ b/.github/workflows/common-codeql.yaml
@@ -1,0 +1,19 @@
+name: CodeQL scanning
+on:
+  workflow_call:
+
+jobs:
+  codeql-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: go
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/common-trivy.yaml
+++ b/.github/workflows/common-trivy.yaml
@@ -1,15 +1,18 @@
-name: Security Scanning
-
+name: Trivy scanning
 on:
-  push:
-    branches: [ "master", "release-*"  ]
-    tags: [ 'v*' ]
-  pull_request:
-    branches: [ "master", "release-*" ]
+  workflow_call:
+    inputs:
+      upload-to-github-security-tab:
+        default: false
+        required: false
+        type: boolean
+      export-csv:
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   trivy-scan-code:
-    name: Trivy scan
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -36,6 +39,7 @@ jobs:
         format: table
 
     - name: Convert report to sarif
+      if: ${{ inputs.upload-to-github-security-tab }}
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: convert
@@ -45,7 +49,14 @@ jobs:
         format: sarif
         output: trivy-report.sarif
 
+    - name: Upload sarif report to GitHub Security tab
+      if: ${{ inputs.upload-to-github-security-tab }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+       sarif_file: trivy-report.sarif
+
     - name: Convert report to csv
+      if: ${{ inputs.export-csv }}
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: convert
@@ -56,39 +67,9 @@ jobs:
         template: "@.github/workflows/trivy-csv.tpl"
         output: trivy-report.csv
 
-    - name: Upload sarif report to GitHub Security tab
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-       sarif_file: trivy-report.sarif
-
     - name: Upload CSV report as an artifact
+      if: ${{ inputs.export-csv }}
       uses: actions/upload-artifact@v3
       with:
         name: trivy-report
         path: trivy-report.csv
-
-  codeQL-scanning:
-    runs-on: ubuntu-latest
-    environment:
-      name: dev
-      url: https://github.com
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: go
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-
-    - name: Upload result to GitHub Code Scanning
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-          sarif_file: codeql.sarif
-          wait-for-processing: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,3 +39,9 @@ jobs:
   build-docs:
     name: Verify docs build and gh-pages update
     uses: "./.github/workflows/common-build-docs.yaml"
+
+  trivy-scan:
+    uses: "./.github/workflows/common-trivy.yaml"
+
+  codeql-scan:
+    uses: "./.github/workflows/common-codeql.yaml"


### PR DESCRIPTION
Split the security scanning workflow into separate parameterized jobs. This makes them re-usable for diiferent workflows, e.g. CI on PRs and image-publishing.

Also drop unneeded and broken parts from the CodeQL scanning job.