### PR TITLE
e2e: fix starting a custom containerd version

### DIFF
--- a/demo/lib/vm.bash
+++ b/demo/lib/vm.bash
@@ -821,6 +821,7 @@ vm-install-cri() {
             for f in ctr containerd containerd-stress containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
                 vm-put-file "$containerd_src/bin/$f" "$vm_cri_dir/$f"
             done
+            vm-command "mkdir -p /etc/containerd; containerd config default | sed -e 's/SystemdCgroup = false/SystemdCgroup = true/g' > /etc/containerd/config.toml"
             vm-command "systemctl enable --now containerd"
         fi
     elif [ "$VM_CRI" == "crio" ]; then


### PR DESCRIPTION
This patch generates new default containerd configuration file when a locally built containerd is installed from containerd_src. This fixes the problem where containerd configuration provided by the Linux distribution does not work with the containerd build defined by the user.