### PR TITLE
balloons: fix applying new configuration

### DIFF
--- a/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/balloons-policy.go
@@ -1069,6 +1069,10 @@ func (p *balloons) setConfig(bpoptions *BalloonsOptions) error {
 		topologyBalancing:           bpoptions.AllocatorTopologyBalancing,
 		preferSpreadOnPhysicalCores: bpoptions.PreferSpreadOnPhysicalCores,
 	})
+	// We can't delay taking new configuration into use beyond this point,
+	// because p.newBalloon() dereferences our options via p.bpoptions, so
+	// it would end up using the old configuration.
+	p.bpoptions = *bpoptions
 	// Instantiate built-in reserved and default balloons.
 	reservedBalloon, err := p.newBalloon(p.reservedBalloonDef, false)
 	if err != nil {
@@ -1105,8 +1109,6 @@ func (p *balloons) setConfig(bpoptions *BalloonsOptions) error {
 	for blnIdx, bln := range p.balloons {
 		log.Info("- balloon %d: %s", blnIdx, bln)
 	}
-	// No errors in balloon creation, take new configuration into use.
-	p.bpoptions = *bpoptions
 	p.updatePinning(p.shareIdleCpus(p.freeCpus, cpuset.New())...)
 	// (Re)configures all CPUs in balloons.
 	p.resetCpuClass()


### PR DESCRIPTION
Allocator options in new configuration were not effective when creating static balloons with new configuration.

Backported from containers/nri-plugins#188.