### PR TITLE
demoter: fix sudden cri-resmgr process exit on page demotion

### DIFF
--- a/pkg/cri/resource-manager/control/page-migrate/demoter.go
+++ b/pkg/cri/resource-manager/control/page-migrate/demoter.go
@@ -336,7 +336,7 @@ func (d *demoter) getPagesForContainer(c *container, sourceNodes idset.IDSet) (p
 		mapsBytes, err := os.ReadFile(mapsPath)
 		if err != nil {
 			log.Error("Could not read maps: %v\n", err)
-			os.Exit(1)
+			continue
 		}
 		mapsLines := strings.Split(string(mapsBytes), "\n")
 


### PR DESCRIPTION
Found processes are allowed to exit during reading their memory maps. This is not a fatal error, demotion can continue from the next pid.