### PR TITLE
github: update setup-go action to v5

### DIFF
--- a/.github/workflows/common-codeql.yaml
+++ b/.github/workflows/common-codeql.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
 

--- a/.github/workflows/common-verify-code.yaml
+++ b/.github/workflows/common-verify-code.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
       id: go


### PR DESCRIPTION
Silencing the last warnings from actions' logs (for now).