### PR TITLE
github: add workflows for image building

### DIFF
--- a/.github/workflows/common-build-images.yaml
+++ b/.github/workflows/common-build-images.yaml
@@ -1,0 +1,39 @@
+name: Build container images
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        default: ${{ github.ref_name }}
+        required: false
+        type: string
+      publish:
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  build-images:
+    name: Build and publish container images
+    runs-on: ubuntu-22.04
+    env:
+      IMAGE_REPO: intel
+      IMAGE_VERSION: ${{ inputs.image-tag }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build images
+      run: "make images IMAGE_VERSION=${IMAGE_VERSION}  Q="
+
+    - name: Login to Docker Hub
+      if: ${{ inputs.publish }}
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Push images
+      if: ${{ inputs.publish }}
+      run: "make images-push IMAGE_VERSION=${IMAGE_VERSION} Q="
+

--- a/.github/workflows/publish-devel-images.yaml
+++ b/.github/workflows/publish-devel-images.yaml
@@ -1,0 +1,25 @@
+name: Build and publish devel container images
+
+on:
+  push:
+    branches: ["master"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-scan:
+    uses: "./.github/workflows/common-trivy.yaml"
+
+  publish-images:
+    uses: "./.github/workflows/common-build-images.yaml"
+    needs: [trivy-scan]
+    secrets: inherit
+    environment:
+      name: staging
+      url: https://github.com
+    with:
+      publish: true
+      image-tag: "devel"
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Build and publish release artifacts
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-scan:
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      export-csv: true
+
+  publish-images:
+    uses: "./.github/workflows/common-build-images.yaml"
+    needs: [trivy-scan]
+    secrets: inherit
+    environment:
+      name: release
+      url: https://github.com
+    with:
+      publish: true
+      image-tag: ${{ github.ref_name }}


### PR DESCRIPTION
Add two new workflows, "Release" and "Publish devel images". The first one is intended for building and publishing all release artefacts - we now add only container images. The second one is for image-publishing only from the master branch.

The patch also adds a common re-usable image building job.