### PR TITLE
e2e: update default distro from Ubuntu 20.04 to 22.04

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEMO_TITLE="Container Runtime End-to-End Testing"
-DEFAULT_DISTRO="ubuntu-20.04"
+DEFAULT_DISTRO="ubuntu-22.04"
 
 PV='pv -qL'
 

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -3,7 +3,7 @@
 TESTS_DIR="$1"
 RUN_SH="${0%/*}/run.sh"
 
-DEFAULT_DISTRO="ubuntu-20.04"
+DEFAULT_DISTRO="ubuntu-22.04"
 
 usage() {
     echo "Usage: run_tests.sh TESTS_DIR"


### PR DESCRIPTION
Run tests in the latest Ubuntu LTS by default.