### PR TITLE
docs: exclude SECURITY.md from docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '.github', '_work', 'generate', 'README.md', 'docs/releases']
+exclude_patterns = ['_build', '.github', '_work', 'generate', 'README.md', 'SECURITY.md', 'docs/releases']
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
Should prevent docs build failures like:

    SECURITY.md:document isn't included in any toctree