### PR TITLE
e2e: use Fedora 38 for the fedora test target

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -391,11 +391,11 @@ centos-install-golang() {
 }
 
 fedora-image-url() {
-    fedora-36-image-url
+    fedora-38-image-url
 }
 
-fedora-36-image-url() {
-    echo "https://mirrors.xtom.de/fedora/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
+fedora-38-image-url() {
+    echo "https://mirrors.xtom.de/fedora/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
 }
 
 fedora-35-image-url() {


### PR DESCRIPTION
Fedora 36 has been EOL'd. Plus, we build rpm packages targeting fedora:latest.