### PR TITLE
pkg/sysfs: drop discovery flags

### DIFF
--- a/pkg/cpuallocator/cpuallocator_test.go
+++ b/pkg/cpuallocator/cpuallocator_test.go
@@ -37,9 +37,7 @@ func TestAllocatorHelper(t *testing.T) {
 	}
 
 	// Discover mock system from the testdata
-	sys, err := sysfs.DiscoverSystemAt(
-		path.Join(tmpdir, "sysfs", "2-socket-4-node-40-core", "sys"),
-		sysfs.DiscoverCPUTopology, sysfs.DiscoverMemTopology)
+	sys, err := sysfs.DiscoverSystemAt(path.Join(tmpdir, "sysfs", "2-socket-4-node-40-core", "sys"))
 	if err != nil {
 		t.Fatalf("failed to discover mock system: %v", err)
 	}

--- a/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
+++ b/pkg/cri/resource-manager/policy/builtin/topology-aware/mocks_test.go
@@ -183,7 +183,7 @@ func (fake *mockSystem) CPUCount() int {
 	}
 	return fake.cpuCount
 }
-func (fake *mockSystem) Discover(flags system.DiscoveryFlag) error {
+func (fake *mockSystem) Discover() error {
 	return nil
 }
 func (fake *mockSystem) Package(idset.ID) system.CPUPackage {


### PR DESCRIPTION
Simplify the code by dropping unused functionality. Effectively, we always used the default flags.

Depends on #1082 