### PR TITLE
go.mod: use correct go toolchain version syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/intel/cri-resource-manager
 
-go 1.22
+go 1.22.0
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/pkg/topology/go.mod
+++ b/pkg/topology/go.mod
@@ -1,6 +1,6 @@
 module github.com/intel/cri-resource-manager/pkg/topology
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
In Go v1.21 and later the patch version should be included (1.x.y syntax).