### PR TITLE
test/e2e: fix incorrect Allocat[ion|or]Priority config key.

### DIFF
--- a/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
@@ -24,7 +24,7 @@ data:
         - Name: btype0
           MinCPUs: ${BTYPE0_MINCPUS:-2}
           MaxCPUs: ${BTYPE0_MAXCPUS:-2}
-          AllocationPriority: ${BTYPE0_ALLOCATIONPRIORITY:-0}
+          AllocatorPriority: ${BTYPE0_ALLOCATORPRIORITY:-0}
           CPUClass: ${BTYPE0_CPUCLASS:-classA}
           PreferNewBalloons: ${BTYPE0_PREFERNEWBALLOONS:-true}
           PreferSpreadingPods: ${BTYPE0_PREFERSPREADINGPODS:-false}
@@ -36,7 +36,7 @@ data:
             - ${BTYPE1_NAMESPACE0:-btype1ns0}
           MinCPUs: ${BTYPE1_MINCPUS:-1}
           MaxCPUs: ${BTYPE1_MAXCPUS:-1}
-          AllocatorPriority: ${BTYPE1_ALLOCATIONPRIORITY:-1}
+          AllocatorPriority: ${BTYPE1_ALLOCATORPRIORITY:-1}
           CPUClass: ${BTYPE1_CPUCLASS:-classB}
           PreferNewBalloons: ${BTYPE1_PREFERNEWBALLOONS:-false}
           PreferSpreadingPods: ${BTYPE1_PREFERSPREADINGPODS:-true}

--- a/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
+++ b/test/e2e/policies.test-suite/balloons/cri-resmgr.cfg
@@ -17,7 +17,7 @@ policy:
       - Name: two-cpu
         MinCPUs: 2
         MaxCPUs: 2
-        AllocationPriority: 0
+        AllocatorPriority: 0
         CPUClass: class2
         PreferNewBalloons: true
 

--- a/test/e2e/policies.test-suite/balloons/n4c16/test08-numa/balloons-numa.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test08-numa/balloons-numa.cfg
@@ -17,5 +17,5 @@ policy:
         # Prevent a balloon to be inflated larger than a NUMA node
         MinCPUs: 0
         MaxCPUs: 4
-        AllocationPriority: 0
+        AllocatorPriority: 0
         PreferNewBalloons: false


### PR DESCRIPTION
Backported from containers/nri-plugins#189.