### PR TITLE
e2e: check default serviceaccount in cluster readiness check

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -1024,6 +1024,7 @@ vm-create-singlenode-cluster() {
     if ! vm-command "kubectl wait --for=condition=Ready node/\$(hostname) --timeout=240s"; then
         command-error "kubectl waiting for node readiness timed out"
     fi
+    vm-run-until --timeout 30 "kubectl get sa default > /dev/null" || error "serviceaccount 'default' not found"
 }
 
 vm-create-cluster() {


### PR DESCRIPTION
In some cases there seems to be a race that the node is in ready condition but pod creation still fails because of default service account (in the default namespace) is missing.