### PR TITLE
e2e: relax dynamic demotion first detection round requirement

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion-deprecated-syntax/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion-deprecated-syntax/code.var.sh
@@ -36,7 +36,7 @@ pages_per_second_per_process="$(awk '
 
 # After how many rounds (seconds) first migrations should be visible.
 first_migrations_visible="$(awk '
-    /PageScanInterval:/{gsub(/[^0-9]/, "", $2); print $2+3}
+    /PageScanInterval:/{gsub(/[^0-9]/, "", $2); print $2+8}
     ' < "$cri_resmgr_cfg")"
 
 # Expected migrated number of pages when fully migrated.

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/code.var.sh
@@ -38,7 +38,7 @@ pages_per_second_per_process="$(awk '
 
 # After how many rounds (seconds) first migrations should be visible.
 first_migrations_visible="$(awk '
-    /PageScanInterval:/{gsub(/[^0-9]/, "", $2); print $2+3}
+    /PageScanInterval:/{gsub(/[^0-9]/, "", $2); print $2+8}
     ' < "$cri_resmgr_cfg")"
 
 # Expected migrated number of pages when fully migrated.


### PR DESCRIPTION
Strict requirement makes the test flaky. Give two more rounds time for detecting first memory moves.