### PR TITLE
github: fix the usage of github environments

### DIFF
--- a/.github/workflows/common-build-images.yaml
+++ b/.github/workflows/common-build-images.yaml
@@ -11,11 +11,16 @@ on:
         default: false
         required: false
         type: boolean
+      github-environment:
+        default: null
+        required: false
+        type: string
 
 jobs:
   build-images:
     name: Build and publish container images
     runs-on: ubuntu-22.04
+    environment: ${{ inputs.github-environment }}
     env:
       IMAGE_REPO: intel
       IMAGE_VERSION: ${{ inputs.image-tag }}

--- a/.github/workflows/publish-devel-images.yaml
+++ b/.github/workflows/publish-devel-images.yaml
@@ -16,10 +16,8 @@ jobs:
     uses: "./.github/workflows/common-build-images.yaml"
     needs: [trivy-scan]
     secrets: inherit
-    environment:
-      name: staging
-      url: https://github.com
     with:
       publish: true
       image-tag: "devel"
+      github-environment: "staging"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,12 +18,10 @@ jobs:
     uses: "./.github/workflows/common-build-images.yaml"
     needs: [trivy-scan]
     secrets: inherit
-    environment:
-      name: release
-      url: https://github.com
     with:
       publish: true
       image-tag: ${{ github.ref_name }}
+      github-environment: "release"
 
   build-packages:
     needs: [trivy-scan]


### PR DESCRIPTION
Fix the usage of github environments in the container image building. Environment cannot be specifiec in the "caller" job of re-usable "on workflow_call" workflows.