### PR TITLE
e2e: drop vm-force-restart()

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -616,25 +616,10 @@ vm-reboot() { # script API
     # Reboots the virtual machine and waits that the ssh server starts
     # responding again.
     vm-command "reboot"
-    sleep 5
-    host-wait-vm-ssh-server
-}
-
-vm-force-restart() { # script API
-    # Usage: vm-force-restart
-    #
-    # Give the virtual machine a chance to shut itself down, then
-    # forcibly restart it using govm stop/start. Wait for the ssh
-    # server to start responding again after restarting. If VM_NAME
-    # is not set assume the target machine to not be govm-managed
-    # and fall back to vm-reboot instead.
-    if vm-is-govm; then
-        vm-command "shutdown -h now"
-        sleep 10
+    sleep 10
+    if ! host-wait-vm-ssh-server; then
         vm-monitor system_reset
         host-wait-vm-ssh-server
-    else
-      vm-reboot
     fi
 }
 

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test08-isolcpus/code.var.sh
@@ -1,6 +1,6 @@
 vm-command "grep isolcpus=8,9 /proc/cmdline" || {
     vm-set-kernel-cmdline "isolcpus=8,9"
-    vm-force-restart
+    vm-reboot
     vm-command "grep isolcpus=8,9 /proc/cmdline" || {
         error "failed to set isolcpus kernel commandline parameter"
     }
@@ -97,7 +97,7 @@ verify "disjoint_sets(set.union(cpus['pod7c0'], cpus['pod7c1'], cpus['pod7c2'], 
 # Cleanup kernel commandline, otherwise isolcpus will affect CPU
 # pinning and cause false negatives from other tests on this VM.
 vm-set-kernel-cmdline ""
-vm-force-restart
+vm-reboot
 vm-command "grep isolcpus /proc/cmdline" && {
     error "failed to clean up isolcpus kernel commandline parameter"
 }


### PR DESCRIPTION
Drop the vm-force-restart() function and just use vm-reboot() instead.
Improve the vm-reboot() to do a forced restart (via Qemu command) if the
normal reboot fails - something that the old vm-force-restart() tried to
do. However, the old vm-force-restart() was broken as we always
unconditionally forced a qemu system resstart independent of whether the
normal shutdown succeeded or not. This led to races in rare cases where
the qemu command was executed precisely when the container was in not
running state. Not to mention that this practice never resulted in
graceful restarts.

Tha patch increases the sleep after reboot command to 10 seconds to
match what vm-force-restart() had, apparently to avoid inadvertent ssh
logins to a shutting down system (before ssh daemon is killed and actual
reboot happens).