### PR TITLE
Makefile: remove -it arg from docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,7 @@ cross-rpm.%: docker/cross-build/% clean-spec spec dist
 	rm -fr $$builddir && mkdir -p $$builddir/{input,build} && \
 	cp cri-resource-manager-$(TAR_VERSION).tar$(GZEXT) $$builddir/input && \
 	cp packaging/rpm/cri-resource-manager.spec $$builddir/input && \
-	$(DOCKER) run --rm -ti $(DOCKER_OPTIONS) --user $$USER \
+	$(DOCKER) run --rm $(DOCKER_OPTIONS) --user $$USER \
 	    --env USER_NAME="$(USER_NAME)" --env USER_EMAIL=$(USER_EMAIL) \
 	    -v $$(pwd)/$$builddir:/build \
 	    -v $$(pwd)/$$outdir:/output \
@@ -659,7 +659,7 @@ cross-deb.%: docker/cross-build/% \
 	rm -fr $$builddir && mkdir -p $$builddir/{input,build} && \
 	cp cri-resource-manager-$(TAR_VERSION).tar$(GZEXT) $$builddir/input && \
 	cp -r debian $$builddir/input && \
-	$(DOCKER) run --rm -ti $(DOCKER_OPTIONS) --user $$USER \
+	$(DOCKER) run --rm $(DOCKER_OPTIONS) --user $$USER \
 	    --env USER_NAME="$(USER_NAME)" --env USER_EMAIL=$(USER_EMAIL) \
 	    -v $$(pwd)/$$builddir:/build \
 	    -v $$(pwd)/$$outdir:/output \
@@ -679,7 +679,7 @@ cross-bin.%: docker/cross-build/% dist
 	mkdir -p $(BINARIES_DIR)/$$distro && \
 	rm -fr $$builddir && mkdir -p $$builddir/{input,build} && \
 	cp cri-resource-manager-$(TAR_VERSION).tar$(GZEXT) $$builddir/input && \
-	$(DOCKER) run --rm -ti $(DOCKER_OPTIONS) --user $$USER \
+	$(DOCKER) run --rm $(DOCKER_OPTIONS) --user $$USER \
 	    --env USER_NAME="$(USER_NAME)" --env USER_EMAIL=$(USER_EMAIL) \
 	    -v $$(pwd)/$$builddir:/build \
 	    -v $$(pwd)/$$outdir:/output \
@@ -695,7 +695,7 @@ cross-tar cross-tarball: dist docker/cross-build/fedora
 	mkdir -p $$outdir && \
 	rm -fr $$builddir && mkdir -p $$builddir/{input,build} && \
 	cp cri-resource-manager-$(TAR_VERSION).tar$(GZEXT) $$builddir/input && \
-	$(DOCKER) run --rm -ti $(DOCKER_OPTIONS) --user $$USER \
+	$(DOCKER) run --rm $(DOCKER_OPTIONS) --user $$USER \
 	    --env USER_NAME="$(USER_NAME)" --env USER_EMAIL=$(USER_EMAIL) \
 	    -v $$(pwd)/$$builddir:/build \
 	    -v $$(pwd)/$$outdir:/output \


### PR DESCRIPTION
Makes it possible to run dockerized targets in CI, for example.