### PR TITLE
fixes: fix a few innocent codeql alert.

### DIFF
--- a/pkg/cgroups/cgroupstats.go
+++ b/pkg/cgroups/cgroupstats.go
@@ -467,7 +467,7 @@ func GetGlobalNumaStats() (map[int]GlobalNumaStats, error) {
 
 	for _, dir := range nodeDirs {
 		id := strings.TrimPrefix(dir, prefix)
-		node, err := strconv.ParseInt(id, 10, 64)
+		node, err := strconv.ParseInt(id, 10, 0)
 		if err != nil {
 			return map[int]GlobalNumaStats{}, fmt.Errorf("error parsing directory name")
 		}

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -722,7 +722,7 @@ func getTopologyHints(hostPath, containerPath string, readOnly bool) topology.Hi
 	ignoredTopologyPathRegexps := []*regexp.Regexp{
 		// Kubelet directory can be different, but we can detect it by structure inside of it.
 		// For now, we can safely ignore exposed config maps and secrets for topology hints.
-		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes.io~(configmap|secret)/`),
+		regexp.MustCompile(`(kubelet)?/pods/[[:xdigit:]-]+/volumes/kubernetes\.io~(configmap|secret)/`),
 	}
 	for _, re := range ignoredTopologyPathRegexps {
 		if re.MatchString(hostPath) || re.MatchString(containerPath) {


### PR DESCRIPTION
Fix the following rather innocent two codeql alerts:
- cache: escape '.' in topology path regexp
- cgroupstats: node to int-sized integer (as opposed to int64) before casting to int