### PR TITLE
github: remove paths-ignore from verify-code

### DIFF
--- a/.github/workflows/verify-pr-code.yaml
+++ b/.github/workflows/verify-pr-code.yaml
@@ -1,10 +1,7 @@
 name: Verify code
 
 on:
-  pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
+  pull_request
 
 permissions:
   contents: read


### PR DESCRIPTION
Required by the branch-protection rules or something...