### PR TITLE
e2e: relax topology-aware coldstart test

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test03-coldstart-deprecated-syntax/bb-coldstart.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test03-coldstart-deprecated-syntax/bb-coldstart.yaml.in
@@ -7,7 +7,7 @@ metadata:
       ${NAME}c0: dram,pmem
     cri-resource-manager.intel.com/cold-start: |
       ${NAME}c0:
-        duration: ${DURATION}
+        duration: ${DURATION_S}s
 spec:
   containers:
     - name: ${NAME}c0
@@ -16,9 +16,9 @@ spec:
       command:
         - sh
         - -c
-        - 'cold_alloc=\$(dd if=/dev/zero bs=${COLD_ALLOC} count=1 | tr \"\\\0\" \"x\");
+        - 'cold_alloc=\$(dd if=/dev/zero bs=${COLD_ALLOC_KB}kB count=1 | tr \"\\\0\" \"x\");
            sh -c \"paused after cold_alloc \\\$(sleep inf)\";
-           warm_alloc=\$(dd if=/dev/zero bs=${WARM_ALLOC} count=1 | tr \"\\\0\" \"x\");
+           warm_alloc=\$(dd if=/dev/zero bs=${WARM_ALLOC_KB}kB count=1 | tr \"\\\0\" \"x\");
            sh -c \"paused after warm_alloc \\\$(sleep inf)\";
            echo ${NAME}c0 \$(sleep inf); # needed for pod resource discovery'
       resources:

--- a/test/e2e/policies.test-suite/topology-aware/c4pmem4/test03-coldstart/bb-coldstart.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/c4pmem4/test03-coldstart/bb-coldstart.yaml.in
@@ -14,9 +14,9 @@ spec:
       command:
         - sh
         - -c
-        - 'cold_alloc=\$(dd if=/dev/zero bs=${COLD_ALLOC} count=1 | tr \"\\\0\" \"x\");
+        - 'cold_alloc=\$(dd if=/dev/zero bs=${COLD_ALLOC_KB}kB count=1 | tr \"\\\0\" \"x\");
            sh -c \"paused after cold_alloc \\\$(sleep inf)\";
-           warm_alloc=\$(dd if=/dev/zero bs=${WARM_ALLOC} count=1 | tr \"\\\0\" \"x\");
+           warm_alloc=\$(dd if=/dev/zero bs=${WARM_ALLOC_KB}kB count=1 | tr \"\\\0\" \"x\");
            sh -c \"paused after warm_alloc \\\$(sleep inf)\";
            echo ${NAME}c0 \$(sleep inf); # needed for pod resource discovery'
       resources:


### PR DESCRIPTION
Increase the amount of memory allocated by the test container, in an attempt to reduce test flakyness by reducing the relative effect of "memory usage noise" caused by other system processes. Make the error threshold (acceptable marging of error) of coldstart memory allocation proportional, being 10 percent of the allocated size.

Also increase the wait duration of coldstart test to avoid flakyness on slow/heavily loaded systems.