### PR TITLE
e2e: fix pod deletion in Ubuntu 24.04 by disabling runc apparmor

### DIFF
--- a/demo/lib/distro.bash
+++ b/demo/lib/distro.bash
@@ -176,6 +176,21 @@ debian-ssh-user() {
     echo debian
 }
 
+ubuntu-apparmor-disable-runc() {
+    vm-command "[ -f /etc/apparmor.d/runc ] && ln -s /etc/apparmor.d/runc /etc/apparmor.d/disable/ && apparmor_parser -R /etc/apparmor.d/runc"
+}
+
+ubuntu-config-containerd() {
+    ubuntu-apparmor-disable-runc
+    default-config-containerd
+}
+
+ubuntu-config-crio() {
+    ubuntu-apparmor-disable-runc
+    default-config-crio
+}
+
+
 debian-pkg-type() {
     echo deb
 }


### PR DESCRIPTION
Pods fail to terminate in Ubuntu 24.04 without disabling runc apparmor.

Changing containerd configuration did not work for me.

https://www.reddit.com/r/kubernetes/comments/1dv6z9d/ubuntu_2404_pod_termination_issue/

This does not break Ubuntu 22.04, that works both with and without this change.