### PR TITLE
github: build and upload release assets in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
     - name: Build packages
       run: "make cross-packages  Q="
 
+    - name: Build vendored dist tarball
+      run: "make vendored-dist  Q="
+
     - name: Upload release assets
       uses: softprops/action-gh-release@v1
       with:
@@ -43,3 +46,4 @@ jobs:
         append_body: true
         files: |
           packages/release-assets/*
+          vendored-cri-resource-manager-*.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,3 +24,22 @@ jobs:
     with:
       publish: true
       image-tag: ${{ github.ref_name }}
+
+  build-packages:
+    needs: [trivy-scan]
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build packages
+      run: "make cross-packages  Q="
+
+    - name: Upload release assets
+      uses: softprops/action-gh-release@v1
+      with:
+        name: ${{ github.ref_name }}
+        draft: true
+        append_body: true
+        files: |
+          packages/release-assets/*


### PR DESCRIPTION
Add release job for publishing binary packages and the vendored dist tarball in the release workflow.