### PR TITLE
e2e: use bridge cni plugin by default

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -381,10 +381,6 @@ centos-8-install-containerd-pre() {
     distro-install-repo https://download.docker.com/linux/centos/docker-ce.repo
 }
 
-centos-7-k8s-cni() {
-    echo "weavenet"
-}
-
 centos-install-golang() {
     distro-install-pkg wget tar gzip git-core
     from-tarball-install-golang
@@ -1059,7 +1055,7 @@ default-install-utils() {
 }
 
 default-k8s-cni() {
-    echo ${k8scni:-cilium}
+    echo ${k8scni:-bridge}
 }
 
 default-k8s-cni-subnet() {

--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -1046,6 +1046,25 @@ vm-destroy-cluster() {
     vm-command "yes | kubeadm reset; rm -f ~$user/.kube/config ~root/.kube/config /etc/kubernetes"
 }
 
+vm-install-cni-bridge() {
+    vm-command "rm -rf /etc/cni/net.d/* && mkdir -p /etc/cni/net.d && cat > /etc/cni/net.d/10-bridge.conf <<EOF
+{
+  \"cniVersion\": \"0.4.0\",
+  \"name\": \"demonet\",
+  \"type\": \"bridge\",
+  \"isGateway\": true,
+  \"ipMasq\": true,
+  \"ipam\": {
+    \"type\": \"host-local\",
+    \"subnet\": \"$CNI_SUBNET\",
+    \"routes\": [
+      { \"dst\": \"0.0.0.0/0\" }
+    ]
+  }
+}
+EOF"
+}
+
 vm-install-cni-cilium() {
     if ! vm-command "curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz && tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin && cilium install && rm -f cilium-linux-amd64.tar.gz"; then
         command-error "installing cilium CNI to Kubernetes failed"


### PR DESCRIPTION
Bridge networking is stupid and simple and works perfectly in our one node cluster setup. More complicated CNI setup brings no value in terms of testing cri-resmgr. Using bridge speeds up tests considerably (by eliminating all clilium/weavenet download and initialization time) plus should virtually eliminate all test flakyness related to CNI plugin failures.