### PR TITLE
github: refactor verify workflow

### DIFF
--- a/.github/workflows/common-verify.yaml
+++ b/.github/workflows/common-verify.yaml
@@ -1,13 +1,13 @@
 name: Verify
-on: [push, pull_request]
-jobs:
 
-  build:
-    name: Build
+on:
+  - workflow_call
+
+jobs:
+  build-and-test:
     runs-on: ubuntu-22.04
     steps:
-
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v1
 
     - name: Set up Go
@@ -37,7 +37,6 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash)
 
   build-docs:
-    name: Verify docs build and gh-pages update
     uses: "./.github/workflows/common-build-docs.yaml"
 
   trivy-scan:

--- a/.github/workflows/verify-periodic.yaml
+++ b/.github/workflows/verify-periodic.yaml
@@ -1,0 +1,14 @@
+name: Verify branches periodic
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    uses: "./.github/workflows/common-verify.yaml"
+

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -1,0 +1,11 @@
+name: Verify PR
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    uses: "./.github/workflows/common-verify.yaml"


### PR DESCRIPTION
Change the verify workflow to run on PRs only. Add concurrency rule so that in-progress runs for a PR are canceled if the PR is updated before their completion.

Add a nightly verify workflow that runs on the master branch every day at 2:30 UTC.