### PR TITLE
e2e: add --wait to kubectl delete of pods and namespaces

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test01-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test01-basic-placement/code.var.sh
@@ -2,7 +2,7 @@
 # reserved and shared CPUs.
 
 cleanup() {
-    vm-command "kubectl delete pods -n kube-system pod0; kubectl delete pods -n three --all --now; kubectl delete pods --all --now; kubectl delete namespace three"
+    vm-command "kubectl delete pods -n kube-system pod0; kubectl delete pods --all --now --wait; kubectl delete namespace three --now --wait --ignore-not-found"
     return 0
 }
 

--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
@@ -1,7 +1,7 @@
 # This test verifies prometheus metrics from the balloons policy.
 
 cleanup() {
-    vm-command "kubectl delete pods --all --now"
+    vm-command "kubectl delete pods --all --now --wait"
     return 0
 }
 
@@ -55,17 +55,17 @@ verify-metrics-has-line 'balloon_type="flex"'
 verify-metrics-has-line 'balloon_type="flex".* 5'
 
 # check deflating a balloon in metrics
-kubectl delete pods --now pod3
+kubectl delete pods --now --wait --ignore-not-found pod3
 verify-metrics-has-line 'balloon_type="flex"'
 verify-metrics-has-line 'balloon_type="flex".* 2'
 
-kubectl delete pods --now pod4
+kubectl delete pods --now --wait --ignore-not-found pod4
 sleep 5
 # check popping a balloon from metrics
 verify-metrics-has-no-line 'balloon_type="flex"'
 
 # pop fast-dualcore[0], keep fast-dualcore[1]
-kubectl delete pods --now pod1
+kubectl delete pods --now --wait --ignore-not-found pod1
 verify-metrics-has-line 'balloon="fast-dualcore\[1\]"'
 sleep 5
 verify-metrics-has-no-line 'balloon="fast-dualcore\[0\]"'

--- a/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/code.var.sh
@@ -3,15 +3,15 @@ cri_resmgr_cfg=${TEST_DIR}/balloons-reserved.cfg launch cri-resmgr
 
 cleanup() {
     vm-command \
-        "kubectl delete pod -n kube-system --now pod0
-         kubectl delete pod -n monitor-mypods --now pod1
-         kubectl delete pod -n system-logs --now pod2
-         kubectl delete pod -n kube-system --now pod3
-         kubectl delete pods --now pod4 pod5 pod6
-         kubectl delete pod -n kube-system --now pod7
-         kubectl delete namespace monitor-mypods
-         kubectl delete namespace system-logs
-         kubectl delete namespace my-exact-name"
+        "kubectl delete pod -n kube-system --now --wait --ignore-not-found pod0
+         kubectl delete pod -n monitor-mypods --now --wait --ignore-not-found pod1
+         kubectl delete pod -n system-logs --now --wait --ignore-not-found pod2
+         kubectl delete pod -n kube-system --now --wait --ignore-not-found pod3
+         kubectl delete pods --now --wait --ignore-not-found pod4 pod5 pod6
+         kubectl delete pod -n kube-system --now --wait --ignore-not-found pod7
+         kubectl delete namespace monitor-mypods --wait --ignore-not-found
+         kubectl delete namespace system-logs --wait --ignore-not-found
+         kubectl delete namespace my-exact-name --wait --ignore-not-found"
     return 0
 }
 

--- a/test/e2e/policies.test-suite/balloons/n4c16/test05-namespace/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test05-namespace/code.var.sh
@@ -3,15 +3,11 @@ cri_resmgr_cfg=${TEST_DIR}/balloons-namespace.cfg launch cri-resmgr
 
 cleanup() {
     vm-command \
-        "kubectl delete pods -n e2e-a --all --now
-         kubectl delete pods -n e2e-b --all --now
-         kubectl delete pods -n e2e-c --all --now
-         kubectl delete pods -n e2e-d --all --now
-         kubectl delete pods --all --now
-         kubectl delete namespace e2e-a
-         kubectl delete namespace e2e-b
-         kubectl delete namespace e2e-c
-         kubectl delete namespace e2e-d"
+        "kubectl delete pods --all --now --wait
+         kubectl delete namespace e2e-a --wait --ignore-not-found
+         kubectl delete namespace e2e-b --wait --ignore-not-found
+         kubectl delete namespace e2e-c --wait --ignore-not-found
+         kubectl delete namespace e2e-d --wait --ignore-not-found"
     return 0
 }
 cleanup

--- a/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
@@ -4,11 +4,9 @@
 testns=e2e-balloons-test06
 
 cleanup() {
-    vm-command "kubectl delete pods --all --now; \
-        kubectl delete pods -n $testns --all --now; \
-        kubectl delete pods -n btype1ns0 --all --now; \
-        kubectl delete namespace $testns || :; \
-        kubectl delete namespace btype1ns0 || :"
+    vm-command "kubectl delete pods --all --now --wait; \
+        kubectl delete namespace $testns --now --wait --ignore-not-found || :; \
+        kubectl delete namespace btype1ns0 --now --wait --ignore-not-found || :"
     terminate cri-resmgr
     terminate cri-resmgr-agent
     vm-command "cri-resmgr -reset-policy; cri-resmgr -reset-config"

--- a/test/e2e/policies.test-suite/balloons/n4c16/test07-maxballoons/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test07-maxballoons/code.var.sh
@@ -1,5 +1,5 @@
 cleanup() {
-    vm-command "kubectl delete pods --all --now"
+    vm-command "kubectl delete pods --all --now --wait"
     return 0
 }
 
@@ -30,7 +30,7 @@ vm-command "kubectl describe pod pod2"
 if ! grep -q 'no suitable balloon instance available' <<< "$COMMAND_OUTPUT"; then
     error "could not find 'no suitable balloon instance available' in pod2 description"
 fi
-vm-command "kubectl delete pod pod2 --now"
+vm-command "kubectl delete pod pod2 --now --wait --ignore-not-found"
 
 # pod2: create dynamically the first dynamictwo balloon
 CPUREQ="800m" CPULIM="800m"
@@ -59,7 +59,7 @@ vm-command "kubectl describe pod pod5"
 if ! grep -q 'no suitable balloon instance available' <<< "$COMMAND_OUTPUT"; then
     error "could not find 'no suitable balloon instance available' in pod6 description"
 fi
-vm-command "kubectl delete pod pod5 --now"
+vm-command "kubectl delete pod pod5 --now --wait --ignore-not-found"
 
 cleanup
 

--- a/test/e2e/policies.test-suite/balloons/n4c16/test08-numa/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test08-numa/code.var.sh
@@ -76,7 +76,7 @@ verify 'len(cpus["pod0c0"]) == 4' \
        'disjoint_sets(cpus["pod0c0"], cpus["pod6c0"])'
 
 # Leave only one guaranteed container to the first balloon.
-kubectl delete pods pod1 pod2 pod3 --now
+kubectl delete pods pod1 pod2 pod3 --now --wait --ignore-not-found
 report allowed
 verify 'len(cpus["pod0c0"]) == 1' \
        'len(cpus["pod4c0"]) == 1' \
@@ -87,7 +87,7 @@ verify 'len(cpus["pod0c0"]) == 1' \
 
 # Leave only bestefforts to the first balloon. Make sure they still
 # have a CPU.
-kubectl delete pods pod4 --now
+kubectl delete pods pod4 --now --wait --ignore-not-found
 report allowed
 verify 'len(cpus["pod0c0"]) == 1' \
        'len(cpus["pod5c0"]) == 1' \

--- a/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c32/test01-dynamic-baloons/code.var.sh
@@ -42,7 +42,7 @@ verify-metrics-has-line 'sharedidlecpus_count="1"'
 verify 'len(nodes["pod8c0"])==2' \
        'len(dies["pod8c0"])==1' \
        'len(packages["pod8c0"])==1'
-kubectl delete pod pod8 --now
+kubectl delete pod pod8 --now --wait --ignore-not-found
 verify-metrics-has-no-line 'cpus_count="5"'
 
 # pod9: Add one more pod with 4 CPUs to inflate over dies, which should cross
@@ -54,7 +54,7 @@ create multicontainerpod
 verify 'len(nodes["pod9c0"])==4' \
        'len(dies["pod9c0"])==2' \
        'len(packages["pod9c0"])==1'
-kubectl delete pod pod9 --now
+kubectl delete pod pod9 --now --wait --ignore-not-found
 verify 'disjoint_sets(nodes["pod0c0"], nodes["pod1c0"], nodes["pod2c0"], nodes["pod3c0"], nodes["pod4c0"], nodes["pod5c0"], nodes["pod6c0"], nodes["pod7c0"])' \
 
 # pod9: Add one more pod with 7 CPUs to inflate over packages, which should cross
@@ -71,6 +71,6 @@ verify-metrics-has-no-line 'sharedidlecpus_count="1"'
 
 # pod0, pod9 deflate. This should free up 10 CPUs that will cause having
 # shared CPUs available again.
-kubectl delete pod pod10 --now
-kubectl delete pod pod0 --now
+kubectl delete pod pod10 --now --wait --ignore-not-found
+kubectl delete pod pod0 --now --wait --ignore-not-found
 verify-metrics-has-line 'sharedidlecpus_count="1"'

--- a/test/e2e/policies.test-suite/podpools/n4c16/test01-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test01-basic-placement/code.var.sh
@@ -1,7 +1,7 @@
 # Test placing containers with and without annotations to correct pools
 # reserved and shared CPUs.
 
-( kubectl delete pods pod3 -n kube-system --now ) || true
+( kubectl delete pods pod3 -n kube-system --now --wait --ignore-not-found ) || true
 
 # pod0: singlecpu
 out ""
@@ -42,7 +42,7 @@ verify 'cpus["pod3c0"] == cpus["pod3c1"] == cpus["pod3c2"]' \
        'cpus["pod3c0"] == expected.cpus.reserved[0]' \
        'mems["pod3c0"] == expected.mems.reserved[0]'
 
-kubectl delete pods pod3 -n kube-system --now
+kubectl delete pods pod3 -n kube-system --now --wait --ignore-not-found
 
 # pod4: bad pool name
 out ""
@@ -52,4 +52,4 @@ report allowed
 verify 'cpus["pod4c0"] == expected.cpus.default[0]' \
        'mems["pod4c0"] == expected.mems.default[0]'
 
-kubectl delete pods pod0 pod1 pod2 --now
+kubectl delete pods pod0 pod1 pod2 --now --wait --ignore-not-found

--- a/test/e2e/policies.test-suite/podpools/n4c16/test02-fill-order/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test02-fill-order/code.var.sh
@@ -35,7 +35,7 @@ verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
        'cpus["pod5c0"] == cpus["pod2c0"]' # the last pool should have been filled by pods 2 and 5
 
 # make a little room to the first pool and clear the last pool
-kubectl delete pods pod0 pod2 pod5 --now
+kubectl delete pods pod0 pod2 pod5 --now --wait --ignore-not-found
 
 # pod6: Balanced fill order should place this pod to the last pool (it has maximal free space)
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: singlecpu" CONTCOUNT=1 create podpools-busybox
@@ -43,7 +43,7 @@ report allowed
 verify 'disjoint_sets(cpus["pod6c0"],
                       set.union(cpus["pod1c0"], cpus["pod3c0"], cpus["pod4c0"]))'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 reset counters
 
 out "### Filling dualcpu pool in Packed fill order"
@@ -60,7 +60,7 @@ verify 'cpus["pod0c0"] == cpus["pod1c0"] == cpus["pod2c0"]' \
        'disjoint_sets(cpus["pod0c0"], cpus["pod3c0"])'
 
 # Deleting two pods from the first pool, one from the last.
-kubectl delete pods pod0 pod1 pod5
+kubectl delete pods pod0 pod1 pod5 --now --wait --ignore-not-found
 
 # pod6: Packed fill order should place this to the last pool (it has minimal free space)
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CONTCOUNT=1 create podpools-busybox

--- a/test/e2e/policies.test-suite/podpools/n4c16/test03-qos/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test03-qos/code.var.sh
@@ -34,7 +34,7 @@ verify-cpushare pod0c0 2 1
 verify-cpushare pod1c0 512 20
 verify-cpushare pod2c0 1024 39
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 reset counters
 
 out "### Assigning BestEffort, Burstable and Guaranteed pods shared CPUs"
@@ -50,7 +50,7 @@ verify-cpushare pod0c0 2 1
 verify-cpushare pod1c0 512 20
 verify-cpushare pod2c0 1024 39
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 reset counters
 
 out "### Assigning BestEffort, Burstable and Guaranteed pods reserved CPUs"
@@ -66,4 +66,4 @@ verify-cpushare pod0c0 2 1
 verify-cpushare pod1c0 512 20
 verify-cpushare pod2c0 1024 39
 
-kubectl delete pods pod0 pod1 pod2 -n kube-system
+kubectl delete pods pod0 pod1 pod2 -n kube-system --now --wait --ignore-not-found

--- a/test/e2e/policies.test-suite/podpools/n4c16/test04-overbook-cpus/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test04-overbook-cpus/code.var.sh
@@ -8,19 +8,19 @@ CRI_RESMGR_OUTPUT="cat cri-resmgr.output.txt"
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=2900m CPULIM="" MEMREQ="" MEMLIM="" create podpools-busybox
 report allowed
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*(2899|2900)m'" || error "missing overbook warning"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod1: overbook with single burstable pod with two containers
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1050m CPULIM="" MEMREQ="" MEMLIM="" CONTCOUNT=2 create podpools-busybox
 report allowed
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*2100m'" || error "missing overbook warning"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod2, pod3: overbook with two guaranteed pods, one container in each pod
 n=2 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=1001m MEMREQ=100M CPULIM=1001m MEMLIM=100M create podpools-busybox
 report allowed
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked.*2002m'" || error "missing overbook warning"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod4, pod5: no overbooking with exact CPUs guaranteed + besteffort pod
 terminate cri-resmgr # restart to clear log
@@ -29,7 +29,7 @@ POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=10
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ="" CPULIM="" MEMREQ="" MEMLIM="" create podpools-busybox
 report allowed
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*overbooked'" && error "overbook warning with maximum allowed load"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 # podpools logs misaligned CPU requests after pod deletion
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*bad CPU requests:.*pod4.* requested 2000 mCPUs.* 666 mCPUs'" || error "bad CPU request from pod4 expected but not found"
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*bad CPU requests:.*pod5.* requested 0 mCPUs.* 666 mCPUs'" || error "bad CPU request from pod5 expected but not found"
@@ -38,4 +38,4 @@ vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*bad CPU requests:.*pod5.* requeste
 POD_ANNOTATION="pool.podpools.cri-resource-manager.intel.com: dualcpu" CPUREQ=167m CPULIM="" MEMREQ="" MEMLIM="" CONTCOUNT=4 create podpools-busybox
 vm-command "$CRI_RESMGR_OUTPUT | grep -E '^E.*bad CPU requests:.*pod6'" && error "pod6 CPU request was ok, but 'bad CPU request' error found"
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait

--- a/test/e2e/policies.test-suite/podpools/n4c16/test05-agent-updates-config/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test05-agent-updates-config/code.var.sh
@@ -1,6 +1,6 @@
 # Relaunch cri-resmgr so that it will listen to cri-resmgr-agent
 cleanup() {
-    vm-command "kubectl delete pod -n kube-system pod0 --now; kubectl delete pods --all --now; kubectl delete cm -n kube-system cri-resmgr-config.default"
+    vm-command "kubectl delete pod -n kube-system pod0 --now --wait --ignore-not-found; kubectl delete pods --all --now --wait; kubectl delete cm -n kube-system cri-resmgr-config.default"
     terminate cri-resmgr
     terminate cri-resmgr-agent
     vm-command "cri-resmgr -reset-policy; cri-resmgr -reset-config"

--- a/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test06-prometheus-metrics/code.var.sh
@@ -1,7 +1,7 @@
 # Test reporting Prometheus metrics from podpools
 
 cleanup() {
-    vm-command "kubectl get pods -A | grep -E ' pod[0-9]' | while read namespace pod rest; do kubectl -n \$namespace delete pod \$pod --now; done"
+    vm-command "kubectl get pods -A | grep -E ' pod[0-9]' | while read namespace pod rest; do kubectl -n \$namespace delete pod \$pod --now --wait --ignore-not-found; done"
 }
 
 parse-commandoutput-log_pool_cpuset() {
@@ -41,7 +41,7 @@ verify-metrics-has-line() {
 
 # Delete left-over test pods from the kube-system namespace
 for podX in $(kubectl get pods -n kube-system | awk '/^pod[0-9]/{print $1}'); do
-    kubectl delete pods $podX -n kube-system --now
+    kubectl delete pods $podX -n kube-system --now --wait --ignore-not-found
 done
 
 metrics_url="http://localhost:8891/metrics"

--- a/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/code.var.sh
+++ b/test/e2e/policies.test-suite/podpools/n4c16/test07-custom-default-pool/code.var.sh
@@ -6,10 +6,9 @@ terminate cri-resmgr
 cri_resmgr_cfg=${TEST_DIR}/podpools-custom-default.cfg launch cri-resmgr
 
 cleanup() {
-    ( kubectl delete pods --all --now )
-    ( kubectl delete pod -n kube-system pod0c-mysystem )
-    ( kubectl delete pod -n daemons pod0c-mydaemon )
-    ( kubectl delete namespace daemons )
+    ( kubectl delete pods --all --now --wait )
+    ( kubectl delete pod -n kube-system pod0c-mysystem --now --wait --ignore-not-found )
+    ( kubectl delete namespace daemons --now --wait --ignore-not-found )
 }
 
 cleanup

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test01-exclusive-pods/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test01-exclusive-pods/code.var.sh
@@ -18,7 +18,7 @@ verify 'len(cores["pod0c0"]) == 1' \
 
 out ""
 out "### Deleting exclusive CMK pod"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 out ""
 out "### Creating exclusive CMK pod with 2 exclusive cores"
@@ -29,7 +29,7 @@ verify 'len(cores["pod1c0"]) == 2' \
 
 out ""
 out "### Deleting exclusive CMK pod"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 out ""
 out "### Creating two exclusive CMK pods with 1 exclusive core each"
@@ -49,7 +49,7 @@ verify 'len(cores["pod2c0"]) == 1' \
        'len(cores["pod4c0"]) == 1' \
        'disjoint_sets(cores["pod2c0"], cores["pod3c0"], cores["pod4c0"])' \
        'set.union(cores["pod2c0"], cores["pod3c0"], cores["pod4c0"]) == exclusive_cores'
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 out ""
 out "### Test consuming all exclusive cores without specifying STP_SOCKET_ID"

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test03-cmk-isolate/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test03-cmk-isolate/code.var.sh
@@ -45,7 +45,7 @@ verify 'cores["pod3c0"] == infra_cores'
 
 out ""
 out "### Deleting only exclusive CMK pods, leave shared/infra running"
-kubectl delete pods/pod0 pods/pod1 --now
+kubectl delete pods/pod0 pods/pod1 --now --wait --ignore-not-found
 
 export CMK_ISOLATE=", '--pool=exclusive'"
 out ""

--- a/test/e2e/policies.test-suite/static-pools/n4c16/test05-negative-tests/code.var.sh
+++ b/test/e2e/policies.test-suite/static-pools/n4c16/test05-negative-tests/code.var.sh
@@ -15,7 +15,7 @@ vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_non_existing_pool'" ||
     error "cannot find expected error message from pod description"
 out "Failed as expected"
 
-kubectl delete pods --all --now || error "failed to delete pods"
+kubectl delete pods --all --now --wait || error "failed to delete pods"
 
 out ""
 out "### Request cores from non-existing socket"
@@ -25,7 +25,7 @@ vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_not_enough_exclcores'" 
     error "cannot find expected error message from pod description"
 out "Failed as expected"
 
-kubectl delete pods --all --now || error "failed to delete pods"
+kubectl delete pods --all --now --wait || error "failed to delete pods"
 
 out ""
 out "### Request exclusive pool but do not mention exclusive-cores"
@@ -35,7 +35,7 @@ vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_zero_cores'" ||
     error "cannot find expected error message from pod description"
 out "Failed as expected"
 
-kubectl delete pods --all --now || error "failed to delete pods"
+kubectl delete pods --all --now --wait || error "failed to delete pods"
 
 out ""
 out "### Request 0 cores from exclusive pool"
@@ -45,7 +45,7 @@ vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_zero_cores'" ||
     error "cannot find expected error message from pod description"
 out "Failed as expected"
 
-kubectl delete pods --all --now || error "failed to delete pods"
+kubectl delete pods --all --now --wait || error "failed to delete pods"
 
 out ""
 out "### Request more cores from socket 0 than available"
@@ -55,7 +55,7 @@ vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_not_enough_exclcores'" 
     error "cannot find expected error message from pod description"
 out "Failed as expected"
 
-kubectl delete pods --all --now || error "failed to delete pods"
+kubectl delete pods --all --now --wait || error "failed to delete pods"
 
 out ""
 out "### Request more cores from socket 1 than available"
@@ -65,4 +65,4 @@ vm-run-until "kubectl describe pods/pod0 | grep '$errmsg_not_enough_exclcores'" 
     error "cannot find expected error message from pod description"
 out "Failed as expected"
 
-kubectl delete pods --all --now || error "failed to delete pods"
+kubectl delete pods --all --now --wait || error "failed to delete pods"

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion-deprecated-syntax/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion-deprecated-syntax/code.var.sh
@@ -103,4 +103,4 @@ while (( round < max_rounds )); do
     round=$(( round + 1 ))
 done
 echo "All rounds were good."
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test04-dynamic-page-demotion/code.var.sh
@@ -105,4 +105,4 @@ while (( round < max_rounds )); do
     round=$(( round + 1 ))
 done
 echo "All rounds were good."
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test05-guarantee-memory/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test05-guarantee-memory/code.var.sh
@@ -2,7 +2,7 @@ CRI_RESMGR_OUTPUT="cat cri-resmgr.output.txt | tr -d '\0'"
 CRI_RESMGR_ROTATE="echo > cri-resmgr.output.txt"
 
 podno=0
-kubectl delete pod --all --now
+kubectl delete pod --all --now --wait
 
 # account for being done with test for the current pod
 nextpod () {
@@ -80,7 +80,7 @@ for pernode in 2 3 4; do
         c=$((c+1))
     done
 
-    kubectl delete pod --all --now
+    kubectl delete pod --all --now --wait
 
     nextpod
 done
@@ -115,7 +115,7 @@ vm-command "$CRI_RESMGR_OUTPUT | grep upward" && {
     error "Unexpected memset upward expansion detected!"
 }
 
-kubectl delete pod $(pod) --now
+kubectl delete pod $(pod) --now --wait --ignore-not-found
 
 nextpod
 

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test00-basic-placement/code.var.sh
@@ -11,7 +11,7 @@ verify \
     'disjoint_sets(cpus["pod0c0"], cpus["pod0c1"], cpus["pod0c2"], cpus["pod0c3"])' \
     'disjoint_sets(nodes["pod0c0"], nodes["pod0c1"], nodes["pod0c2"], nodes["pod0c3"])'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod1: Test that 4 guaranteed containers not eligible for isolated CPU allocation
 # gets evenly spread over NUMA nodes.
@@ -25,7 +25,7 @@ verify \
     'disjoint_sets(cpus["pod1c0"], cpus["pod1c1"], cpus["pod1c2"], cpus["pod1c3"])' \
     'disjoint_sets(nodes["pod1c0"], nodes["pod1c1"], nodes["pod1c2"], nodes["pod1c3"])'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod2: Test that 4 burstable containers not eligible for isolated/exclusive CPU allocation
 # gets evenly spread over NUMA nodes.
@@ -35,7 +35,7 @@ verify \
     'disjoint_sets(cpus["pod2c0"], cpus["pod2c1"], cpus["pod2c2"], cpus["pod2c3"])' \
     'disjoint_sets(nodes["pod2c0"], nodes["pod2c1"], nodes["pod2c2"], nodes["pod2c3"])'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod3: Test that initContainer resources are freed before launching
 # containers: instantiate 5 init containers, each requiring 5 CPUs. If
@@ -49,7 +49,7 @@ verify \
     'disjoint_sets(nodes["pod3c0"], nodes["pod3c1"])' \
     'disjoint_sets(packages["pod3c0"], packages["pod3c1"])'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod4: Test that with pod colocation enabled containers within a pod get
 # colocated (assigned topologically close to each other) as opposed to being
@@ -65,7 +65,7 @@ verify \
     'cpus["pod4c2"] == cpus["pod4c0"]' \
     'cpus["pod4c3"] == cpus["pod4c0"]'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod{5,6,7}: Test that with namespace colocation enabled containers of pods
 # in the same namespace get colocated (assigned topologically close to each
@@ -85,8 +85,7 @@ verify \
     'cpus["pod7c0"] == cpus["pod5c0"]' \
     'cpus["pod7c1"] == cpus["pod5c0"]'
 
-kubectl delete pods -n test-ns --all --now
-kubectl delete namespace test-ns
+kubectl delete namespace test-ns --now --wait --ignore-not-found
 
 # Restore default test configuration, restart cri-resmgr.
 terminate cri-resmgr

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test01-always-fits/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test01-always-fits/code.var.sh
@@ -51,7 +51,7 @@ verify \
     'len(nodes["pod3c0"]) == 2' \
     'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"], cpus["pod3c0"])'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod4, fits in a die/package
 CPU=5 create guaranteed
@@ -76,7 +76,7 @@ verify \
     'len(dies["pod5c0"]) == 1' \
     'disjoint_sets(cpus["pod4c0"], cpus["pod5c0"])'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod6, doesn't fit in a die/package, needs virtual root
 CPU=9 create guaranteed
@@ -85,7 +85,7 @@ verify \
     'len(cpus["pod6c0"]) == 9' \
     'len(packages["pod6c0"]) == 2'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 reset counters
 
@@ -110,7 +110,7 @@ verify \
     'len(cpus["pod1c0"]) >= 4' \
     'len(cpus["pod2c0"]) >= 5'
 
-kubectl delete pods pod0 pod1 --now
+kubectl delete pods pod0 pod1 --now --wait --ignore-not-found
 
 # pod3
 CPUREQ=8 CPULIM=$(( CPUREQ + 1 )) create burstable
@@ -119,7 +119,7 @@ verify \
     'len(cpus["pod2c0"]) >= 5' \
     'len(cpus["pod3c0"]) >= 8'
 
-kubectl delete pods pod3 --now
+kubectl delete pods pod3 --now --wait --ignore-not-found
 
 # pod4, pod5 (and existing pod2) take 5 and 4 CPUs. As there are 8
 # CPUs/node, pod2 and pod4 have consumed free node

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test03-simple-affinity/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test03-simple-affinity/code.var.sh
@@ -54,7 +54,7 @@ verify \
     'nodes["pod0c2"] == {"node3"}' \
     'nodes["pod0c3"] == {"node0"}'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod1
 # 4 containers, affinites [0,1], [2,3] => colocate c0,c1 in node1, c2,c3 in node2
@@ -65,7 +65,7 @@ verify \
     'nodes["pod1c0"] == nodes["pod1c1"] == {"node1"}' \
     'nodes["pod1c2"] == nodes["pod1c3"] == {"node2"}'
 
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod2
 # 6 containers, anti-affinites 4:[0,1,2], 5:[0,2,3]

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test04-available-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test04-available-resources/code.var.sh
@@ -17,7 +17,7 @@ verify "cpus['pod1c0'] == {'cpu08', 'cpu09', 'cpu10'}" \
        "cpus['pod1c1'] == {'cpu08', 'cpu09', 'cpu10'}" \
        "mems['pod1c0'] == {'node2'}" \
        "mems['pod1c1'] == {'node2'}"
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 reset counters
 
 # Test cgroup cpuset directory in AvailableResources.CPU
@@ -35,7 +35,7 @@ test-and-verify-allowed() {
     verify "disjoint_sets(cpus['pod1c0'], cpus['pod0c0'])" \
            "disjoint_sets(cpus['pod1c0'], cpus['pod0c1'])"
 
-    kubectl delete pods --all --now
+    kubectl delete pods --all --now --wait
     reset counters
 }
 

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test05-reserved-resources/code.var.sh
@@ -13,7 +13,7 @@ cri_resmgr_cfg_orig=$cri_resmgr_cfg
 # if exiting with success. Otherwise leave the pod running for
 # debugging in case of a failure.
 cleanup-kube-system() {
-    ( kubectl delete pods pod0 pod1 pod2 pod3 pod4 pod5 -n kube-system --now ) || true
+    ( kubectl delete pods pod0 pod1 pod2 pod3 pod4 pod5 -n kube-system --now --wait --ignore-not-found ) || true
 }
 cleanup-kube-system
 
@@ -43,7 +43,7 @@ launch cri-resmgr
 namespace=kube-system CONTCOUNT=3 create besteffort
 report allowed
 verify "cpus['pod0c0'] == cpus['pod0c1'] == cpus['pod0c2'] == {'cpu10', 'cpu11'}"
-kubectl delete -n kube-system pods pod0
+kubectl delete -n kube-system pods pod0 --now --wait --ignore-not-found
 
 # Test that BestEffort containers are pinned to reserved CPUs.
 terminate cri-resmgr
@@ -74,7 +74,7 @@ verify "cpus['pod2c0'] == cpus['pod2c1'] == cpus['pod2c2'] == cpus['pod2c3']" \
 for pod in pod3 pod4; do
     namespace=kube-system CPU=1 CONTCOUNT=1 create guaranteed
     verify "cpus['${pod}c0'] == {'cpu07', 'cpu11'}"
-    kubectl delete -n kube-system pods/$pod --now
+    kubectl delete -n kube-system pods/$pod --now --wait --ignore-not-found
 done
 
 # Test requesting more reserved CPUs than available in the system.
@@ -95,7 +95,7 @@ launch cri-resmgr
 namespace=kube-system CPU=2 CONTCOUNT=1 create besteffort
 verify "cpus['pod0c0'] == {'cpu04', 'cpu05', 'cpu06'}"
 
-kubectl delete -n kube-system pods/pod0
+kubectl delete -n kube-system pods/pod0 --now --wait --ignore-not-found
 
 terminate cri-resmgr
 cri_resmgr_cfg=$cri_resmgr_cfg_orig

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test06-fuzz/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test06-fuzz/code.var.sh
@@ -4,7 +4,7 @@ source $TEST_DIR/codelib.sh || {
 }
 
 # Clean test pods from the kube-system namespace
-( kubectl delete pods -n kube-system $(kubectl get pods -n kube-system | awk '/t[0-9]r[gb][ue]/{print $1}') ) || true
+( kubectl delete pods --now --wait --ignore-not-found -n kube-system $(kubectl get pods -n kube-system | awk '/t[0-9]r[gb][ue]/{print $1}') ) || true
 
 # Run generated*.sh test scripts in this directory.
 genscriptcount=0

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test06-fuzz/fuzz.aal
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test06-fuzz/fuzz.aal
@@ -108,18 +108,18 @@ input
 
 # Delete single pod
 input
-    "NAME=gu0 kubectl delete pod gu0 --now",
-    "NAME=gu1 kubectl delete pod gu1 --now",
-    "NAME=gu2 kubectl delete pod gu2 --now",
-    "NAME=gu3 kubectl delete pod gu3 --now",
-    "NAME=gu4 kubectl delete pod gu4 --now",
-    "NAME=bu0 kubectl delete pod bu0 --now",
-    "NAME=bu1 kubectl delete pod bu1 --now",
-    "NAME=be0 kubectl delete pod be0 --now",
-    "NAME=be1 kubectl delete pod be1 --now",
-    "NAME=rgu0 kubectl delete pod rgu0 -n kube-system --now",
-    "NAME=rbu0 kubectl delete pod rbu0 -n kube-system --now",
-    "NAME=rbe0 kubectl delete pod rbe0 -n kube-system --now"
+    "NAME=gu0 kubectl delete pod gu0 --now --wait --ignore-not-found",
+    "NAME=gu1 kubectl delete pod gu1 --now --wait --ignore-not-found",
+    "NAME=gu2 kubectl delete pod gu2 --now --wait --ignore-not-found",
+    "NAME=gu3 kubectl delete pod gu3 --now --wait --ignore-not-found",
+    "NAME=gu4 kubectl delete pod gu4 --now --wait --ignore-not-found",
+    "NAME=bu0 kubectl delete pod bu0 --now --wait --ignore-not-found",
+    "NAME=bu1 kubectl delete pod bu1 --now --wait --ignore-not-found",
+    "NAME=be0 kubectl delete pod be0 --now --wait --ignore-not-found",
+    "NAME=be1 kubectl delete pod be1 --now --wait --ignore-not-found",
+    "NAME=rgu0 kubectl delete pod rgu0 -n kube-system --now --wait --ignore-not-found",
+    "NAME=rbu0 kubectl delete pod rbu0 -n kube-system --now --wait --ignore-not-found",
+    "NAME=rbe0 kubectl delete pod rbe0 -n kube-system --now --wait --ignore-not-found"
 {
     guard {
         v = inputvars(input_name)

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test07-mixed-allocations/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test07-mixed-allocations/code.var.sh
@@ -72,7 +72,7 @@ verify `# every container is placed on a single node (no socket, no root)` \
 # no-effect from isolated preference.
 # - opt-out from shared CPUs (=> opt-in to exclusive CPUs)
 # - opt-out from isolated CPUs (this does not affect getting exclusive CPUs)
-kubectl delete pods pod3 --now
+kubectl delete pods pod3 --now --wait --ignore-not-found
 ANNOTATIONS=('prefer-shared-cpus.cri-resource-manager.intel.com/pod: "false"'
              'prefer-isolated-cpus.cri-resource-manager.intel.com/pod: "false"')
 CONTCOUNT=1 CPU=2400m create guaranteed-annotated
@@ -89,7 +89,7 @@ verify `# every container is placed on a single node (no socket, no root)` \
 # Replace pod1 with pod5.
 # pod1 implicitly opted-in to exlusive CPUs due to 1500 mCPU request.
 # Now explicitly opt-out of it by opting-in to shared-cpus.
-kubectl delete pods pod1 --now
+kubectl delete pods pod1 --now --wait --ignore-not-found
 # Make sure that shared pool size increased correctly after mixed pod deletion.
 verify `# pod0c0 or pod0c1 shared a node with pod1c1 and had only 3 CPUs` \
        "len(cpus['pod0c0']) == 4" \

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
@@ -37,7 +37,7 @@ verify "cpus['pod0c0'] == {'cpu08'} or cpus['pod0c0'] == {'cpu09'}" \
        "mems['pod2c0'] == {'node2'}"
 
 # free isolated (and all other) cpus
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod3: opt-in isolated CPUs, take all of them
 ANNOTATIONS='prefer-isolated-cpus.cri-resource-manager.intel.com/pod: "true"'
@@ -47,7 +47,7 @@ verify "cpus['pod3c0'] == {'cpu08', 'cpu09'}" \
        "len(cpus['pod3c0']) == 2"
 
 # free isolated cpus
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod4: opt-in isolated CPUs but require a fraction more CPUs than there are isolated CPUs
 ANNOTATIONS=('prefer-isolated-cpus.cri-resource-manager.intel.com/pod: "true"'
@@ -58,7 +58,7 @@ verify "'cpu08' in cpus['pod4c0'] and 'cpu09' in cpus['pod4c0']" \
        "len(cpus['pod4c0']) == 4"
 
 # free isolated cpus
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod5: opt-in isolated CPUs but require a fraction less CPUs than there are isolated CPUs
 ANNOTATIONS=('prefer-isolated-cpus.cri-resource-manager.intel.com/pod: "true"'
@@ -70,7 +70,7 @@ verify "'cpu08' in cpus['pod5c0'] or 'cpu09' in cpus['pod5c0']" \
        "len(cpus['pod5c0']) == 3"
 
 # free isolated cpus
-kubectl delete pods --all --now
+kubectl delete pods --all --now --wait
 
 # pod6: opt-in isolated CPUs but require a full CPU more than there
 # are isolated CPUs

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test10-additional-reserved-namespaces/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test10-additional-reserved-namespaces/code.var.sh
@@ -10,8 +10,8 @@ cri_resmgr_cfg_orig=$cri_resmgr_cfg
 # if exiting with success. Otherwise leave the pod running for
 # debugging in case of a failure.
 cleanup-test-pods() {
-    ( kubectl delete pods pod0 -n kube-system --now ) || true
-    ( kubectl delete pods pod1 --now ) || true
+    ( kubectl delete pods pod0 -n kube-system --now --wait --ignore-not-found ) || true
+    ( kubectl delete pods pod1 --now --wait --ignore-not-found ) || true
 }
 cleanup-test-pods
 
@@ -37,7 +37,7 @@ cleanup-test-pods
 (kubectl create namespace foobar) || true
 
 cleanup-foobar-namespace() {
-    (kubectl delete pods -n foobar --all) || true
+    (kubectl delete pods -n foobar --all --now --wait) || true
 }
 cleanup-foobar-namespace
 

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test11-reserved-cpu-annotations/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test11-reserved-cpu-annotations/code.var.sh
@@ -4,8 +4,8 @@
 cri_resmgr_cfg_orig=$cri_resmgr_cfg
 
 cleanup-test-pods() {
-    ( kubectl delete pods pod0 --now ) || true
-    ( kubectl delete pods pod1 --now ) || true
+    ( kubectl delete pods pod0 --now --wait --ignore-not-found ) || true
+    ( kubectl delete pods pod1 --now --wait --ignore-not-found ) || true
 }
 cleanup-test-pods
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1044,7 +1044,7 @@ help() { # script API
 ### End of user code helpers
 
 test-user-code() {
-    vm-command-q "kubectl get pods 2>&1 | grep -q NAME" && vm-command "kubectl delete pods --all --now"
+    vm-command-q "kubectl get pods 2>&1 | grep -q NAME" && vm-command "kubectl delete pods --all --now --wait"
     ( eval "$code" ) || {
         TEST_FAILURES="${TEST_FAILURES} test script failed"
     }


### PR DESCRIPTION
Add --wait and --ignore-missing (to make sure that we really wait for the objects that does exist) to prevent naming collisions caused by long termination times of pods. Also add --now where it is missing so that stuff gets deleted quickly.