### PR TITLE
Bump golangci-lint to v1.55.2

### DIFF
--- a/.github/workflows/common-verify-code.yaml
+++ b/.github/workflows/common-verify-code.yaml
@@ -17,7 +17,7 @@ jobs:
       id: go
 
     - name: Install golangci-lint
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
+      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
     - name: Gofmt
       run: make format

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -79,7 +79,7 @@ func NewResourceManagerAgent() (ResourceManagerAgent, error) {
 		return nil, agentError("failed to initialize gRPC server")
 	}
 
-	if a.updater, err = newConfigUpdater(opts.resmgrSocket); err != nil {
+	if a.updater, err = newConfigUpdater(); err != nil {
 		return nil, agentError("failed to initialize config updater instance: %v", err)
 	}
 

--- a/pkg/agent/config-updater.go
+++ b/pkg/agent/config-updater.go
@@ -62,7 +62,7 @@ type updater struct {
 	cfgErr        error
 }
 
-func newConfigUpdater(socket string) (configUpdater, error) {
+func newConfigUpdater() (configUpdater, error) {
 	u := &updater{Logger: log.NewLogger("config-updater")}
 
 	c, err := newResmgrCli(opts.resmgrSocket)

--- a/pkg/agent/kubernetes.go
+++ b/pkg/agent/kubernetes.go
@@ -111,7 +111,7 @@ func patchNodeStatus(cli *k8sclient.Clientset, fields map[string]string) error {
 }
 
 // patchAdjustmentStatus is a helper for patching the status of a Adjustment CRD.
-func patchAdjustmentStatus(cli *resmgr.CriresmgrV1alpha1Client, status *resmgrStatus, names ...string) error {
+func patchAdjustmentStatus(_ *resmgr.CriresmgrV1alpha1Client, _ *resmgrStatus, _ ...string) error {
 	return nil
 }
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -111,7 +111,7 @@ type grpcServer struct {
 }
 
 // GetNode gets K8s node object.
-func (g *grpcServer) GetNode(ctx context.Context, req *v1.GetNodeRequest) (*v1.GetNodeReply, error) {
+func (g *grpcServer) GetNode(_ context.Context, req *v1.GetNodeRequest) (*v1.GetNodeReply, error) {
 	g.Debug("received GetNodeRequest: %v", req)
 	rpl := &v1.GetNodeReply{}
 
@@ -129,7 +129,7 @@ func (g *grpcServer) GetNode(ctx context.Context, req *v1.GetNodeRequest) (*v1.G
 }
 
 // PatchNode patches the K8s node object.
-func (g *grpcServer) PatchNode(ctx context.Context, req *v1.PatchNodeRequest) (*v1.PatchNodeReply, error) {
+func (g *grpcServer) PatchNode(_ context.Context, req *v1.PatchNodeRequest) (*v1.PatchNodeReply, error) {
 	g.Debug("received PatchNodeRequest: %v", req)
 	rpl := &v1.PatchNodeReply{}
 
@@ -145,7 +145,7 @@ func (g *grpcServer) PatchNode(ctx context.Context, req *v1.PatchNodeRequest) (*
 }
 
 // UpdateNodeCapacity updates capacity in Node status
-func (g *grpcServer) UpdateNodeCapacity(ctx context.Context, req *v1.UpdateNodeCapacityRequest) (*v1.UpdateNodeCapacityReply, error) {
+func (g *grpcServer) UpdateNodeCapacity(_ context.Context, req *v1.UpdateNodeCapacityRequest) (*v1.UpdateNodeCapacityReply, error) {
 	g.Debug("received UpdateNodeCapacityRequest: %v", req)
 
 	rpl := &v1.UpdateNodeCapacityReply{}
@@ -172,7 +172,7 @@ func (g *grpcServer) UpdateNodeCapacity(ctx context.Context, req *v1.UpdateNodeC
 }
 
 // HealthCheck checks if the agent is in healthy state
-func (g *grpcServer) HealthCheck(ctx context.Context, req *v1.HealthCheckRequest) (*v1.HealthCheckReply, error) {
+func (g *grpcServer) HealthCheck(_ context.Context, req *v1.HealthCheckRequest) (*v1.HealthCheckReply, error) {
 	g.Debug("received HealthCheckRequest: %v", req)
 
 	reply := &v1.HealthCheckReply{}

--- a/pkg/cgroups/cgroupblkio.go
+++ b/pkg/cgroups/cgroupblkio.go
@@ -185,18 +185,18 @@ func ResetBlkioParameters(cgroupsDir string, blockIO OciBlockIOParameters) error
 
 // resetDevRates adds wanted rate parameters to new and resets unwated rates
 func resetDevRates(old, wanted []OciDeviceRate) []OciDeviceRate {
-	new := []OciDeviceRate{}
+	rates := []OciDeviceRate{}
 	seenDev := map[devMajMin]bool{}
 	for _, rdp := range wanted {
-		new = append(new, rdp)
+		rates = append(rates, rdp)
 		seenDev[devMajMin{rdp.Major, rdp.Minor}] = true
 	}
 	for _, rdp := range old {
 		if !seenDev[devMajMin{rdp.Major, rdp.Minor}] {
-			new = append(new, OciDeviceRate{rdp.Major, rdp.Minor, 0})
+			rates = append(rates, OciDeviceRate{rdp.Major, rdp.Minor, 0})
 		}
 	}
-	return new
+	return rates
 }
 
 // GetBlkioParameters returns OCI BlockIO parameters from files in cgroups blkio controller directory.

--- a/pkg/cgroups/cgroupid.go
+++ b/pkg/cgroups/cgroupid.go
@@ -71,8 +71,7 @@ func (cgid *CgroupID) Find(id uint64) (string, error) {
 		return "", err
 	} else if !found {
 		return "", fmt.Errorf("cgroupid %v not found", id)
-	} else {
-		cgid.cache[id] = p
-		return p, nil
 	}
+	cgid.cache[id] = p
+	return p, nil
 }

--- a/pkg/cri/client/client.go
+++ b/pkg/cri/client/client.go
@@ -254,7 +254,7 @@ func (c *client) dialNotify(socket string) {
 	c.options.DialNotify(socket, uid, gid, mode, nil)
 }
 
-func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...grpc.CallOption) (*criv1.VersionResponse, error) {
+func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, _ ...grpc.CallOption) (*criv1.VersionResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...
 	return c.client.Version(ctx, in)
 }
 
-func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, opts ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
+func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, _ ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxReque
 	return c.client.RunPodSandbox(ctx, in)
 }
 
-func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, opts ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
+func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, _ ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxReq
 	return c.client.StopPodSandbox(ctx, in)
 }
 
-func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, opts ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
+func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, _ ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandbo
 	return c.client.RemovePodSandbox(ctx, in)
 }
 
-func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
+func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, _ ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatu
 	return c.client.PodSandboxStatus(ctx, in)
 }
 
-func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
+func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxReq
 	return c.client.ListPodSandbox(ctx, in)
 }
 
-func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, opts ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
+func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, _ ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerR
 	return c.client.CreateContainer(ctx, in)
 }
 
-func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, opts ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
+func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, _ ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerReq
 	return c.client.StartContainer(ctx, in)
 }
 
-func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, opts ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
+func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, _ ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerReque
 	return c.client.StopContainer(ctx, in)
 }
 
-func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, opts ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
+func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, _ ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerR
 	return c.client.RemoveContainer(ctx, in)
 }
 
-func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, opts ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
+func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, _ ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersReq
 	return c.client.ListContainers(ctx, in)
 }
 
-func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, opts ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
+func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, _ ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusR
 	return c.client.ContainerStatus(ctx, in)
 }
 
-func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, opts ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
+func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, _ ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateC
 	return c.client.UpdateContainerResources(ctx, in)
 }
 
-func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, opts ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
+func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, _ ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -366,7 +366,7 @@ func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContain
 	return c.client.ReopenContainerLog(ctx, in)
 }
 
-func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
+func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, _ ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts .
 	return c.client.ExecSync(ctx, in)
 }
 
-func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.CallOption) (*criv1.ExecResponse, error) {
+func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, _ ...grpc.CallOption) (*criv1.ExecResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.C
 	return c.client.Exec(ctx, in)
 }
 
-func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...grpc.CallOption) (*criv1.AttachResponse, error) {
+func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, _ ...grpc.CallOption) (*criv1.AttachResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -390,7 +390,7 @@ func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...gr
 	return c.client.Attach(ctx, in)
 }
 
-func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, opts ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
+func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, _ ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, 
 	return c.client.PortForward(ctx, in)
 }
 
-func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
+func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, _ ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsReq
 	return c.client.ContainerStats(ctx, in)
 }
 
-func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
+func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, _ ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainer
 	return c.client.ListContainerStats(ctx, in)
 }
 
-func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
+func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, _ ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsR
 	return c.client.PodSandboxStats(ctx, in)
 }
 
-func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
+func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandb
 	return c.client.ListPodSandboxStats(ctx, in)
 }
 
-func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, opts ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
+func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, _ ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntim
 	return c.client.UpdateRuntimeConfig(ctx, in)
 }
 
-func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...grpc.CallOption) (*criv1.StatusResponse, error) {
+func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, _ ...grpc.CallOption) (*criv1.StatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -447,24 +447,24 @@ func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...gr
 }
 
 /*
-func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
+func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, _ ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
 	return nil, fmt.Errorf("unimplemented by CRI RuntimeService")
 }
 
-func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetContainerEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
+func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetContainerEventsRequest, _ ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
 	return nil, fmt.Errorf("unimplemented by CRI RuntimeService")
 }
 
-func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, opts ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
+func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, _ ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
 	return nil, fmt.Errorf("unimplemented by CRI RuntimeService")
 }
 
-func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
+func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
 	return nil, fmt.Errorf("unimplemented by CRI RuntimeService")
 }
 */
 
-func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, opts ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
+func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, _ ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -472,7 +472,7 @@ func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, op
 	return c.client.ListImages(ctx, in)
 }
 
-func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, opts ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
+func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, _ ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, 
 	return c.client.ImageStatus(ctx, in)
 }
 
-func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts ...grpc.CallOption) (*criv1.PullImageResponse, error) {
+func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, _ ...grpc.CallOption) (*criv1.PullImageResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -488,7 +488,7 @@ func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts
 	return c.client.PullImage(ctx, in)
 }
 
-func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, opts ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
+func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, _ ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, 
 	return c.client.RemoveImage(ctx, in)
 }
 
-func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, opts ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
+func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, _ ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}

--- a/pkg/cri/client/v1/client.go
+++ b/pkg/cri/client/v1/client.go
@@ -81,7 +81,7 @@ func (c *client) checkImageService() error {
 	return nil
 }
 
-func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...grpc.CallOption) (*criv1.VersionResponse, error) {
+func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, _ ...grpc.CallOption) (*criv1.VersionResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...
 	return c.rsc.Version(ctx, in)
 }
 
-func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, opts ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
+func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, _ ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxReque
 	return c.rsc.RunPodSandbox(ctx, in)
 }
 
-func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, opts ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
+func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, _ ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxReq
 	return c.rsc.StopPodSandbox(ctx, in)
 }
 
-func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, opts ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
+func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, _ ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandbo
 	return c.rsc.RemovePodSandbox(ctx, in)
 }
 
-func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
+func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, _ ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatu
 	return c.rsc.PodSandboxStatus(ctx, in)
 }
 
-func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
+func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxReq
 	return c.rsc.ListPodSandbox(ctx, in)
 }
 
-func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, opts ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
+func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, _ ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerR
 	return c.rsc.CreateContainer(ctx, in)
 }
 
-func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, opts ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
+func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, _ ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerReq
 	return c.rsc.StartContainer(ctx, in)
 }
 
-func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, opts ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
+func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, _ ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerReque
 	return c.rsc.StopContainer(ctx, in)
 }
 
-func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, opts ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
+func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, _ ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerR
 	return c.rsc.RemoveContainer(ctx, in)
 }
 
-func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, opts ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
+func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, _ ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersReq
 	return c.rsc.ListContainers(ctx, in)
 }
 
-func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, opts ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
+func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, _ ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusR
 	return c.rsc.ContainerStatus(ctx, in)
 }
 
-func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, opts ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
+func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, _ ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateC
 	return c.rsc.UpdateContainerResources(ctx, in)
 }
 
-func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, opts ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
+func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, _ ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContain
 	return c.rsc.ReopenContainerLog(ctx, in)
 }
 
-func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
+func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, _ ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts .
 	return c.rsc.ExecSync(ctx, in)
 }
 
-func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.CallOption) (*criv1.ExecResponse, error) {
+func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, _ ...grpc.CallOption) (*criv1.ExecResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.C
 	return c.rsc.Exec(ctx, in)
 }
 
-func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...grpc.CallOption) (*criv1.AttachResponse, error) {
+func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, _ ...grpc.CallOption) (*criv1.AttachResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...gr
 	return c.rsc.Attach(ctx, in)
 }
 
-func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, opts ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
+func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, _ ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, 
 	return c.rsc.PortForward(ctx, in)
 }
 
-func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
+func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, _ ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsReq
 	return c.rsc.ContainerStats(ctx, in)
 }
 
-func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
+func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, _ ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainer
 	return c.rsc.ListContainerStats(ctx, in)
 }
 
-func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
+func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, _ ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsR
 	return c.rsc.PodSandboxStats(ctx, in)
 }
 
-func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
+func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandb
 	return c.rsc.ListPodSandboxStats(ctx, in)
 }
 
-func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, opts ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
+func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, _ ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntim
 	return c.rsc.UpdateRuntimeConfig(ctx, in)
 }
 
-func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...grpc.CallOption) (*criv1.StatusResponse, error) {
+func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, _ ...grpc.CallOption) (*criv1.StatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...gr
 	return c.rsc.Status(ctx, in)
 }
 
-func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
+func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, _ ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointCo
 	return c.rsc.CheckpointContainer(ctx, in)
 }
 
-func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
+func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequest, _ ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequ
 // These are being introduced but they are not defined yet for the
 // CRI API version we are compiling against.
 /*
-func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, opts ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
+func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, _ ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetric
 	return c.rsc.ListMetricDescriptors(ctx, in)
 }
 
-func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
+func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSan
 }
 */
 
-func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, opts ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
+func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, _ ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, op
 	return c.isc.ListImages(ctx, in)
 }
 
-func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, opts ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
+func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, _ ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, 
 	return c.isc.ImageStatus(ctx, in)
 }
 
-func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts ...grpc.CallOption) (*criv1.PullImageResponse, error) {
+func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, _ ...grpc.CallOption) (*criv1.PullImageResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -339,7 +339,7 @@ func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts
 	return c.isc.PullImage(ctx, in)
 }
 
-func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, opts ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
+func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, _ ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -347,7 +347,7 @@ func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, 
 	return c.isc.RemoveImage(ctx, in)
 }
 
-func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, opts ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
+func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, _ ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}

--- a/pkg/cri/client/v1alpha2/client.go
+++ b/pkg/cri/client/v1alpha2/client.go
@@ -82,7 +82,7 @@ func (c *client) checkImageService() error {
 	return nil
 }
 
-func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...grpc.CallOption) (*criv1.VersionResponse, error) {
+func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, _ ...grpc.CallOption) (*criv1.VersionResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (c *client) Version(ctx context.Context, in *criv1.VersionRequest, opts ...
 	return v1resp, nil
 }
 
-func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, opts ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
+func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxRequest, _ ...grpc.CallOption) (*criv1.RunPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (c *client) RunPodSandbox(ctx context.Context, in *criv1.RunPodSandboxReque
 	return v1resp, nil
 }
 
-func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, opts ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
+func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxRequest, _ ...grpc.CallOption) (*criv1.StopPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (c *client) StopPodSandbox(ctx context.Context, in *criv1.StopPodSandboxReq
 	return v1resp, nil
 }
 
-func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, opts ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
+func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandboxRequest, _ ...grpc.CallOption) (*criv1.RemovePodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (c *client) RemovePodSandbox(ctx context.Context, in *criv1.RemovePodSandbo
 	return v1resp, nil
 }
 
-func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
+func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatusRequest, _ ...grpc.CallOption) (*criv1.PodSandboxStatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (c *client) PodSandboxStatus(ctx context.Context, in *criv1.PodSandboxStatu
 	return v1resp, nil
 }
 
-func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
+func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (c *client) ListPodSandbox(ctx context.Context, in *criv1.ListPodSandboxReq
 	return v1resp, nil
 }
 
-func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, opts ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
+func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerRequest, _ ...grpc.CallOption) (*criv1.CreateContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (c *client) CreateContainer(ctx context.Context, in *criv1.CreateContainerR
 	return v1resp, nil
 }
 
-func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, opts ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
+func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerRequest, _ ...grpc.CallOption) (*criv1.StartContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func (c *client) StartContainer(ctx context.Context, in *criv1.StartContainerReq
 	return v1resp, nil
 }
 
-func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, opts ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
+func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerRequest, _ ...grpc.CallOption) (*criv1.StopContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (c *client) StopContainer(ctx context.Context, in *criv1.StopContainerReque
 	return v1resp, nil
 }
 
-func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, opts ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
+func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerRequest, _ ...grpc.CallOption) (*criv1.RemoveContainerResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (c *client) RemoveContainer(ctx context.Context, in *criv1.RemoveContainerR
 	return v1resp, nil
 }
 
-func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, opts ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
+func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersRequest, _ ...grpc.CallOption) (*criv1.ListContainersResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (c *client) ListContainers(ctx context.Context, in *criv1.ListContainersReq
 	return v1resp, nil
 }
 
-func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, opts ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
+func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusRequest, _ ...grpc.CallOption) (*criv1.ContainerStatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -394,7 +394,7 @@ func (c *client) ContainerStatus(ctx context.Context, in *criv1.ContainerStatusR
 	return v1resp, nil
 }
 
-func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, opts ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
+func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateContainerResourcesRequest, _ ...grpc.CallOption) (*criv1.UpdateContainerResourcesResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (c *client) UpdateContainerResources(ctx context.Context, in *criv1.UpdateC
 	return v1resp, nil
 }
 
-func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, opts ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
+func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContainerLogRequest, _ ...grpc.CallOption) (*criv1.ReopenContainerLogResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (c *client) ReopenContainerLog(ctx context.Context, in *criv1.ReopenContain
 	return v1resp, nil
 }
 
-func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
+func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, _ ...grpc.CallOption) (*criv1.ExecSyncResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -472,7 +472,7 @@ func (c *client) ExecSync(ctx context.Context, in *criv1.ExecSyncRequest, opts .
 	return v1resp, nil
 }
 
-func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.CallOption) (*criv1.ExecResponse, error) {
+func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, _ ...grpc.CallOption) (*criv1.ExecResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -498,7 +498,7 @@ func (c *client) Exec(ctx context.Context, in *criv1.ExecRequest, opts ...grpc.C
 	return v1resp, nil
 }
 
-func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...grpc.CallOption) (*criv1.AttachResponse, error) {
+func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, _ ...grpc.CallOption) (*criv1.AttachResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -524,7 +524,7 @@ func (c *client) Attach(ctx context.Context, in *criv1.AttachRequest, opts ...gr
 	return v1resp, nil
 }
 
-func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, opts ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
+func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, _ ...grpc.CallOption) (*criv1.PortForwardResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -550,7 +550,7 @@ func (c *client) PortForward(ctx context.Context, in *criv1.PortForwardRequest, 
 	return v1resp, nil
 }
 
-func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
+func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsRequest, _ ...grpc.CallOption) (*criv1.ContainerStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -576,7 +576,7 @@ func (c *client) ContainerStats(ctx context.Context, in *criv1.ContainerStatsReq
 	return v1resp, nil
 }
 
-func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, opts ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
+func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainerStatsRequest, _ ...grpc.CallOption) (*criv1.ListContainerStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -602,7 +602,7 @@ func (c *client) ListContainerStats(ctx context.Context, in *criv1.ListContainer
 	return v1resp, nil
 }
 
-func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
+func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsRequest, _ ...grpc.CallOption) (*criv1.PodSandboxStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -628,7 +628,7 @@ func (c *client) PodSandboxStats(ctx context.Context, in *criv1.PodSandboxStatsR
 	return v1resp, nil
 }
 
-func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
+func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandboxStatsRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxStatsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -654,7 +654,7 @@ func (c *client) ListPodSandboxStats(ctx context.Context, in *criv1.ListPodSandb
 	return v1resp, nil
 }
 
-func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, opts ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
+func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntimeConfigRequest, _ ...grpc.CallOption) (*criv1.UpdateRuntimeConfigResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -680,7 +680,7 @@ func (c *client) UpdateRuntimeConfig(ctx context.Context, in *criv1.UpdateRuntim
 	return v1resp, nil
 }
 
-func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...grpc.CallOption) (*criv1.StatusResponse, error) {
+func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, _ ...grpc.CallOption) (*criv1.StatusResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -706,13 +706,13 @@ func (c *client) Status(ctx context.Context, in *criv1.StatusRequest, opts ...gr
 	return v1resp, nil
 }
 
-func (c *client) CheckpointContainer(ctx context.Context, in *criv1.CheckpointContainerRequest, opts ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
+func (c *client) CheckpointContainer(_ context.Context, _ *criv1.CheckpointContainerRequest, _ ...grpc.CallOption) (*criv1.CheckpointContainerResponse, error) {
 	c.Errorf("internal error: GetContainerEvents() called for v1alpha2 client")
 	return &criv1.CheckpointContainerResponse{},
 		fmt.Errorf("internal error: CheckpointContainer() called for v1alpha2 client")
 }
 
-func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequest, opts ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
+func (c *client) GetContainerEvents(_ context.Context, _ *criv1.GetEventsRequest, _ ...grpc.CallOption) (criv1.RuntimeService_GetContainerEventsClient, error) {
 	c.Errorf("internal error: GetContainerEvents() called for v1alpha2 client")
 	return nil, fmt.Errorf("internal error: GetContainerEvents() called for v1alpha2 client")
 }
@@ -721,7 +721,7 @@ func (c *client) GetContainerEvents(ctx context.Context, in *criv1.GetEventsRequ
 // These are being introduced but they are not defined yet for the
 // CRI API version we are compiling against.
 /*
-func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, opts ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
+func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetricDescriptorsRequest, _ ...grpc.CallOption) (*criv1.ListMetricDescriptorsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -729,7 +729,7 @@ func (c *client) ListMetricDescriptors(ctx context.Context, in *criv1.ListMetric
 	return c.rsc.ListMetricDescriptors(ctx, in)
 }
 
-func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, opts ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
+func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSandboxMetricsRequest, _ ...grpc.CallOption) (*criv1.ListPodSandboxMetricsResponse, error) {
 	if err := c.checkRuntimeService(); err != nil {
 		return nil, err
 	}
@@ -738,7 +738,7 @@ func (c *client) ListPodSandboxMetrics(ctx context.Context, in *criv1.ListPodSan
 }
 */
 
-func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, opts ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
+func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, _ ...grpc.CallOption) (*criv1.ListImagesResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -764,7 +764,7 @@ func (c *client) ListImages(ctx context.Context, in *criv1.ListImagesRequest, op
 	return v1resp, nil
 }
 
-func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, opts ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
+func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, _ ...grpc.CallOption) (*criv1.ImageStatusResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -790,7 +790,7 @@ func (c *client) ImageStatus(ctx context.Context, in *criv1.ImageStatusRequest, 
 	return v1resp, nil
 }
 
-func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts ...grpc.CallOption) (*criv1.PullImageResponse, error) {
+func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, _ ...grpc.CallOption) (*criv1.PullImageResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (c *client) PullImage(ctx context.Context, in *criv1.PullImageRequest, opts
 	return v1resp, nil
 }
 
-func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, opts ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
+func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, _ ...grpc.CallOption) (*criv1.RemoveImageResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}
@@ -842,7 +842,7 @@ func (c *client) RemoveImage(ctx context.Context, in *criv1.RemoveImageRequest, 
 	return v1resp, nil
 }
 
-func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, opts ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
+func (c *client) ImageFsInfo(ctx context.Context, in *criv1.ImageFsInfoRequest, _ ...grpc.CallOption) (*criv1.ImageFsInfoResponse, error) {
 	if err := c.checkImageService(); err != nil {
 		return nil, err
 	}

--- a/pkg/cri/relay/runtime-service.go
+++ b/pkg/cri/relay/runtime-service.go
@@ -188,6 +188,6 @@ func (r *relay) CheckpointContainer(ctx context.Context, req *criv1.CheckpointCo
 	return r.client.CheckpointContainer(ctx, req)
 }
 
-func (r *relay) GetContainerEvents(req *criv1.GetEventsRequest, src criv1.RuntimeService_GetContainerEventsServer) error {
+func (r *relay) GetContainerEvents(_ *criv1.GetEventsRequest, _ criv1.RuntimeService_GetContainerEventsServer) error {
 	return status.Errorf(codes.Unimplemented, "method GetContainerEvents not implemented")
 }

--- a/pkg/cri/resource-manager/cache/cache.go
+++ b/pkg/cri/resource-manager/cache/cache.go
@@ -1224,7 +1224,7 @@ func (cch *cache) GetPolicyEntry(key string, ptr interface{}) bool {
 		}
 	} else {
 		// subsequent accesses to key
-		if err := cch.setEntry(key, ptr, obj); err != nil {
+		if err := cch.setEntry(ptr, obj); err != nil {
 			cch.Fatal("failed use cached entry for key '%s' of policy '%s': %v",
 				key, cch.PolicyName, err)
 		}
@@ -1327,7 +1327,7 @@ func (cch *cache) cacheEntry(key string, ptr interface{}) error {
 }
 
 // Serve an unmarshaled opaque policy entry, special-casing some simple/common types.
-func (cch *cache) setEntry(key string, ptr, obj interface{}) error {
+func (cch *cache) setEntry(ptr, obj interface{}) error {
 	if cachable, ok := ptr.(Cachable); ok {
 		cachable.Set(obj)
 		return nil

--- a/pkg/cri/resource-manager/cache/container.go
+++ b/pkg/cri/resource-manager/cache/container.go
@@ -774,9 +774,9 @@ func (c *container) GetCgroupDir() string {
 		return c.CgroupDir
 	}
 	if pod, ok := c.GetPod(); ok {
-		parent, podID := pod.GetCgroupParentDir(), pod.GetID()
+		parent, _ := pod.GetCgroupParentDir(), pod.GetID()
 		ID := c.GetID()
-		c.CgroupDir = findContainerDir(parent, podID, ID)
+		c.CgroupDir = findContainerDir(parent, ID)
 	}
 	return c.CgroupDir
 }

--- a/pkg/cri/resource-manager/cache/utils.go
+++ b/pkg/cri/resource-manager/cache/utils.go
@@ -216,7 +216,7 @@ func resourcesToQOS(podResources *PodResourceRequirements) corev1.PodQOSClass {
 }
 
 // findContainerDir brute-force searches for a container cgroup dir.
-func findContainerDir(podCgroupDir, podID, ID string) string {
+func findContainerDir(podCgroupDir, ID string) string {
 	var dirs []string
 
 	if podCgroupDir == "" {

--- a/pkg/cri/resource-manager/config/server.go
+++ b/pkg/cri/resource-manager/config/server.go
@@ -120,7 +120,7 @@ func (s *server) Stop() {
 }
 
 // SetConfig pushes a configuration update to the server.
-func (s *server) SetConfig(ctx context.Context, req *v1.SetConfigRequest) (*v1.SetConfigReply, error) {
+func (s *server) SetConfig(_ context.Context, req *v1.SetConfigRequest) (*v1.SetConfigReply, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -136,7 +136,7 @@ func (s *server) SetConfig(ctx context.Context, req *v1.SetConfigRequest) (*v1.S
 }
 
 // SetAdjustment pushes updated external policies to the server.
-func (s *server) SetAdjustment(ctx context.Context, req *v1.SetAdjustmentRequest) (*v1.SetAdjustmentReply, error) {
+func (s *server) SetAdjustment(_ context.Context, req *v1.SetAdjustmentRequest) (*v1.SetAdjustmentReply, error) {
 	s.Lock()
 	defer s.Unlock()
 

--- a/pkg/cri/resource-manager/control/blockio/blockio.go
+++ b/pkg/cri/resource-manager/control/blockio/blockio.go
@@ -52,7 +52,7 @@ func getBlockIOController() *blockioctl {
 }
 
 // Start initializes the controller for enforcing decisions.
-func (ctl *blockioctl) Start(cache cache.Cache, client client.Client) error {
+func (ctl *blockioctl) Start(cache cache.Cache, _ client.Client) error {
 	ctl.cache = cache
 	ctl.reconfigureRunningContainers()
 	return nil
@@ -63,12 +63,12 @@ func (ctl *blockioctl) Stop() {
 }
 
 // PreCreateHook is the block I/O controller pre-create hook.
-func (ctl *blockioctl) PreCreateHook(c cache.Container) error {
+func (ctl *blockioctl) PreCreateHook(_ cache.Container) error {
 	return nil
 }
 
 // PreStartHook is the block I/O controller pre-start hook.
-func (ctl *blockioctl) PreStartHook(c cache.Container) error {
+func (ctl *blockioctl) PreStartHook(_ cache.Container) error {
 	return nil
 }
 
@@ -103,7 +103,7 @@ func (ctl *blockioctl) PostUpdateHook(c cache.Container) error {
 }
 
 // PostStop is the block I/O controller post-stop hook.
-func (ctl *blockioctl) PostStopHook(c cache.Container) error {
+func (ctl *blockioctl) PostStopHook(_ cache.Container) error {
 	return nil
 }
 
@@ -143,7 +143,7 @@ func (ctl *blockioctl) assign(c cache.Container) error {
 }
 
 // configNotify is blockio class mapping and class definition configuration callback
-func (ctl *blockioctl) configNotify(event config.Event, source config.Source) error {
+func (ctl *blockioctl) configNotify(event config.Event, _ config.Source) error {
 	ignoreErrors := (event == config.RevertEvent)
 	err := blockio.UpdateOciConfig(ignoreErrors)
 	if err != nil {

--- a/pkg/cri/resource-manager/control/cpu/cpu.go
+++ b/pkg/cri/resource-manager/control/cpu/cpu.go
@@ -73,7 +73,7 @@ func getCPUController() *cpuctl {
 }
 
 // Start initializes the controller for enforcing decisions.
-func (ctl *cpuctl) Start(cache cache.Cache, client client.Client) error {
+func (ctl *cpuctl) Start(cache cache.Cache, _ client.Client) error {
 	sys, err := sysfs.DiscoverSystem()
 	if err != nil {
 		return fmt.Errorf("failed to discover system topology: %w", err)
@@ -103,27 +103,27 @@ func (ctl *cpuctl) Stop() {
 }
 
 // PreCreateHook handler for the CPU controller.
-func (ctl *cpuctl) PreCreateHook(c cache.Container) error {
+func (ctl *cpuctl) PreCreateHook(_ cache.Container) error {
 	return nil
 }
 
 // PreStartHook handler for the CPU controller.
-func (ctl *cpuctl) PreStartHook(c cache.Container) error {
+func (ctl *cpuctl) PreStartHook(_ cache.Container) error {
 	return nil
 }
 
 // PostStartHook handler for the CPU controller.
-func (ctl *cpuctl) PostStartHook(c cache.Container) error {
+func (ctl *cpuctl) PostStartHook(_ cache.Container) error {
 	return nil
 }
 
 // PostUpdateHook handler for the CPU controller.
-func (ctl *cpuctl) PostUpdateHook(c cache.Container) error {
+func (ctl *cpuctl) PostUpdateHook(_ cache.Container) error {
 	return nil
 }
 
 // PostStopHook handler for the CPU controller.
-func (ctl *cpuctl) PostStopHook(c cache.Container) error {
+func (ctl *cpuctl) PostStopHook(_ cache.Container) error {
 	return nil
 }
 
@@ -275,7 +275,7 @@ func (ctl *cpuctl) configure() error {
 }
 
 // Callback for runtime configuration notifications.
-func (ctl *cpuctl) configNotify(event pkgcfg.Event, source pkgcfg.Source) error {
+func (ctl *cpuctl) configNotify(_ pkgcfg.Event, _ pkgcfg.Source) error {
 	if !ctl.started {
 		// We don't want to configure until the controller has been fully
 		// started and initialized. We will configure on Start(), anyway.

--- a/pkg/cri/resource-manager/control/cri/cri.go
+++ b/pkg/cri/resource-manager/control/cri/cri.go
@@ -98,12 +98,12 @@ func (ctl *crictl) PreCreateHook(c cache.Container) error {
 }
 
 // PreStartHook is the CRI controller pre-start hook.
-func (ctl *crictl) PreStartHook(c cache.Container) error {
+func (ctl *crictl) PreStartHook(_ cache.Container) error {
 	return nil
 }
 
 // PostStartHook is the CRI controller post-start hook.
-func (ctl *crictl) PostStartHook(c cache.Container) error {
+func (ctl *crictl) PostStartHook(_ cache.Container) error {
 	return nil
 }
 
@@ -141,7 +141,7 @@ func (ctl *crictl) PostUpdateHook(c cache.Container) error {
 }
 
 // PostStop is the CRI controller post-stop hook.
-func (ctl *crictl) PostStopHook(c cache.Container) error {
+func (ctl *crictl) PostStopHook(_ cache.Container) error {
 	return nil
 }
 

--- a/pkg/cri/resource-manager/control/flags.go
+++ b/pkg/cri/resource-manager/control/flags.go
@@ -17,8 +17,9 @@ package control
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/intel/cri-resource-manager/pkg/config"
 	"strings"
+
+	"github.com/intel/cri-resource-manager/pkg/config"
 )
 
 // Options captures our runtime configuration.
@@ -55,7 +56,7 @@ func (o *options) ControllerMode(name string) mode {
 }
 
 // configNotify is our configuration update notification callback.
-func (o *options) configNotify(event config.Event, source config.Source) error {
+func (o *options) configNotify(_ config.Event, _ config.Source) error {
 	log.Info("configuration updated")
 	for name, controller := range controllers {
 		controller.mode = o.ControllerMode(name)

--- a/pkg/cri/resource-manager/control/memory/memory.go
+++ b/pkg/cri/resource-manager/control/memory/memory.go
@@ -57,7 +57,7 @@ func getMemoryController() *memctl {
 }
 
 // Start initializes the controller for enforcing decisions.
-func (ctl *memctl) Start(cache cache.Cache, client client.Client) error {
+func (ctl *memctl) Start(cache cache.Cache, _ client.Client) error {
 	// Let's keep this off for now so we can exercise this without a patched kernel...
 	if !ctl.checkToptierLimitSupport() {
 		return memctlError("cgroup top tier memory limit control not available")
@@ -71,12 +71,12 @@ func (ctl *memctl) Stop() {
 }
 
 // PreCreateHook is the memory controller pre-create hook.
-func (ctl *memctl) PreCreateHook(c cache.Container) error {
+func (ctl *memctl) PreCreateHook(_ cache.Container) error {
 	return nil
 }
 
 // PreStartHook is the memory controller pre-start hook.
-func (ctl *memctl) PreStartHook(c cache.Container) error {
+func (ctl *memctl) PreStartHook(_ cache.Container) error {
 	return nil
 }
 
@@ -111,7 +111,7 @@ func (ctl *memctl) PostUpdateHook(c cache.Container) error {
 }
 
 // PostStop is the memory controller post-stop hook.
-func (ctl *memctl) PostStopHook(c cache.Container) error {
+func (ctl *memctl) PostStopHook(_ cache.Container) error {
 	return nil
 }
 

--- a/pkg/cri/resource-manager/control/page-migrate/demoter.go
+++ b/pkg/cri/resource-manager/control/page-migrate/demoter.go
@@ -462,7 +462,7 @@ func (d *demoter) getPagesForContainer(c *container, sourceNodes idset.IDSet) (p
 	return pool, nil
 }
 
-func pickClosestPMEMNode(currentNode idset.ID, targetNodes idset.IDSet) idset.ID {
+func pickClosestPMEMNode(targetNodes idset.IDSet) idset.ID {
 	// TODO: analyze the topology information (and possibly the amount of free memory) and choose the "best"
 	// PMEM node to demote the page to. The array targetNodes already contains only the subset of PMEM nodes
 	// available in this topology subtree. Right now just pick a random controller.
@@ -509,7 +509,7 @@ func (d *demoter) movePagesForPid(p []page, count uint, pid int, targetNodes ids
 		if !targetNodes.Has(idset.ID(pageStatus)) {
 			// In case of many PMEM controllers choose the one that is the closest.
 			dramPages = append(dramPages, pages[i])
-			nodes = append(nodes, int(pickClosestPMEMNode(idset.ID(pageStatus), targetNodes)))
+			nodes = append(nodes, int(pickClosestPMEMNode(targetNodes)))
 		} // else no need to move.
 	}
 

--- a/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
+++ b/pkg/cri/resource-manager/control/page-migrate/page-migrate.go
@@ -96,7 +96,7 @@ func getMigrationController() *migration {
 }
 
 // Start prepares the controller for resource control/decision enforcement.
-func (m *migration) Start(cache cache.Cache, client client.Client) error {
+func (m *migration) Start(cache cache.Cache, _ client.Client) error {
 	m.cache = cache
 	m.syncWithCache()
 	m.demoter.Reconfigure()

--- a/pkg/cri/resource-manager/control/rdt/rdt.go
+++ b/pkg/cri/resource-manager/control/rdt/rdt.go
@@ -81,7 +81,7 @@ func getRDTController() *rdtctl {
 }
 
 // Start initializes the controller for enforcing decisions.
-func (ctl *rdtctl) Start(cache cache.Cache, client client.Client) error {
+func (ctl *rdtctl) Start(cache cache.Cache, _ client.Client) error {
 	if err := rdt.Initialize(resctrlGroupPrefix); err != nil {
 		return rdtError("failed to initialize RDT controls: %v", err)
 	}
@@ -109,12 +109,12 @@ func (ctl *rdtctl) Stop() {
 }
 
 // PreCreateHook is the RDT controller pre-create hook.
-func (ctl *rdtctl) PreCreateHook(c cache.Container) error {
+func (ctl *rdtctl) PreCreateHook(_ cache.Container) error {
 	return nil
 }
 
 // PreStartHook is the RDT controller pre-start hook.
-func (ctl *rdtctl) PreStartHook(c cache.Container) error {
+func (ctl *rdtctl) PreStartHook(_ cache.Container) error {
 	return nil
 }
 
@@ -350,7 +350,7 @@ func (ctl *rdtctl) configure() error {
 }
 
 // configNotify is our runtime configuration notification callback.
-func (ctl *rdtctl) configNotify(event pkgcfg.Event, source pkgcfg.Source) error {
+func (ctl *rdtctl) configNotify(_ pkgcfg.Event, _ pkgcfg.Source) error {
 	log.Info("configuration update, applying new config")
 	return ctl.configure()
 }

--- a/pkg/cri/resource-manager/introspect/introspect.go
+++ b/pkg/cri/resource-manager/introspect/introspect.go
@@ -157,7 +157,7 @@ func (s *Server) set(state *State) error {
 }
 
 // serve serves a single HTTP request.
-func (s *Server) serve(w http.ResponseWriter, req *http.Request) {
+func (s *Server) serve(w http.ResponseWriter, _ *http.Request) {
 	if !s.ready {
 		return
 	}

--- a/pkg/cri/resource-manager/policy/builtin/balloons/cputree.go
+++ b/pkg/cri/resource-manager/policy/builtin/balloons/cputree.go
@@ -289,7 +289,7 @@ func (t *cpuTreeNode) CpuLocations(cpus cpuset.CPUSet) [][]string {
 // NewCpuTreeFromSystem returns the root node of the topology tree
 // constructed from the underlying system.
 func NewCpuTreeFromSystem() (*cpuTreeNode, error) {
-	sys, err := system.DiscoverSystem(system.DiscoverCPUTopology)
+	sys, err := system.DiscoverSystem()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/pools_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/pools_test.go
@@ -381,9 +381,8 @@ func TestPoolCreation(t *testing.T) {
 				},
 			}
 
-			log.EnableDebug(true)
+			log.EnableDebug()
 			policy := CreateTopologyAwarePolicy(policyOptions).(*policy)
-			log.EnableDebug(false)
 
 			if policy.root.GetSupply().SharableCPUs().Size()+policy.root.GetSupply().IsolatedCPUs().Size()+policy.root.GetSupply().ReservedCPUs().Size() != tc.expectedRootNodeCPUs {
 				t.Errorf("Expected %d CPUs, got %d", tc.expectedRootNodeCPUs,
@@ -516,9 +515,8 @@ func TestWorkloadPlacement(t *testing.T) {
 				},
 			}
 
-			log.EnableDebug(true)
+			log.EnableDebug()
 			policy := CreateTopologyAwarePolicy(policyOptions).(*policy)
-			log.EnableDebug(false)
 
 			scores, filteredPools := policy.sortPoolsByScore(tc.req, tc.affinities)
 			fmt.Printf("scores: %v, remaining pools: %v\n", scores, filteredPools)
@@ -668,9 +666,8 @@ func TestContainerMove(t *testing.T) {
 				},
 			}
 
-			log.EnableDebug(true)
+			log.EnableDebug()
 			policy := CreateTopologyAwarePolicy(policyOptions).(*policy)
-			log.EnableDebug(false)
 
 			grant1, err := policy.allocatePool(tc.container1, "")
 			if err != nil {
@@ -939,19 +936,17 @@ func TestAffinities(t *testing.T) {
 				},
 			}
 
-			log.EnableDebug(true)
+			log.EnableDebug()
 			policy := CreateTopologyAwarePolicy(policyOptions).(*policy)
-			log.EnableDebug(false)
 
 			affinities := map[int]int32{}
 			for name, weight := range tc.affinities {
 				affinities[findNodeWithName(name, policy.pools).NodeID()] = weight
 			}
 
-			log.EnableDebug(true)
+			log.EnableDebug()
 			scores, filteredPools := policy.sortPoolsByScore(tc.req, affinities)
 			fmt.Printf("scores: %v, remaining pools: %v\n", scores, filteredPools)
-			log.EnableDebug(false)
 
 			if len(filteredPools) < 1 {
 				t.Errorf("pool scoring failed to find any pools")

--- a/pkg/cri/resource-manager/policy/policy.go
+++ b/pkg/cri/resource-manager/policy/policy.go
@@ -233,7 +233,7 @@ func NewPolicy(cache cache.Cache, o *Options) (Policy, error) {
 	}
 
 	if log.DebugEnabled() {
-		logger.Get(opt.Policy).EnableDebug(true)
+		logger.Get(opt.Policy).EnableDebug()
 	}
 
 	backendOpts.Cache = p.cache
@@ -445,7 +445,7 @@ func ConstraintToString(value Constraint) string {
 }
 
 // configNotify is the configuration change notification callback for the genric policy layer.
-func configNotify(event config.Event, src config.Source) error {
+func configNotify(_ config.Event, _ config.Source) error {
 	// let the active policy know of changes
 	backendOpts.Available = opt.Available
 	backendOpts.Reserved = opt.Reserved

--- a/pkg/cri/resource-manager/requests.go
+++ b/pkg/cri/resource-manager/requests.go
@@ -502,7 +502,7 @@ func (m *resmgr) StartContainer(ctx context.Context, method string, request inte
 		m.Error("%s: policy failed to handle event %s: %v", method, e.Type, err)
 	}
 
-	if err := m.runPostStartHooks(ctx, method, container); err != nil {
+	if err := m.runPostStartHooks(method, container); err != nil {
 		m.Error("%s: failed to run post-start hooks for %s: %v",
 			method, container.PrettyName(), err)
 	}
@@ -665,8 +665,8 @@ func (m *resmgr) ListContainers(ctx context.Context, method string, request inte
 }
 
 // UpdateContainer intercepts CRI requests for updating Containers.
-func (m *resmgr) UpdateContainer(ctx context.Context, method string, request interface{},
-	handler server.Handler) (interface{}, error) {
+func (m *resmgr) UpdateContainer(_ context.Context, _ string, _ interface{},
+	_ server.Handler) (interface{}, error) {
 
 	m.Lock()
 	defer m.Unlock()
@@ -853,7 +853,7 @@ func (m *resmgr) runPostAllocateHooks(ctx context.Context, method string) error 
 }
 
 // runPostStartHooks runs the necessary hooks after having started a container.
-func (m *resmgr) runPostStartHooks(ctx context.Context, method string, c cache.Container) error {
+func (m *resmgr) runPostStartHooks(method string, c cache.Container) error {
 	if err := m.control.RunPostStartHooks(c); err != nil {
 		m.Error("%s: post-start hook failed for %s: %v", method, c.PrettyName(), err)
 	}

--- a/pkg/cri/resource-manager/visualizer/visualizer.go
+++ b/pkg/cri/resource-manager/visualizer/visualizer.go
@@ -123,7 +123,7 @@ const (
 )
 
 // generateIndexHTML generates a HTML page to access all known visualization UIs.
-func (v *visualizer) generateIndexHTML(w http.ResponseWriter, req *http.Request) {
+func (v *visualizer) generateIndexHTML(w http.ResponseWriter, _ *http.Request) {
 	builtinUIs := []string{}
 	for name := range v.builtin {
 		builtinUIs = append(builtinUIs, name)

--- a/pkg/cri/server/services.go
+++ b/pkg/cri/server/services.go
@@ -498,6 +498,6 @@ func (s *server) CheckpointContainer(ctx context.Context, req *criv1.CheckpointC
 	return rsp.(*criv1.CheckpointContainerResponse), err
 }
 
-func (s *server) GetContainerEvents(req *criv1.GetEventsRequest, src criv1.RuntimeService_GetContainerEventsServer) error {
+func (s *server) GetContainerEvents(_ *criv1.GetEventsRequest, _ criv1.RuntimeService_GetContainerEventsServer) error {
 	return grpcstatus.Errorf(grpccodes.Unimplemented, "GetContainerEvents not implemented")
 }

--- a/pkg/dump/dump_test.go
+++ b/pkg/dump/dump_test.go
@@ -446,7 +446,7 @@ func (t *testlog) DebugBlock(prefix string, format string, args ...interface{}) 
 	}
 }
 
-func (*testlog) EnableDebug(bool) bool { return true }
-func (*testlog) DebugEnabled() bool    { return true }
-func (*testlog) Stop()                 {}
-func (*testlog) Source() string        { return "" }
+func (*testlog) EnableDebug() bool  { return true }
+func (*testlog) DebugEnabled() bool { return true }
+func (*testlog) Stop()              {}
+func (*testlog) Source() string     { return "" }

--- a/pkg/dump/flags.go
+++ b/pkg/dump/flags.go
@@ -187,7 +187,7 @@ func defaultOptions() interface{} {
 }
 
 // configNotify updates our runtime configuration.
-func (o *options) configNotify(event config.Event, source config.Source) error {
+func (o *options) configNotify(event config.Event, _ config.Source) error {
 	log.Info("message dumper configuration %v", event)
 	log.Info(" * config: %s", o.Config)
 

--- a/pkg/instrumentation/flags.go
+++ b/pkg/instrumentation/flags.go
@@ -219,7 +219,7 @@ func defaultOptions() interface{} {
 }
 
 // configNotify is our configuration udpate notification handler.
-func configNotify(event config.Event, source config.Source) error {
+func configNotify(_ config.Event, _ config.Source) error {
 	log.Info("instrumentation configuration is now %v", opt)
 
 	log.Info("reconfiguring...")

--- a/pkg/instrumentation/http/http_test.go
+++ b/pkg/instrumentation/http/http_test.go
@@ -80,7 +80,7 @@ type testHandler struct {
 	response string
 }
 
-func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	fmt.Fprintf(w, h.response)
 }
 

--- a/pkg/instrumentation/instrumentation_test.go
+++ b/pkg/instrumentation/instrumentation_test.go
@@ -40,7 +40,7 @@ func TestSamplingIdempotency(t *testing.T) {
 }
 
 func TestPrometheusConfiguration(t *testing.T) {
-	log.EnableDebug(true)
+	log.EnableDebug()
 
 	if opt.HTTPEndpoint == "" {
 		opt.HTTPEndpoint = ":0"

--- a/pkg/log/flags.go
+++ b/pkg/log/flags.go
@@ -172,7 +172,7 @@ func (m srcmap) clone() srcmap {
 }
 
 // configNotify is the configuration change notification callback for options.
-func (o *options) configNotify(event pkgcfg.Event, src pkgcfg.Source) error {
+func (o *options) configNotify(event pkgcfg.Event, _ pkgcfg.Source) error {
 	deflog.Info("logger configuration %v", event)
 	deflog.Info(" * debugging: %s", o.Debug.String())
 	deflog.Info(" * log source: %v", o.LogSource)

--- a/pkg/log/grpc-logger.go
+++ b/pkg/log/grpc-logger.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"fmt"
+
 	"google.golang.org/grpc/grpclog"
 )
 
@@ -89,6 +90,6 @@ func (g grpclogger) Fatalf(format string, args ...interface{}) {
 	g.Logger.Fatal(format, args...)
 }
 
-func (g grpclogger) V(l int) bool {
+func (g grpclogger) V(_ int) bool {
 	return true
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -87,7 +87,7 @@ type Logger interface {
 	ErrorBlock(prefix string, format string, args ...interface{})
 
 	// EnableDebug enables debug messages for this Logger.
-	EnableDebug(bool) bool
+	EnableDebug() bool
 	// DebugEnabled checks if debug messages are enabled for this Logger.
 	DebugEnabled() bool
 
@@ -304,7 +304,7 @@ func (log *logging) get(source string) logger {
 	return l
 }
 
-func (l logger) EnableDebug(state bool) bool {
+func (l logger) EnableDebug() bool {
 	log.Lock()
 	defer log.Unlock()
 	if _, ok := log.sources[l]; !ok {

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -37,7 +37,7 @@ func GetPath() string {
 
 // SetPath sets the pidfile path to the given one.
 func SetPath(path string) {
-	close()
+	closePIDFile()
 	pidFilePath = path
 }
 
@@ -61,7 +61,7 @@ func Write() error {
 
 	_, err = pidFile.Write([]byte(fmt.Sprintf("%d\n", os.Getpid())))
 	if err != nil {
-		close()
+		closePIDFile()
 		return errors.Wrap(err, "failed to write PID file")
 	}
 
@@ -92,8 +92,8 @@ func Read() (int, error) {
 	return pid, nil
 }
 
-// close closes the PID file and truncates it to zero length.
-func close() {
+// closePIDFile closes the PID file and truncates it to zero length.
+func closePIDFile() {
 	if pidFile != nil {
 		pidFile.Truncate(0)
 		pidFile.Close()
@@ -104,7 +104,7 @@ func close() {
 // Remove removes the PID file for the process unconditionally, regardless if
 // the current process had created the PID file or not.
 func Remove() error {
-	close()
+	closePIDFile()
 	err := os.Remove(pidFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -61,7 +61,7 @@ func TestDefaults(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, pid, os.Getpid())
 
-		close()
+		closePIDFile()
 		err = Write()
 		require.NotNil(t, err)
 
@@ -160,7 +160,7 @@ func TestReadClosed(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, pid, os.Getpid())
 
-		close()
+		closePIDFile()
 		pid, err = Read()
 		require.NotNil(t, err)
 		require.Equal(t, pid, -1)
@@ -183,7 +183,7 @@ func TestFailToOverwrite(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, pid, os.Getpid())
 
-		close()
+		closePIDFile()
 		err = Write()
 		require.NotNil(t, err)
 	})

--- a/pkg/sysfs/system.go
+++ b/pkg/sysfs/system.go
@@ -249,7 +249,7 @@ func SysRoot() string {
 }
 
 // DiscoverSystem performs discovery of the running systems details.
-func DiscoverSystem(args ...DiscoveryFlag) (System, error) {
+func DiscoverSystem() (System, error) {
 	return DiscoverSystemAt(filepath.Join("/", sysRoot, "sys"))
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -69,11 +69,11 @@ func (version) IsBoolFlag() bool {
 
 // Set is our dummy flag.Value setter.
 func (version) Set(value string) error {
-	print, err := strconv.ParseBool(value)
+	printVersion, err := strconv.ParseBool(value)
 	if err != nil {
 		return err
 	}
-	if print {
+	if printVersion {
 		PrintVersionInfo()
 		os.Exit(0)
 	}

--- a/test/functional/fake_cri_server_test.go
+++ b/test/functional/fake_cri_server_test.go
@@ -273,7 +273,7 @@ func (s *fakeCriServer) CheckpointContainer(ctx context.Context, req *criv1.Chec
 	return response.(*criv1.CheckpointContainerResponse), err
 }
 
-func (s *fakeCriServer) GetContainerEvents(req *criv1.GetEventsRequest, srv criv1.RuntimeService_GetContainerEventsServer) error {
+func (s *fakeCriServer) GetContainerEvents(_ *criv1.GetEventsRequest, _ criv1.RuntimeService_GetContainerEventsServer) error {
 	return nil
 }
 


### PR DESCRIPTION
The second commit patches the code to pass muster:

- drop unused function arguments
- rename unused function args (that cannot be dropped) to `_`
- rename variables that would override builtin names (`print`, `close`, `new`)
- remove unnecessary `else`