### PR TITLE
e2e: fixes to debian-sid

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -278,7 +278,7 @@ debian-install-crio-pre() {
 debian-install-k8s() {
     local _k8s=$k8s
     debian-refresh-pkg-db
-    debian-install-pkg apt-transport-https curl
+    debian-install-pkg gpg apt-transport-https curl
 
     if [[ -z "$k8s" ]] || [[ "$k8s" == "latest" ]]; then
         vm-command "curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | grep tag_name | sed -e 's/.*v\([0-9]\+\.[0-9]\+\).*/\1/g'"
@@ -304,6 +304,10 @@ debian-set-kernel-cmdline() {
 
 debian-env-file-dir() {
     echo "/etc/default"
+}
+
+debian-sid-govm-env() {
+    echo "DISABLE_VGA=N"
 }
 
 ###########################################################################

--- a/demo/lib/host.bash
+++ b/demo/lib/host.bash
@@ -266,7 +266,10 @@ host-wait-vm-ssh-server() {
 host-wait-cloud-init() {
     retries=60
     retries_left=$retries
-    while ! $SSH -o ConnectTimeout=2 ${VM_SSH_USER}@${VM_IP} sudo cloud-init status --wait 2>/dev/null; do
+    while true; do
+        $SSH -o ConnectTimeout=2 ${VM_SSH_USER}@${VM_IP} sudo cloud-init status --wait 2>/dev/null
+        [ "$?" -eq 0 -o "$?" -eq 2 ] && break
+
         if [ "$retries" == "$retries_left" ]; then
             echo -n "Waiting for VM cloud-init to finish..."
         fi


### PR DESCRIPTION
Set DISABLE_VGA to false, otherwise the latest SID image fails to boot. Install gpg which is needed by apt-key add (but somehow missing from the system).  Also accept exit code 2 from cloud-init:

2 - Recoverable error - Cloud-init completed but experienced errors.