### PR TITLE
e2e: clean up vm as the last step in the static-pools test suite

### DIFF
--- a/test/e2e/policies.test-suite/static-pools/n4c16/test99-cleanup/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test99-cleanup/code.var.sh
@@ -1,0 +1,5 @@
+# This test cleans up static-pools test suite configurations from vm.
+# Other policy tests can be run after this test on the same vm without
+# recreating the vm from scratch.
+
+static-pools-cleanup

--- a/test/e2e/policies.test-suite/static-pools/static-pools-lib.source.sh
+++ b/test/e2e/policies.test-suite/static-pools/static-pools-lib.source.sh
@@ -23,3 +23,11 @@ static-pools-relaunch-cri-resmgr() {
         launch cri-resmgr-webhook
     fi
 }
+
+static-pools-cleanup() {
+    ( terminate cri-resmgr-agent )
+    ( uninstall cri-resmgr-webhook )
+    ( extended-resources remove cmk.intel.com/exclusive-cpus >/dev/null )
+    ( terminate cri-resmgr )
+    vm-command 'kubectl taint node $(hostname) cmk=true:NoSchedule-' || true
+}


### PR DESCRIPTION
Without this patch static-pools test suite leaves webhook and cmk node taint behind which will cause next tests on the same vm fail.